### PR TITLE
Register the out of order histogram

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -422,6 +422,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.checkpointCreationTotal,
 			m.mmapChunkCorruptionTotal,
 			m.snapshotReplayErrorTotal,
+			m.oooHistogram,
 			// Metrics bound to functions and not needed in tests
 			// can be created and registered on the spot.
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{


### PR DESCRIPTION
An oversight from my review in https://github.com/grafana/prometheus-private/pull/56, we actually forgot to register the metric, which this PR fixes.