### PR TITLE
Fix error reported by asyncBlockWriter.addSeries()

### DIFF
--- a/tsdb/async_block_writer.go
+++ b/tsdb/async_block_writer.go
@@ -13,9 +13,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
-var (
-	errAsyncBlockWriterNotRunning = errors.New("asyncBlockWriter doesn't run anymore")
-)
+var errAsyncBlockWriterNotRunning = errors.New("asyncBlockWriter doesn't run anymore")
 
 // asyncBlockWriter runs a background goroutine that writes series and chunks to the block asynchronously.
 type asyncBlockWriter struct {


### PR DESCRIPTION
`asyncBlockWriter.loop()` can stop anytime due to an error. If returns an error, but the return error is just used to populate `bw.finishedCh`.

However, `asyncBlockWriter.addSeries()` doesn't include the error stored in `bw.result` when returning the error so the actual error stored in `bw.result` is not visible in logs if an error occurs before we hit the `asyncBlockWriter.waitFinished()`.

This PR should fix it.