### PR TITLE
Write OOO samples to the WAL

### DIFF
--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -520,7 +520,7 @@ func createBlockFromHead(tb testing.TB, dir string, head *Head) string {
 func createHead(tb testing.TB, w *wal.WAL, series []storage.Series, chunkDir string) *Head {
 	opts := DefaultHeadOptions()
 	opts.ChunkDirRoot = chunkDir
-	head, err := NewHead(nil, nil, w, opts, nil)
+	head, err := NewHead(nil, nil, w, nil, opts, nil)
 	require.NoError(tb, err)
 
 	app := head.Appender(context.Background())

--- a/tsdb/blockwriter.go
+++ b/tsdb/blockwriter.go
@@ -72,7 +72,7 @@ func (w *BlockWriter) initHead() error {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = w.blockSize
 	opts.ChunkDirRoot = w.chunkDir
-	h, err := NewHead(nil, w.logger, nil, opts, NewHeadStats())
+	h, err := NewHead(nil, w.logger, nil, nil, opts, NewHeadStats())
 	if err != nil {
 		return errors.Wrap(err, "tsdb.NewHead")
 	}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1298,7 +1298,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
 			opts.ChunkDirRoot = chunkDir
-			h, err := NewHead(nil, nil, nil, opts, nil)
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
 			require.NoError(b, err)
 			for ln := 0; ln < labelNames; ln++ {
 				app := h.Appender(context.Background())

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -392,7 +392,7 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	ooow, err := wal.Open(db.logger, filepath.Join(db.dir, "ooo_wal"))
+	ooow, err := wal.Open(db.logger, filepath.Join(db.dir, wal.OOOWalDirName))
 	if err != nil {
 		return err
 	}
@@ -472,7 +472,7 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		if err != nil {
 			return nil, err
 		}
-		ooow, err := wal.Open(db.logger, filepath.Join(db.dir, "ooo_wal"))
+		ooow, err := wal.Open(db.logger, filepath.Join(db.dir, wal.OOOWalDirName))
 		if err != nil {
 			return nil, err
 		}
@@ -665,7 +665,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	}
 
 	walDir := filepath.Join(dir, "wal")
-	oooWalDir := filepath.Join(dir, "ooo_wal")
+	oooWalDir := filepath.Join(dir, wal.OOOWalDirName)
 
 	// Migrate old WAL if one exists.
 	if err := MigrateWAL(l, walDir); err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3531,37 +3531,37 @@ func TestOOOWALWrite(t *testing.T) {
 	s1, s2 := labels.FromStrings("l", "v1"), labels.FromStrings("l", "v2")
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
 
-	appendSample := func(app storage.Appender, l labels.Labels, ts int64, v float64) {
-		_, err = app.Append(0, l, ts, v)
+	appendSample := func(app storage.Appender, l labels.Labels, mins int64) {
+		_, err = app.Append(0, l, minutes(mins), float64(mins))
 		require.NoError(t, err)
 	}
 
 	// Ingest sample at 1h.
 	app := db.Appender(context.Background())
-	appendSample(app, s1, minutes(60), 60)
-	appendSample(app, s2, minutes(60), 60)
+	appendSample(app, s1, 60)
+	appendSample(app, s2, 60)
 	require.NoError(t, app.Commit())
 
 	// OOO for s1.
 	app = db.Appender(context.Background())
-	appendSample(app, s1, minutes(40), 40)
+	appendSample(app, s1, 40)
 	require.NoError(t, app.Commit())
 
 	// OOO for s2.
 	app = db.Appender(context.Background())
-	appendSample(app, s2, minutes(42), 42)
+	appendSample(app, s2, 42)
 	require.NoError(t, app.Commit())
 
 	// OOO for both s1 and s2 in the same commit.
 	app = db.Appender(context.Background())
-	appendSample(app, s2, minutes(45), 45)
-	appendSample(app, s1, minutes(35), 35)
+	appendSample(app, s2, 45)
+	appendSample(app, s1, 35)
 	require.NoError(t, app.Commit())
 
 	// OOO for s1 but not for s2 in the same commit.
 	app = db.Appender(context.Background())
-	appendSample(app, s1, minutes(50), 50)
-	appendSample(app, s2, minutes(65), 65)
+	appendSample(app, s1, 50)
+	appendSample(app, s2, 65)
 	require.NoError(t, app.Commit())
 
 	oooSamplesRecords := [][]record.RefSample{

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3646,7 +3646,7 @@ func TestOOOWALWrite(t *testing.T) {
 	require.Equal(t, inOrderSamplesRecords, samples)
 
 	// The OOO WAL.
-	series, samples = getRecords(path.Join(dir, "ooo_wal"))
+	series, samples = getRecords(path.Join(dir, wal.OOOWalDirName))
 	require.Equal(t, oooSamplesRecords, samples)
 	require.Len(t, series, 0)
 }

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(b, err)
 	defer h.Close()
 
@@ -55,7 +55,7 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(b, err)
 	defer h.Close()
 
@@ -83,7 +83,7 @@ func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
 	// Mock the PreCreation() callback to fail on each series.
 	opts.SeriesCallback = failingSeriesLifecycleCallback{}
 
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(b, err)
 	defer h.Close()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -62,7 +62,7 @@ func newTestHead(t testing.TB, chunkRange int64, compressWAL bool) (*Head, *wal.
 	opts.EnableExemplarStorage = true
 	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
 
-	h, err := NewHead(nil, nil, wlog, opts, nil)
+	h, err := NewHead(nil, nil, wlog, nil, opts, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, h.chunkDiskMapper.IterateAllChunks(func(_ chunks.HeadSeriesRef, _ chunks.ChunkDiskMapperRef, _, _ int64, _ uint16) error { return nil }))
@@ -261,7 +261,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 						opts := DefaultHeadOptions()
 						opts.ChunkRange = 1000
 						opts.ChunkDirRoot = w.Dir()
-						h, err := NewHead(nil, nil, w, opts, nil)
+						h, err := NewHead(nil, nil, w, nil, opts, nil)
 						require.NoError(b, err)
 						h.Init(0)
 					}
@@ -578,7 +578,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = w.Dir()
-	head, err = NewHead(nil, nil, w, opts, nil)
+	head, err = NewHead(nil, nil, w, nil, opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(0))
 	defer func() {
@@ -897,7 +897,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 				opts := DefaultHeadOptions()
 				opts.ChunkRange = 1000
 				opts.ChunkDirRoot = reloadedW.Dir()
-				reloadedHead, err := NewHead(nil, nil, reloadedW, opts, nil)
+				reloadedHead, err := NewHead(nil, nil, reloadedW, nil, opts, nil)
 				require.NoError(t, err)
 				require.NoError(t, reloadedHead.Init(0))
 
@@ -1582,7 +1582,7 @@ func TestWalRepair_DecodingError(t *testing.T) {
 					opts := DefaultHeadOptions()
 					opts.ChunkRange = 1
 					opts.ChunkDirRoot = w.Dir()
-					h, err := NewHead(nil, nil, w, opts, nil)
+					h, err := NewHead(nil, nil, w, nil, opts, nil)
 					require.NoError(t, err)
 					require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.walCorruptionsTotal))
 					initErr := h.Init(math.MinInt64)
@@ -1640,7 +1640,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 		opts := DefaultHeadOptions()
 		opts.ChunkRange = chunkRange
 		opts.ChunkDirRoot = dir
-		h, err := NewHead(nil, nil, w, opts, nil)
+		h, err := NewHead(nil, nil, w, nil, opts, nil)
 		require.NoError(t, err)
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.mmapChunkCorruptionTotal))
 		require.NoError(t, h.Init(math.MinInt64))
@@ -1879,7 +1879,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = wlog.Dir()
-	hb, err = NewHead(nil, nil, wlog, opts, nil)
+	hb, err = NewHead(nil, nil, wlog, nil, opts, nil)
 	defer func() { require.NoError(t, hb.Close()) }()
 	require.NoError(t, err)
 	require.NoError(t, hb.Init(0))
@@ -2886,7 +2886,7 @@ func TestChunkSnapshot(t *testing.T) {
 	openHeadAndCheckReplay := func() {
 		w, err := wal.NewSize(nil, nil, head.wal.Dir(), 32768, false)
 		require.NoError(t, err)
-		head, err = NewHead(nil, nil, w, head.opts, nil)
+		head, err = NewHead(nil, nil, w, nil, head.opts, nil)
 		require.NoError(t, err)
 		require.NoError(t, head.Init(math.MinInt64))
 
@@ -3096,7 +3096,7 @@ func TestSnapshotError(t *testing.T) {
 	w, err := wal.NewSize(nil, nil, head.wal.Dir(), 32768, false)
 	require.NoError(t, err)
 	// Testing https://github.com/prometheus/prometheus/issues/9437 with the registry.
-	head, err = NewHead(prometheus.NewRegistry(), nil, w, head.opts, nil)
+	head, err = NewHead(prometheus.NewRegistry(), nil, w, nil, head.opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(math.MinInt64))
 
@@ -3155,7 +3155,7 @@ func TestChunkSnapshotReplayBug(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkDirRoot = dir
 	opts.EnableMemorySnapshotOnShutdown = true
-	head, err := NewHead(nil, nil, wlog, opts, nil)
+	head, err := NewHead(nil, nil, wlog, nil, opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(math.MinInt64))
 	defer func() {
@@ -3189,7 +3189,7 @@ func TestChunkSnapshotTakenAfterIncompleteSnapshot(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkDirRoot = dir
 	opts.EnableMemorySnapshotOnShutdown = true
-	head, err := NewHead(nil, nil, wlog, opts, nil)
+	head, err := NewHead(nil, nil, wlog, nil, opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(math.MinInt64))
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkQuerier(b *testing.B) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, h.Close())
@@ -201,7 +201,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(b, err)
 	defer h.Close()
 	app := h.Appender(context.Background())

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -460,7 +460,7 @@ func TestBlockQuerier_AgainstHeadWithOpenChunks(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 2 * time.Hour.Milliseconds()
-			h, err := NewHead(nil, nil, nil, opts, nil)
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
 			require.NoError(t, err)
 			defer h.Close()
 
@@ -1641,7 +1641,7 @@ func TestPostingsForMatchers(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = chunkDir
-	h, err := NewHead(nil, nil, nil, opts, nil)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, h.Close())

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -201,36 +201,41 @@ type walMetrics struct {
 	writesFailed    prometheus.Counter
 }
 
-func newWALMetrics(r prometheus.Registerer) *walMetrics {
+func newWALMetrics(r prometheus.Registerer, isOOO bool) *walMetrics {
 	m := &walMetrics{}
 
+	prefix := "prometheus_tsdb_wal"
+	if isOOO {
+		prefix = "prometheus_tsdb_out_of_order_wal"
+	}
+
 	m.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "prometheus_tsdb_wal_fsync_duration_seconds",
+		Name:       fmt.Sprintf("%s_fsync_duration_seconds", prefix),
 		Help:       "Duration of WAL fsync.",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 	m.pageFlushes = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_page_flushes_total",
+		Name: fmt.Sprintf("%s_page_flushes_total", prefix),
 		Help: "Total number of page flushes.",
 	})
 	m.pageCompletions = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_completed_pages_total",
+		Name: fmt.Sprintf("%s_completed_pages_total", prefix),
 		Help: "Total number of completed pages.",
 	})
 	m.truncateFail = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_truncations_failed_total",
+		Name: fmt.Sprintf("%s_truncations_failed_total", prefix),
 		Help: "Total number of WAL truncations that failed.",
 	})
 	m.truncateTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_truncations_total",
+		Name: fmt.Sprintf("%s_truncations_total", prefix),
 		Help: "Total number of WAL truncations attempted.",
 	})
 	m.currentSegment = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_wal_segment_current",
+		Name: fmt.Sprintf("%s_segment_current", prefix),
 		Help: "WAL segment index that TSDB is currently writing to.",
 	})
 	m.writesFailed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_tsdb_wal_writes_failed_total",
+		Name: fmt.Sprintf("%s_writes_failed_total", prefix),
 		Help: "Total number of WAL writes that failed.",
 	})
 
@@ -275,7 +280,12 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		stopc:       make(chan chan struct{}),
 		compress:    compress,
 	}
-	w.metrics = newWALMetrics(reg)
+	isOOO := false
+	if filepath.Base(dir) == "ooo_wal" {
+		// TODO(codesome): have a less hacky way to do it.
+		isOOO = true
+	}
+	w.metrics = newWALMetrics(reg, isOOO)
 
 	_, last, err := Segments(w.Dir())
 	if err != nil {

--- a/tsdb/wal/wal.go
+++ b/tsdb/wal/wal.go
@@ -41,6 +41,7 @@ const (
 	DefaultSegmentSize = 128 * 1024 * 1024 // 128 MB
 	pageSize           = 32 * 1024         // 32KB
 	recordHeaderSize   = 7
+	OOOWalDirName      = "ooo_wal"
 )
 
 // The table gets initialized with sync.Once but may still cause a race
@@ -281,7 +282,7 @@ func NewSize(logger log.Logger, reg prometheus.Registerer, dir string, segmentSi
 		compress:    compress,
 	}
 	isOOO := false
-	if filepath.Base(dir) == "ooo_wal" {
+	if filepath.Base(dir) == OOOWalDirName {
 		// TODO(codesome): have a less hacky way to do it.
 		isOOO = true
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2171,7 +2171,7 @@ func (f *fakeDB) Stats(statsByLabelName string) (_ *tsdb.Stats, retErr error) {
 	}()
 	opts := tsdb.DefaultHeadOptions()
 	opts.ChunkRange = 1000
-	h, _ := tsdb.NewHead(nil, nil, nil, opts, nil)
+	h, _ := tsdb.NewHead(nil, nil, nil, nil, opts, nil)
 	return h.Stats(statsByLabelName), nil
 }
 


### PR DESCRIPTION
This PR writes OOO samples to a separate WAL with directory name `ooo_wal`.

It also fixes a bug in the ingestion.