### PR TITLE
Implement OOOHeadChunkReader

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -599,7 +599,7 @@ func analyzeCompaction(block tsdb.BlockReader, indexr tsdb.IndexReader) (err err
 
 		for _, chk := range chks {
 			// Load the actual data of the chunk.
-			chk, err := chunkr.Chunk(chk.Ref)
+			chk, err := chunkr.Chunk(chk)
 			if err != nil {
 				return err
 			}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -128,7 +128,7 @@ type ChunkWriter interface {
 // ChunkReader provides reading access of serialized time series data.
 type ChunkReader interface {
 	// Chunk returns the series data chunk with the given reference.
-	Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error)
+	Chunk(ref chunks.Meta) (chunkenc.Chunk, error)
 
 	// Close releases all underlying resources of the reader.
 	Close() error

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -556,8 +556,8 @@ func (s *Reader) Size() int64 {
 }
 
 // Chunk returns a chunk from a given reference.
-func (s *Reader) Chunk(ref ChunkRef) (chunkenc.Chunk, error) {
-	sgmIndex, chkStart := BlockChunkRef(ref).Unpack()
+func (s *Reader) Chunk(meta Meta) (chunkenc.Chunk, error) {
+	sgmIndex, chkStart := BlockChunkRef(meta.Ref).Unpack()
 	chkCRC32 := newCRC32()
 
 	if sgmIndex >= len(s.bs) {

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -23,6 +23,6 @@ func TestReaderWithInvalidBuffer(t *testing.T) {
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 	r := &Reader{bs: []ByteSlice{b}}
 
-	_, err := r.Chunk(0)
+	_, err := r.Chunk(Meta{Ref: 0})
 	require.Error(t, err)
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -2814,7 +2814,7 @@ func TestChunkWriter_ReadAfterWrite(t *testing.T) {
 
 			for _, chks := range test.chks {
 				for _, chkExp := range chks {
-					chkAct, err := r.Chunk(chkExp.Ref)
+					chkAct, err := r.Chunk(chkExp)
 					require.NoError(t, err)
 					require.Equal(t, chkExp.Chunk.Bytes(), chkAct.Bytes())
 				}
@@ -2876,7 +2876,7 @@ func TestChunkReader_ConcurrentReads(t *testing.T) {
 			go func(chunk chunks.Meta) {
 				defer wg.Done()
 
-				chkAct, err := r.Chunk(chunk.Ref)
+				chkAct, err := r.Chunk(chunk)
 				require.NoError(t, err)
 				require.Equal(t, chunk.Chunk.Bytes(), chkAct.Bytes())
 			}(chk)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1688,7 +1688,6 @@ type memSeries struct {
 	// (the first sample would create a headChunk, hence appender, but rollback skipped it while the Append() call would create a series).
 	app chunkenc.Appender
 
-	// TODO(jesus.vazquez) What is memChunkPool for?
 	memChunkPool *sync.Pool
 
 	// txs is nil if isolation is disabled.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1688,6 +1688,7 @@ type memSeries struct {
 	// (the first sample would create a headChunk, hence appender, but rollback skipped it while the Append() call would create a series).
 	app chunkenc.Appender
 
+	// TODO(jesus.vazquez) What is memChunkPool for?
 	memChunkPool *sync.Pool
 
 	// txs is nil if isolation is disabled.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -428,7 +428,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 
 	// Next we want to sort all the collected chunks by min time so we can find
 	// those that overlap and stop when we know the rest don't.
-	sort.Sort(byMinTime(tmpChks))
+	sort.Sort(byMinTimeAndMinRef(tmpChks))
 
 	oc := &mergedOOOChunks{}
 	for _, c := range tmpChks {
@@ -440,7 +440,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 		if c.Ref == meta.Ref || len(oc.chunks) > 0 && c.MinTime <= oc.chunks[len(oc.chunks)-1].MaxTime {
 
 			if c.Ref == oooHeadRef {
-				xor, err := s.oooHeadChunk.chunk.ToXor()
+				xor, err := s.oooHeadChunk.chunk.ToXor() // TODO(jesus.vazquez) See if we could use a copy of the underlying slice. That would leave the more expensive ToXor() function only for the usecase where Bytes() is called.
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to convert ooo head chunk to xor chunk")
 				}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -296,8 +296,8 @@ func (h *headChunkReader) Close() error {
 }
 
 // Chunk returns the chunk for the reference number.
-func (h *headChunkReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
-	sid, cid := chunks.HeadChunkRef(ref).Unpack()
+func (h *headChunkReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
+	sid, cid := chunks.HeadChunkRef(meta.Ref).Unpack()
 
 	s := h.head.series.getByID(sid)
 	// This means that the series has been garbage collected.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1370,16 +1370,16 @@ func TestGCChunkAccess(t *testing.T) {
 
 	cr, err := h.chunksRange(0, 1500, nil)
 	require.NoError(t, err)
-	_, err = cr.Chunk(chunks[0].Ref)
+	_, err = cr.Chunk(chunks[0])
 	require.NoError(t, err)
-	_, err = cr.Chunk(chunks[1].Ref)
+	_, err = cr.Chunk(chunks[1])
 	require.NoError(t, err)
 
 	require.NoError(t, h.Truncate(1500)) // Remove a chunk.
 
-	_, err = cr.Chunk(chunks[0].Ref)
+	_, err = cr.Chunk(chunks[0])
 	require.Equal(t, storage.ErrNotFound, err)
-	_, err = cr.Chunk(chunks[1].Ref)
+	_, err = cr.Chunk(chunks[1])
 	require.NoError(t, err)
 }
 
@@ -1424,18 +1424,18 @@ func TestGCSeriesAccess(t *testing.T) {
 
 	cr, err := h.chunksRange(0, 2000, nil)
 	require.NoError(t, err)
-	_, err = cr.Chunk(chunks[0].Ref)
+	_, err = cr.Chunk(chunks[0])
 	require.NoError(t, err)
-	_, err = cr.Chunk(chunks[1].Ref)
+	_, err = cr.Chunk(chunks[1])
 	require.NoError(t, err)
 
 	require.NoError(t, h.Truncate(2000)) // Remove the series.
 
 	require.Equal(t, (*memSeries)(nil), h.series.getByID(1))
 
-	_, err = cr.Chunk(chunks[0].Ref)
+	_, err = cr.Chunk(chunks[0])
 	require.Equal(t, storage.ErrNotFound, err)
-	_, err = cr.Chunk(chunks[1].Ref)
+	_, err = cr.Chunk(chunks[1])
 	require.Equal(t, storage.ErrNotFound, err)
 }
 

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -29,9 +29,7 @@ func (oh *OOORangeHead) Index() (IndexReader, error) {
 }
 
 func (oh *OOORangeHead) Chunks() (ChunkReader, error) {
-	// TODO(jesus.vazquez) Need to create a oooHeadChunkReader that implements
-	// ChunkReader. Check the above Index() method as an inspiration.
-	panic("implement me")
+	return NewOOOHeadChunkReader(oh.head, oh.mint, oh.maxt), nil
 }
 
 func (oh *OOORangeHead) Tombstones() (tombstones.Reader, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 )
@@ -144,4 +145,27 @@ func (oh *OOOHeadIndexReader) Postings(name string, values ...string) (index.Pos
 		}
 		return index.Merge(res...), nil
 	}
+}
+
+type OOOHeadChunkReader struct {
+	head       *Head
+	mint, maxt int64
+	isoState   *isolationState
+}
+
+func NewOOOHeadChunkReader(head *Head, mint, maxt int64) *OOOHeadChunkReader {
+	return &OOOHeadChunkReader{
+		head: head,
+		mint: mint,
+		maxt: maxt,
+	}
+}
+
+func (cr OOOHeadChunkReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
+	panic("implement me")
+}
+
+func (cr OOOHeadChunkReader) Close() error {
+	cr.isoState.Close()
+	return nil
 }

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -1,9 +1,11 @@
 package tsdb
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 type chunkInterval struct {
@@ -352,4 +355,285 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestOOOHeadChunkReader_Chunk tests that the Chunk method works as expected.
+// It does so by appending out of order samples to the db and then initializing
+// an OOOHeadChunkReader to read chunks from it.
+func TestOOOHeadChunkReader_Chunk(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OOOCapMin = 1
+	opts.OOOCapMax = 5
+	opts.OOOAllowance = 120 * time.Minute.Milliseconds()
+
+	s1 := labels.FromStrings("l", "v1")
+	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
+
+	appendSample := func(app storage.Appender, l labels.Labels, timestamp int64, value float64) storage.SeriesRef {
+		ref, err := app.Append(0, l, timestamp, value)
+		require.NoError(t, err)
+		return ref
+	}
+
+	t.Run("Getting a non existing chunk fails with not found error", func(t *testing.T) {
+		db := newTestDBWithOpts(t, opts)
+
+		cr := NewOOOHeadChunkReader(db.head, 0, 1000)
+		c, err := cr.Chunk(chunks.Meta{
+			Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 300,
+		})
+		require.Equal(t, err, fmt.Errorf("not found"))
+		require.Equal(t, c, nil)
+	})
+
+	tests := []struct {
+		name                 string
+		queryMinT            int64
+		queryMaxT            int64
+		firstInOrderSampleAt int64
+		dbOpts               *Options
+		inputSamples         tsdbutil.SampleSlice
+		expChunkError        bool
+		expChunksSamples     []tsdbutil.SampleSlice
+	}{
+		{
+			name:                 "Getting the head when there are no overlapping chunks returns just the samples in the head",
+			queryMinT:            minutes(0),
+			queryMaxT:            minutes(100),
+			firstInOrderSampleAt: minutes(120),
+			dbOpts:               opts,
+			inputSamples: tsdbutil.SampleSlice{
+				sample{t: minutes(30), v: float64(0)},
+				sample{t: minutes(40), v: float64(0)},
+			},
+			expChunkError: false,
+			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
+			// Query Interval          [------------------------------------------------------------------------------------------]
+			// Chunk 0: Current Head                              [--------] (With 2 samples)
+			// Expected Output
+			// Output Graphically                                 [--------] (With 2 samples)
+			expChunksSamples: []tsdbutil.SampleSlice{
+				{
+					sample{t: minutes(30), v: float64(0)},
+					sample{t: minutes(40), v: float64(0)},
+				},
+			},
+		},
+		{
+			name:                 "Getting the head chunk when there are overlapping chunks returns all combined",
+			queryMinT:            minutes(0),
+			queryMaxT:            minutes(100),
+			firstInOrderSampleAt: minutes(120),
+			dbOpts:               opts,
+			inputSamples: tsdbutil.SampleSlice{
+				// opts.OOOCapMax is 5 so these will be mmapped to the first mmapped chunk
+				sample{t: minutes(41), v: float64(0)},
+				sample{t: minutes(42), v: float64(0)},
+				sample{t: minutes(43), v: float64(0)},
+				sample{t: minutes(44), v: float64(0)},
+				sample{t: minutes(45), v: float64(0)},
+				// The following samples will go to the head chunk, and we want it
+				// to overlap with the previous chunk
+				sample{t: minutes(40), v: float64(1)},
+				sample{t: minutes(50), v: float64(1)},
+			},
+			expChunkError: false,
+			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
+			// Query Interval          [------------------------------------------------------------------------------------------]
+			// Chunk 0                                                     [---] (With 5 samples)
+			// Chunk 1: Current Head                              [-----------------] (With 2 samples)
+			// Expected Output  [Chunk 1] With 7 samples
+			// Output Graphically                                 [-----------------] (With 7 samples)
+			expChunksSamples: []tsdbutil.SampleSlice{
+				{
+					sample{t: minutes(40), v: float64(1)},
+					sample{t: minutes(41), v: float64(0)},
+					sample{t: minutes(42), v: float64(0)},
+					sample{t: minutes(43), v: float64(0)},
+					sample{t: minutes(44), v: float64(0)},
+					sample{t: minutes(45), v: float64(0)},
+					sample{t: minutes(50), v: float64(1)},
+				},
+			},
+		},
+		{
+			name:                 "Two windows of overlapping chunks get properly converged",
+			queryMinT:            minutes(0),
+			queryMaxT:            minutes(100),
+			firstInOrderSampleAt: minutes(120),
+			dbOpts:               opts,
+			inputSamples: tsdbutil.SampleSlice{
+				// Chunk 0
+				sample{t: minutes(10), v: float64(0)},
+				sample{t: minutes(12), v: float64(0)},
+				sample{t: minutes(14), v: float64(0)},
+				sample{t: minutes(16), v: float64(0)},
+				sample{t: minutes(20), v: float64(0)},
+				// Chunk 1
+				sample{t: minutes(20), v: float64(1)},
+				sample{t: minutes(22), v: float64(1)},
+				sample{t: minutes(24), v: float64(1)},
+				sample{t: minutes(26), v: float64(1)},
+				sample{t: minutes(29), v: float64(1)},
+				// Chunk 2
+				sample{t: minutes(30), v: float64(2)},
+				sample{t: minutes(32), v: float64(2)},
+				sample{t: minutes(34), v: float64(2)},
+				sample{t: minutes(36), v: float64(2)},
+				sample{t: minutes(40), v: float64(2)},
+				// Head
+				sample{t: minutes(40), v: float64(3)},
+				sample{t: minutes(50), v: float64(3)},
+			},
+			expChunkError: false,
+			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
+			// Query Interval          [------------------------------------------------------------------------------------------]
+			// Chunk 0                          [--------]
+			// Chunk 1                                   [-------]
+			// Chunk 2                                            [--------]
+			// Chunk 3: Current Head                                       [--------]
+			// Expected Output  [Chunk 0] (With samples between minute 10 and minute 29) and [Chunk 3] (With samples between minute 30 and minute 50)
+			// Output Graphically               [----------------][-----------------]
+			expChunksSamples: []tsdbutil.SampleSlice{
+				{
+					sample{t: minutes(10), v: float64(0)},
+					sample{t: minutes(12), v: float64(0)},
+					sample{t: minutes(14), v: float64(0)},
+					sample{t: minutes(16), v: float64(0)},
+					sample{t: minutes(20), v: float64(1)},
+					sample{t: minutes(22), v: float64(1)},
+					sample{t: minutes(24), v: float64(1)},
+					sample{t: minutes(26), v: float64(1)},
+					sample{t: minutes(29), v: float64(1)},
+				},
+				{
+					sample{t: minutes(30), v: float64(2)},
+					sample{t: minutes(32), v: float64(2)},
+					sample{t: minutes(34), v: float64(2)},
+					sample{t: minutes(36), v: float64(2)},
+					sample{t: minutes(40), v: float64(3)},
+					sample{t: minutes(50), v: float64(3)},
+				},
+			},
+		},
+		{
+			name:                 "If chunks are not overlapped they are not converged",
+			queryMinT:            minutes(0),
+			queryMaxT:            minutes(100),
+			firstInOrderSampleAt: minutes(120),
+			dbOpts:               opts,
+			inputSamples: tsdbutil.SampleSlice{
+				// Chunk 0
+				sample{t: minutes(10), v: float64(0)},
+				sample{t: minutes(12), v: float64(0)},
+				sample{t: minutes(14), v: float64(0)},
+				sample{t: minutes(16), v: float64(0)},
+				sample{t: minutes(18), v: float64(0)},
+				// Chunk 1
+				sample{t: minutes(20), v: float64(1)},
+				sample{t: minutes(22), v: float64(1)},
+				sample{t: minutes(24), v: float64(1)},
+				sample{t: minutes(26), v: float64(1)},
+				sample{t: minutes(28), v: float64(1)},
+				// Chunk 2
+				sample{t: minutes(30), v: float64(2)},
+				sample{t: minutes(32), v: float64(2)},
+				sample{t: minutes(34), v: float64(2)},
+				sample{t: minutes(36), v: float64(2)},
+				sample{t: minutes(38), v: float64(2)},
+				// Head
+				sample{t: minutes(40), v: float64(3)},
+				sample{t: minutes(42), v: float64(3)},
+			},
+			expChunkError: false,
+			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
+			// Query Interval          [------------------------------------------------------------------------------------------]
+			// Chunk 0                          [-------]
+			// Chunk 1                                   [-------]
+			// Chunk 2                                            [-------]
+			// Chunk 3: Current Head                                       [-------]
+			// Expected Output  All chunks separated since they dont overlap
+			// Output Graphically               [-------][-------][-------][--------]
+			expChunksSamples: []tsdbutil.SampleSlice{
+				{
+					sample{t: minutes(10), v: float64(0)},
+					sample{t: minutes(12), v: float64(0)},
+					sample{t: minutes(14), v: float64(0)},
+					sample{t: minutes(16), v: float64(0)},
+					sample{t: minutes(18), v: float64(0)},
+				},
+				{
+					sample{t: minutes(20), v: float64(1)},
+					sample{t: minutes(22), v: float64(1)},
+					sample{t: minutes(24), v: float64(1)},
+					sample{t: minutes(26), v: float64(1)},
+					sample{t: minutes(28), v: float64(1)},
+				},
+				{
+					sample{t: minutes(30), v: float64(2)},
+					sample{t: minutes(32), v: float64(2)},
+					sample{t: minutes(34), v: float64(2)},
+					sample{t: minutes(36), v: float64(2)},
+					sample{t: minutes(38), v: float64(2)},
+				},
+				{
+					sample{t: minutes(40), v: float64(3)},
+					sample{t: minutes(42), v: float64(3)},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
+			db := newTestDBWithOpts(t, tc.dbOpts)
+
+			app := db.Appender(context.Background())
+			s1Ref := appendSample(app, s1, tc.firstInOrderSampleAt, float64(tc.firstInOrderSampleAt/1*time.Minute.Milliseconds()))
+			require.NoError(t, app.Commit())
+
+			// OOO few samples for s1.
+			app = db.Appender(context.Background())
+			for _, s := range tc.inputSamples {
+				appendSample(app, s1, s.T(), s.V())
+			}
+			require.NoError(t, app.Commit())
+
+			// The Series method is the one that populates the chunk meta OOO
+			// markers like OOOLastRef. These are then used by the ChunkReader.
+			ir := NewOOOHeadIndexReader(db.head, tc.queryMinT, tc.queryMaxT)
+			var chks []chunks.Meta
+			var respLset labels.Labels
+			err := ir.Series(s1Ref, &respLset, &chks)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expChunksSamples), len(chks))
+
+			cr := NewOOOHeadChunkReader(db.head, tc.queryMinT, tc.queryMaxT)
+			for i := 0; i < len(chks); i++ {
+				c, err := cr.Chunk(chks[i])
+				require.NoError(t, err)
+
+				var resultSamples tsdbutil.SampleSlice
+				it := c.Iterator(nil)
+				for it.Next() {
+					t, v := it.At()
+					resultSamples = append(resultSamples, sample{t: t, v: v})
+				}
+				require.Equal(t, tc.expChunksSamples[i], resultSamples)
+			}
+		})
+	}
+}
+
+func newTestDBWithOpts(t *testing.T, opts *Options) *DB {
+	dir := t.TempDir()
+
+	db, err := Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -518,7 +518,7 @@ func (p *populateWithDelGenericSeriesIterator) next() bool {
 	p.i++
 	p.currChkMeta = p.chks[p.i]
 
-	p.currChkMeta.Chunk, p.err = p.chunks.Chunk(p.currChkMeta.Ref)
+	p.currChkMeta.Chunk, p.err = p.chunks.Chunk(p.currChkMeta)
 	if p.err != nil {
 		p.err = errors.Wrapf(p.err, "cannot populate chunk %d", p.currChkMeta.Ref)
 		return false
@@ -847,7 +847,7 @@ func newNopChunkReader() ChunkReader {
 	}
 }
 
-func (cr nopChunkReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
+func (cr nopChunkReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
 	return cr.emptyChunk, nil
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -629,10 +629,10 @@ func createFakeReaderAndNotPopulatedChunks(s ...[]tsdbutil.Sample) (*fakeChunksR
 	return f, chks
 }
 
-func (r *fakeChunksReader) Chunk(ref chunks.ChunkRef) (chunkenc.Chunk, error) {
-	chk, ok := r.chks[ref]
+func (r *fakeChunksReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
+	chk, ok := r.chks[meta.Ref]
 	if !ok {
-		return nil, errors.Errorf("chunk not found at ref %v", ref)
+		return nil, errors.Errorf("chunk not found at ref %v", meta.Ref)
 	}
 	return chk, nil
 }
@@ -1018,8 +1018,8 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 
 type mockChunkReader map[chunks.ChunkRef]chunkenc.Chunk
 
-func (cr mockChunkReader) Chunk(id chunks.ChunkRef) (chunkenc.Chunk, error) {
-	chk, ok := cr[id]
+func (cr mockChunkReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
+	chk, ok := cr[meta.Ref]
 	if ok {
 		return chk, nil
 	}


### PR DESCRIPTION
Relates to https://github.com/grafana/mimir-prometheus/issues/147

This PR implements the ChunkReader interface for the OOORangeHead and its called `OOOHeadChunkReader`. We're taking the structure from the [headChunkReader](https://github.com/grafana/mimir-prometheus/blob/62252d7f8a2fa0bd12681860b8c785c8005994d6/tsdb/head_read.go#L295) implementation and making the necessary changes for out of order.
- The interface has an important method called `Chunk()` and as we explained in https://github.com/grafana/mimir-prometheus/issues/147#issuecomment-1048064175 it needs to return a merged chunk from all chunks that overlap with it. Remember that in the OOOHead chunks may not be ordered in time.
- `Chunk()` makes use of a new function called `oooMergedChunk` which is the actual function that will take care of merging the chunks.
- We're combining all the overlapping chunks into a single struct called `mergedOOOChunks` which satisfies `chunkenc.Chunk` and provides an iterator to go through all the overlapping chunks samples in order.
- Unit tests added that use the ingestion path for out of order to get the samples in and then query the chunks back to make sure the results match the expectations.

