### PR TITLE
Fix failing unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,14 @@ jobs:
           sudo mv /tmp/go /usr/local/go
           cd -
           ls -l /usr/bin/go
+
       - name: Checkout Repo
         uses: actions/checkout@v2
+
+      # This file would normally be created by `make assets`, here we just
+      #  mock it because the file is required for the tests to pass.
+      - name: Mock building of necessary react file
+        run: mkdir web/ui/static/react && touch web/ui/static/react/index.html
+
       - name: Run Tests
         run: GO=/usr/local/go/bin/go make common-test


### PR DESCRIPTION
The reason why one of the tests in the CI fails is because this test requires an html file which gets generated when running `make assets`. This PR just creates that html file with a `touch`.

I know that it would be better to run `make assets` instead of mocking that html file but `make assets` fails in the CI due to some `npm` related reason and I'm new to `npm`, so instead of spending a lot of time trying to make `make assets` work I figured it would be more time efficient to just create that html file directly. If somebody knows how to make `make assets` work then I'm happy to undo this change again.