### PR TITLE
Test that approxBytesPerEntry const is correct

### DIFF
--- a/tsdb/hashcache/series_hash_cache_test.go
+++ b/tsdb/hashcache/series_hash_cache_test.go
@@ -64,6 +64,7 @@ func TestSeriesHashCache_MeasureApproximateSizePerEntry(t *testing.T) {
 	runtime.ReadMemStats(&after)
 
 	t.Logf("approximate size per entry: %d bytes", (after.TotalAlloc-before.TotalAlloc)/numEntries)
+	require.Equal(t, uint64(approxBytesPerEntry), (after.TotalAlloc-before.TotalAlloc)/numEntries, "approxBytesPerEntry constant is out date")
 }
 
 func TestSeriesHashCache_Concurrency(t *testing.T) {


### PR DESCRIPTION
The comment on the constant mentions where it comes from, so we can actually check its value in that test.
