### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-/web/ui @juliusv
-/storage/remote @csmarchbanks @cstyan @bwplotka @tomwilkie
-/discovery/kubernetes @brancz
-/tsdb @codesome
-/promql @codesome @roidelapluie


### PR DESCRIPTION
Else this will ping folks outside Grafana Labs unnecessarily for every PR touching those directories when we make it public. Another option is to only remove non-Grafana folks (but I guess for this fork it's best to not auto request for reviews but manually request where required).