### PR TITLE
Replay OOO samples from the WAL

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -686,14 +686,44 @@ func (h *Head) Init(minValidTime int64) error {
 		level.Info(h.logger).Log("msg", "WAL segment loaded", "segment", i, "maxSegment", endAt)
 		h.updateWALReplayStatusRead(i)
 	}
+	walReplayDuration := time.Since(walReplayStart)
 
-	walReplayDuration := time.Since(start)
-	h.metrics.walTotalReplayDuration.Set(walReplayDuration.Seconds())
+	// Replay OOO WAL.
+	oooWalReplayStart := time.Now()
+	startFrom, endAt, e = wal.Segments(h.oooWal.Dir())
+	if e != nil {
+		return errors.Wrap(e, "finding OOO WAL segments")
+	}
+	h.startWALReplayStatus(startFrom, endAt)
+
+	for i := startFrom; i <= endAt; i++ {
+		s, err := wal.OpenReadSegment(wal.SegmentName(h.oooWal.Dir(), i))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("open OOO WAL segment: %d", i))
+		}
+
+		sr := wal.NewSegmentBufReader(s)
+		err = h.loadOOOWal(wal.NewReader(sr), multiRef)
+		if err := sr.Close(); err != nil {
+			level.Warn(h.logger).Log("msg", "Error while closing the ooo wal segments reader", "err", err)
+		}
+		if err != nil {
+			return err
+		}
+		level.Info(h.logger).Log("msg", "OOO WAL segment loaded", "segment", i, "maxSegment", endAt)
+		h.updateWALReplayStatusRead(i)
+	}
+
+	oooWalReplayDuration := time.Since(oooWalReplayStart)
+
+	walTotalReplayDuration := time.Since(start)
+	h.metrics.walTotalReplayDuration.Set(walTotalReplayDuration.Seconds())
 	level.Info(h.logger).Log(
 		"msg", "WAL replay completed",
 		"checkpoint_replay_duration", checkpointReplayDuration.String(),
-		"wal_replay_duration", time.Since(walReplayStart).String(),
-		"total_replay_duration", walReplayDuration.String(),
+		"wal_replay_duration", walReplayDuration.String(),
+		"ooo_wal_replay_duration", oooWalReplayDuration.String(),
+		"total_replay_duration", walTotalReplayDuration.String(),
 	)
 
 	return nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -333,7 +333,7 @@ type headMetrics struct {
 	tooOldSamples            prometheus.Counter
 	walTruncateDuration      prometheus.Summary
 	walCorruptionsTotal      prometheus.Counter
-	walTotalReplayDuration   prometheus.Gauge
+	dataTotalReplayDuration  prometheus.Gauge
 	headTruncateFail         prometheus.Counter
 	headTruncateTotal        prometheus.Counter
 	checkpointDeleteFail     prometheus.Counter
@@ -393,7 +393,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_wal_corruptions_total",
 			Help: "Total number of WAL corruptions.",
 		}),
-		walTotalReplayDuration: prometheus.NewGauge(prometheus.GaugeOpts{
+		dataTotalReplayDuration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "prometheus_tsdb_data_replay_duration_seconds",
 			Help: "Time taken to replay the data on disk.",
 		}),
@@ -474,7 +474,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.gcDuration,
 			m.walTruncateDuration,
 			m.walCorruptionsTotal,
-			m.walTotalReplayDuration,
+			m.dataTotalReplayDuration,
 			m.samplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,
@@ -716,14 +716,14 @@ func (h *Head) Init(minValidTime int64) error {
 
 	oooWalReplayDuration := time.Since(oooWalReplayStart)
 
-	walTotalReplayDuration := time.Since(start)
-	h.metrics.walTotalReplayDuration.Set(walTotalReplayDuration.Seconds())
+	totalReplayDuration := time.Since(start)
+	h.metrics.dataTotalReplayDuration.Set(totalReplayDuration.Seconds())
 	level.Info(h.logger).Log(
 		"msg", "WAL replay completed",
 		"checkpoint_replay_duration", checkpointReplayDuration.String(),
 		"wal_replay_duration", walReplayDuration.String(),
 		"ooo_wal_replay_duration", oooWalReplayDuration.String(),
-		"total_replay_duration", walTotalReplayDuration.String(),
+		"total_replay_duration", totalReplayDuration.String(),
 	)
 
 	return nil

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -517,7 +517,7 @@ func (h *Head) loadOOOWal(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunk
 	// The records are always replayed from the oldest to the newest.
 	for d := range decoded {
 		samples := d
-		// We split up the samples into chunks of 5000 samples or less.
+		// We split up the samples into parts of 5000 samples or less.
 		// With O(300 * #cores) in-flight sample batches, large scrapes could otherwise
 		// cause thousands of very large in flight buffers occupying large amounts
 		// of unused memory.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -446,6 +446,205 @@ func (wp *walSubsetProcessor) waitUntilIdle() {
 	}
 }
 
+func (h *Head) loadOOOWal(r *wal.Reader, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef) (err error) {
+	// Track number of samples that referenced a series we don't know about
+	// for error reporting.
+	var unknownRefs atomic.Uint64
+
+	// Start workers that each process samples for a partition of the series ID space.
+	var (
+		wg         sync.WaitGroup
+		n          = runtime.GOMAXPROCS(0)
+		processors = make([]oooWalSubsetProcessor, n)
+
+		dec    record.Decoder
+		shards = make([][]record.RefSample, n)
+
+		decoded     = make(chan []record.RefSample, 10)
+		decodeErr   error
+		samplesPool = sync.Pool{
+			New: func() interface{} {
+				return []record.RefSample{}
+			},
+		}
+	)
+
+	defer func() {
+		// For CorruptionErr ensure to terminate all workers before exiting.
+		_, ok := err.(*wal.CorruptionErr)
+		if ok {
+			for i := 0; i < n; i++ {
+				processors[i].closeAndDrain()
+			}
+			wg.Wait()
+		}
+	}()
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		processors[i].setup()
+
+		go func(wp *oooWalSubsetProcessor) {
+			unknown := wp.processWALSamples(h)
+			unknownRefs.Add(unknown)
+			wg.Done()
+		}(&processors[i])
+	}
+
+	go func() {
+		defer close(decoded)
+		for r.Next() {
+			rec := r.Record()
+			switch dec.Type(rec) {
+			case record.Samples:
+				samples := samplesPool.Get().([]record.RefSample)[:0]
+				samples, err = dec.Samples(rec, samples)
+				if err != nil {
+					decodeErr = &wal.CorruptionErr{
+						Err:     errors.Wrap(err, "decode samples"),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- samples
+			default:
+				// Noop.
+			}
+		}
+	}()
+
+	// The records are always replayed from the oldest to the newest.
+	for d := range decoded {
+		samples := d
+		// We split up the samples into chunks of 5000 samples or less.
+		// With O(300 * #cores) in-flight sample batches, large scrapes could otherwise
+		// cause thousands of very large in flight buffers occupying large amounts
+		// of unused memory.
+		for len(samples) > 0 {
+			m := 5000
+			if len(samples) < m {
+				m = len(samples)
+			}
+			for i := 0; i < n; i++ {
+				shards[i] = processors[i].reuseBuf()
+			}
+			for _, sam := range samples[:m] {
+				if r, ok := multiRef[sam.Ref]; ok {
+					sam.Ref = r
+				}
+				mod := uint64(sam.Ref) % uint64(n)
+				shards[mod] = append(shards[mod], sam)
+			}
+			for i := 0; i < n; i++ {
+				processors[i].input <- shards[i]
+			}
+			samples = samples[m:]
+		}
+		//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
+		samplesPool.Put(d)
+	}
+
+	if decodeErr != nil {
+		return decodeErr
+	}
+
+	// Signal termination to each worker and wait for it to close its output channel.
+	for i := 0; i < n; i++ {
+		processors[i].closeAndDrain()
+	}
+	wg.Wait()
+
+	if r.Err() != nil {
+		return errors.Wrap(r.Err(), "read records")
+	}
+
+	if unknownRefs.Load() > 0 {
+		level.Warn(h.logger).Log("msg", "Unknown series references for ooo WAL replay", "samples", unknownRefs.Load())
+	}
+	return nil
+}
+
+type errLoadOOOWal struct {
+	err error
+}
+
+func (e errLoadOOOWal) Error() string {
+	return e.err.Error()
+}
+
+// To support errors.Cause().
+func (e errLoadOOOWal) Cause() error {
+	return e.err
+}
+
+// To support errors.Unwrap().
+func (e errLoadOOOWal) Unwrap() error {
+	return e.err
+}
+
+// isErrLoadOOOWal returns a boolean if the error is errLoadOOOWal.
+func isErrLoadOOOWal(err error) bool {
+	_, ok := errors.Cause(err).(*errLoadOOOWal)
+	return ok
+}
+
+type oooWalSubsetProcessor struct {
+	mx     sync.Mutex // Take this lock while modifying series in the subset.
+	input  chan []record.RefSample
+	output chan []record.RefSample
+}
+
+func (wp *oooWalSubsetProcessor) setup() {
+	wp.output = make(chan []record.RefSample, 300)
+	wp.input = make(chan []record.RefSample, 300)
+}
+
+func (wp *oooWalSubsetProcessor) closeAndDrain() {
+	close(wp.input)
+	for range wp.output {
+	}
+}
+
+// If there is a buffer in the output chan, return it for reuse, otherwise return nil.
+func (wp *oooWalSubsetProcessor) reuseBuf() []record.RefSample {
+	select {
+	case buf := <-wp.output:
+		return buf[:0]
+	default:
+	}
+	return nil
+}
+
+// processWALSamples adds the samples it receives to the head and passes
+// the buffer received to an output channel for reuse.
+// Samples before the minValidTime timestamp are discarded.
+func (wp *oooWalSubsetProcessor) processWALSamples(h *Head) (unknownRefs uint64) {
+	defer close(wp.output)
+
+	// We don't check for minValidTime for ooo samples.
+
+	for samples := range wp.input {
+		wp.mx.Lock()
+		for _, s := range samples {
+			ms := h.series.getByID(s.Ref)
+			if ms == nil {
+				unknownRefs++
+				continue
+			}
+			// TODO(codesome): Ignore samples that are already m-mapped. Needs a m-map marker in the WAL.
+			if _, chunkCreated := ms.insert(s.T, s.V, h.chunkDiskMapper); chunkCreated {
+				h.metrics.chunksCreated.Inc()
+				h.metrics.chunks.Inc()
+			}
+		}
+		wp.mx.Unlock()
+		wp.output <- samples
+	}
+
+	return unknownRefs
+}
+
 const (
 	chunkSnapshotRecordTypeSeries     uint8 = 1
 	chunkSnapshotRecordTypeTombstones uint8 = 2


### PR DESCRIPTION
This is a follow up of https://github.com/grafana/mimir-prometheus/pull/181 and based on that PR. Once that is merged, the diff of this PR will be more digestible.

The changes look intimidating, but what I have done is:

1. Copy `loadWal` into `loadOOOWal` and remove all that is not required (i.e. keeping only samples replay and nothing to do with m-map chunks here yet).
2. Copy the `walSubsetProcessor` struct and its methods into `oooWalSubsetProcessor` and modify `oooWalSubsetProcessor.processWALSamples()` to write to the ooo chunk instead or the in-order chunk.
3. Some handling to identify if the replay error was for old WAL replay or the ooo WAL replay hence repair the appropriate WAL in db.go.

Things still missing and TODO in a follow up PR:
1. Add markers in the WAL as to when the series m-mapped a ooo chunk.
2. Replay ooo m-map chunks during the replay (also requires identifying ooo m-map chunks, needs adding the metadata during m-mapping).
3. Use the m-map marker from above to discard the WAL samples to prevent duplicate m-map chunks.