### PR TITLE
Add overlapping chunks in decreasing order test

### DIFF
--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -68,7 +68,7 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, lbls *labels.Labels,
 
 		tmpChks = append(tmpChks, chunks.Meta{
 			MinTime:        s.oooHeadChunk.minTime,
-			MaxTime:        math.MaxInt64, // Set the head chunks as open (being appended to).
+			MaxTime:        s.oooHeadChunk.maxTime,
 			Ref:            lastChunkRef,
 			OOOLastRef:     lastChunkRef,
 			OOOLastMinTime: lastMinT,

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -59,49 +59,41 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, lbls *labels.Labels,
 	var lastChunkRef chunks.ChunkRef
 	lastMinT, lastMaxT := int64(math.MaxInt64), int64(math.MaxInt64)
 
-	// We first collect the oooHeadChunk, if any. And if it exists we set value
-	// for the markers defined above.
-	if s.oooHeadChunk != nil && s.oooHeadChunk.OverlapsClosedInterval(oh.mint, oh.maxt) {
-		lastMinT = s.oooHeadChunk.minTime
-		lastMaxT = s.oooHeadChunk.maxTime
-		lastChunkRef = chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.oooMmappedChunks))))
+	addChunk := func(minT, maxT int64, ref chunks.ChunkRef) {
+
+		// the first time we get called is for the last included chunk.
+		// set the markers accordingly
+		if lastMinT == int64(math.MaxInt64) {
+			lastChunkRef = ref
+			lastMinT = minT
+			lastMaxT = maxT
+		}
 
 		tmpChks = append(tmpChks, chunks.Meta{
-			MinTime:        s.oooHeadChunk.minTime,
-			MaxTime:        s.oooHeadChunk.maxTime,
-			Ref:            lastChunkRef,
+			MinTime:        minT,
+			MaxTime:        maxT,
+			Ref:            ref,
 			OOOLastRef:     lastChunkRef,
 			OOOLastMinTime: lastMinT,
 			OOOLastMaxTime: lastMaxT,
 		})
-
 	}
 
-	// Next collect the memory mapped chunks in reverse order, if any.
-	// In case there was no head chunk before, we want the last memory mapped
-	// chunk to be our last reference for the markers and the chunk meta.
+	// Collect all chunks that overlap the query range, in order from most recent to most old,
+	// so we can set the correct markers.
+	if s.oooHeadChunk != nil {
+		c := s.oooHeadChunk
+		if c.OverlapsClosedInterval(oh.mint, oh.maxt) {
+			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.oooMmappedChunks))))
+			addChunk(c.minTime, c.maxTime, ref)
+		}
+	}
 	for i := len(s.oooMmappedChunks) - 1; i >= 0; i-- {
 		c := s.oooMmappedChunks[i]
-
-		// Do not expose chunks that are outside of the specified range.
-		if !c.OverlapsClosedInterval(oh.mint, oh.maxt) {
-			continue
+		if c.OverlapsClosedInterval(oh.mint, oh.maxt) {
+			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(i)))
+			addChunk(c.minTime, c.maxTime, ref)
 		}
-
-		if lastMinT == int64(math.MaxInt64) {
-			lastChunkRef = chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(i)))
-			lastMinT = c.minTime
-			lastMaxT = c.maxTime
-		}
-
-		tmpChks = append(tmpChks, chunks.Meta{
-			MinTime:        c.minTime,
-			MaxTime:        c.maxTime,
-			Ref:            chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(i))),
-			OOOLastRef:     lastChunkRef,
-			OOOLastMinTime: lastMinT,
-			OOOLastMaxTime: lastMaxT,
-		})
 	}
 
 	// There is nothing to do if we did not collect any chunk
@@ -119,7 +111,7 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, lbls *labels.Labels,
 	// In the example 5 overlaps with 7 and 6 overlaps with 8 so we only want to
 	// to return chunk Metas for chunk 5 and chunk 6
 	*chks = append(*chks, tmpChks[0])
-	maxTime := tmpChks[0].MaxTime
+	maxTime := tmpChks[0].MaxTime // tracks the maxTime of the previous "to be merged chunk"
 	for _, c := range tmpChks[1:] {
 		if c.MinTime > maxTime {
 			*chks = append(*chks, c)

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -60,7 +60,6 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, lbls *labels.Labels,
 	lastMinT, lastMaxT := int64(math.MaxInt64), int64(math.MaxInt64)
 
 	addChunk := func(minT, maxT int64, ref chunks.ChunkRef) {
-
 		// the first time we get called is for the last included chunk.
 		// set the markers accordingly
 		if lastMinT == int64(math.MaxInt64) {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -50,7 +50,6 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		expChunks           []chunkInterval
 	}{
 		{
-			// TODO with the permutation stuff, seems like we skip this first one
 			name:           "Test1: Empty result and no error when head is empty",
 			queryMinT:      0,
 			queryMaxT:      100,
@@ -190,7 +189,15 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 	s1ID := uint64(1)
 
 	for _, tc := range tests {
-		permutations := permutateChunkIntervals(tc.inputChunkIntervals, nil, 0, len(tc.inputChunkIntervals)-1)
+		var permutations [][]chunkInterval
+		if len(tc.inputChunkIntervals) == 0 {
+			// handle special case
+			permutations = [][]chunkInterval{
+				nil,
+			}
+		} else {
+			permutations = permutateChunkIntervals(tc.inputChunkIntervals, nil, 0, len(tc.inputChunkIntervals)-1)
+		}
 		for perm, intervals := range permutations {
 			for _, headChunk := range []bool{false, true} {
 				t.Run(fmt.Sprintf("name=%s, permutation=%d, headChunk=%t", tc.name, perm, headChunk), func(t *testing.T) {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -47,15 +47,13 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		queryMinT           int64
 		queryMaxT           int64
 		inputChunkIntervals []chunkInterval
-		expSeriesError      bool
 		expChunks           []chunkInterval
 	}{
 		{
-			name:           "Empty result and no error when head is empty",
-			queryMinT:      0,
-			queryMaxT:      100,
-			expSeriesError: false,
-			expChunks:      nil,
+			name:      "Empty result and no error when head is empty",
+			queryMinT: 0,
+			queryMaxT: 100,
+			expChunks: nil,
 		},
 		{
 			name:      "If query interval is bigger than the existing chunks nothing is returned",
@@ -64,11 +62,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			inputChunkIntervals: []chunkInterval{
 				{0, 100, 400},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval                                                                                                  [---------------------------------------]
 			// Chunk 0                         [-----------------------------------------------------------]
-			// Expected Output  Empty
 			expChunks: nil,
 		},
 		{
@@ -78,11 +74,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			inputChunkIntervals: []chunkInterval{
 				{0, 500, 700},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval                [-----------------------------------------------------------]
 			// Chunk 0:                                                                                                        [---------------------------------------]
-			// Expected Output  Empty
 			expChunks: nil,
 		},
 		{
@@ -92,11 +86,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			inputChunkIntervals: []chunkInterval{
 				{0, 150, 350},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval                [-----------------------------------------------------------]
 			// Chunk 0:                                 [---------------------------------------]
-			// Expected Output  Empty
 			expChunks: []chunkInterval{
 				{0, 150, 350},
 			},
@@ -108,11 +100,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			inputChunkIntervals: []chunkInterval{
 				{0, 100, 400},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval:                          [---------------------------------------]
 			// Chunk 0:                       [-----------------------------------------------------------]
-			// Expected Output  Empty
 			expChunks: []chunkInterval{
 				{0, 100, 400},
 			},
@@ -127,14 +117,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{2, 150, 250},
 				{3, 550, 650},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
 			// Chunk 0:                        [-------------------]
 			// Chunk 1:                                                                                                        [-------------------]
 			// Chunk 2:                                  [-------------------]
 			// Chunk 3:                                                                                                                  [-------------------]
-			// Expected Output  [0x1000000, 0x1000001] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [-----------------------------]                                                 [-----------------------------]
 			expChunks: []chunkInterval{
 				{0, 100, 250},
@@ -151,14 +139,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{2, 300, 400},
 				{3, 400, 500},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
 			// Chunk 0:                        [-------------------]
 			// Chunk 1:                                            [-------------------]
 			// Chunk 2:                                                                [-------------------]
 			// Chunk 3:                                                                                    [------------------]
-			// Expected Output  [0x1000000] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------------------------------------------------------------------]
 			expChunks: []chunkInterval{
 				{0, 100, 500},
@@ -174,14 +160,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{2, 300, 399},
 				{3, 400, 499},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
 			// Chunk 0:                        [------------------]
 			// Chunk 1:                                            [------------------]
 			// Chunk 2:                                                                [------------------]
 			// Chunk 3:                                                                                    [------------------]
-			// Expected Output  [0x1000000, 0x1000001, 0x1000002, 0x1000003] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------][------------------][------------------][------------------]
 			expChunks: []chunkInterval{
 				{0, 100, 199},
@@ -200,14 +184,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{2, 250, 350},
 				{3, 450, 550},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [--------------------------------------------------------------------]
 			// Chunk 0:                        [------------------]
 			// Chunk 1:                                 [-----------------------------]
 			// Chunk 2:                                                     [------------------]
 			// Chunk 3:                                                                                             [------------------]
-			// Expected Output  [0x1000000, 0x1000001, 0x1000002] with OOOLastReferences pointing to 0x1000002
 			// Output Graphically              [-----------------------------------------------]
 			expChunks: []chunkInterval{
 				{0, 100, 350},
@@ -222,13 +204,11 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{1, 0, 200},
 				{2, 150, 300},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval                [------------------------------------------------------------]
 			// Chunk 0:                                                     [-------------------------------------------------]
 			// Chunk 1:             [-----------------------------]
 			// Chunk 2:                                [------------------------------]
-			// Expected Output  [0x1000000, 0x1000001, 0x1000002] with OOOLastReferences pointing to 0x1000002
 			// Output Graphically   [-----------------------------------------------------------------------------------------]
 			expChunks: []chunkInterval{
 				{1, 0, 500},
@@ -245,7 +225,6 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{3, 650, 750},
 				{4, 600, 800},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700       750       800       850
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------------------------------------]
 			// Chunk 0:                        [---------------------------------------]
@@ -253,7 +232,6 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 2:                                  [-------------------]
 			// Chunk 3:                                                                                                                                      [-------------------]
 			// Chunk 4:                                                                                                                             [---------------------------------------]
-			// Expected Output  [0x1000000, 0x1000004] With OOOLastReferences pointing to 0v1000004
 			// Output Graphically              [---------------------------------------]                                                            [------------------------------------------------]
 			expChunks: []chunkInterval{
 				{0, 100, 300},
@@ -269,14 +247,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 				{1, 300, 350},
 				{2, 200, 250},
 			},
-			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700       750       800       850
 			// Query Interval        [----------------------------------------------------------------------------------------------------------------------]
 			// Chunk 0:                        [-------]
 			// Chunk 1:                                                              [----------]
 			// Chunk 2:                                           [--------]
-			// Expected Output  [0x1000000, 0x1000001, 0x000002] With OOOLastReferences pointing to 0v1000002
-			// Output Graphically              [-------] [--------]                  [--------------]
+			// Output Graphically              [-------]          [--------]         [----------]
 			expChunks: []chunkInterval{
 				{0, 100, 150},
 				{1, 300, 350},
@@ -309,17 +285,17 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 
 					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
 
-					var markerChunk chunkInterval
-					var markerPos int
+					var lastChunk chunkInterval
+					var lastChunkPos int
 
 					// the marker should be set based on whichever is the last chunk/interval that overlaps with the query range
 					for i, interv := range intervals {
 						if overlapsClosedInterval(interv.mint, interv.maxt, tc.queryMinT, tc.queryMaxT) {
-							markerChunk = interv
-							markerPos = i
+							lastChunk = interv
+							lastChunkPos = i
 						}
 					}
-					markerRef := chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(uint64(markerPos))))
+					lastChunkRef := chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(uint64(lastChunkPos))))
 
 					// define our expected chunks, by looking at the expected ChunkIntervals and setting...
 					var expChunks []chunks.Meta
@@ -328,16 +304,16 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 							Chunk:   chunkenc.Chunk(nil),
 							MinTime: e.mint,
 							MaxTime: e.maxt,
-							// 1) markers based on the last chunk we found above
-							OOOLastMinTime: markerChunk.mint,
-							OOOLastMaxTime: markerChunk.maxt,
-							OOOLastRef:     markerRef,
+							// markers based on the last chunk we found above
+							OOOLastMinTime: lastChunk.mint,
+							OOOLastMaxTime: lastChunk.maxt,
+							OOOLastRef:     lastChunkRef,
 						}
 
-						// 3) Ref to whatever Ref the chunk has, that we refer to by ID
+						// Ref to whatever Ref the chunk has, that we refer to by ID
 						for ref, c := range intervals {
 							if c.ID == e.ID {
-								meta.Ref = chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
+								meta.Ref = chunks.ChunkRef(chunks.NewHeadChunkRef(chunks.HeadSeriesRef(s1ID), chunks.HeadChunkID(ref)))
 								break
 							}
 						}
@@ -347,7 +323,6 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 
 					if headChunk && len(intervals) > 0 {
 						// Put the last interval in the head chunk
-						//t.Logf("headchunk %v", intervals[len(intervals)-1])
 						s1.oooHeadChunk = &oooHeadChunk{
 							minTime: intervals[len(intervals)-1].mint,
 							maxTime: intervals[len(intervals)-1].maxt,
@@ -360,7 +335,6 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 							minTime: ic.mint,
 							maxTime: ic.maxt,
 						})
-						//t.Logf("     chunk %v", ic)
 					}
 
 					ir := NewOOOHeadIndexReader(h, tc.queryMinT, tc.queryMaxT)
@@ -368,14 +342,12 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 					var chks []chunks.Meta
 					var respLset labels.Labels
 					err := ir.Series(storage.SeriesRef(s1ID), &respLset, &chks)
-					if tc.expSeriesError {
-						require.Error(t, err)
-					} else {
-						require.NoError(t, err)
-					}
+					require.NoError(t, err)
 					require.Equal(t, s1Lset, respLset)
-
 					require.Equal(t, expChunks, chks)
+
+					err = ir.Series(storage.SeriesRef(s1ID+1), &respLset, &chks)
+					require.Equal(t, storage.ErrNotFound, err)
 				})
 			}
 		}

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
+type chunkInterval struct {
+	// because we permutate the order of chunks, we cannot determine at test declaration time which chunkRefs we expect in the Output.
+	// This ID matches expected output chunks against test input chunks, the test runner will assert the chunkRef for the matching chunk
+	ID   int
+	mint int64
+	maxt int64
+}
+
+// permutateChunkIntervals returns all possible orders of the given chunkIntervals
+func permutateChunkIntervals(in []chunkInterval, out [][]chunkInterval, left, right int) [][]chunkInterval {
+	if left == right {
+		inCopy := make([]chunkInterval, len(in))
+		copy(inCopy, in)
+		return append(out, inCopy)
+	}
+	for i := left; i <= right; i++ {
+		in[left], in[i] = in[i], in[left]
+		out = permutateChunkIntervals(in, out, left+1, right)
+		in[left], in[i] = in[i], in[left]
+	}
+	return out
+}
+
 // TestOOOHeadIndexReader_Series tests that the Series method works as expected.
 // However it does so by creating chunks and memory mapping them unlike other
 // tests of the head where samples are appended and we let the head memory map.
@@ -22,176 +45,143 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		name                string
 		queryMinT           int64
 		queryMaxT           int64
-		inputChunkIntervals []struct{ mint, maxt int64 }
+		inputChunkIntervals []chunkInterval
 		expSeriesError      bool
-		expChunks           []chunks.Meta
+		expChunks           []chunkInterval
 	}{
 		{
-			name:           "Empty result and no error when head is empty",
+			// TODO with the permutation stuff, seems like we skip this first one
+			name:           "Test1: Empty result and no error when head is empty",
 			queryMinT:      0,
 			queryMaxT:      100,
 			expSeriesError: false,
 			expChunks:      nil,
 		},
 		{
-			name:      "If query interval is bigger than the existing chunks nothing is returned",
+			name:      "Test2: If query interval is bigger than the existing chunks nothing is returned",
 			queryMinT: 500,
 			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 400},
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 400},
 			},
 			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval                                                                                                  [---------------------------------------]
-			// Chunk 0: 0x1000000              [-----------------------------------------------------------]
+			// Chunk 0                         [-----------------------------------------------------------]
 			// Expected Output  Empty
 			expChunks: nil,
 		},
 		{
-			name:      "When there are overlapping chunks, only the references of the first overlapping chunks are returned",
+			name:      "Test3: If query interval is smaller than the existing chunks nothing is returned",
+			queryMinT: 100,
+			queryMaxT: 400,
+			inputChunkIntervals: []chunkInterval{
+				{0, 500, 700},
+			},
+			expSeriesError: false,
+			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
+			// Query Interval                [-----------------------------------------------------------]
+			// Chunk 0:                                                                                                        [---------------------------------------]
+			// Expected Output  Empty
+			expChunks: nil,
+		},
+		{
+			name:      "Test4: Pairwise overlaps should return the references of the first of each pair",
 			queryMinT: 0,
 			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 200},
-				{500, 600},
-				{150, 250},
-				{550, 650},
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 200},
+				{1, 500, 600},
+				{2, 150, 250},
+				{3, 550, 650},
 			},
 			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000              [-------------------]
-			// Chunk 1: 0x1000001                                                                                              [-------------------]
-			// Chunk 2: 0x1000002                        [-------------------]
-			// Chunk 3: 0x1000003                                                                                                        [-------------------]
+			// Chunk 0:                        [-------------------]
+			// Chunk 1:                                                                                                        [-------------------]
+			// Chunk 2:                                  [-------------------]
+			// Chunk 3:                                                                                                                  [-------------------]
 			// Expected Output  [0x1000000, 0x1000001] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [-----------------------------]                                                 [-----------------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 250, OOOLastRef: 0x1000003, OOOLastMinTime: 550, OOOLastMaxTime: 650},
-				{Ref: 0x1000001, Chunk: chunkenc.Chunk(nil), MinTime: 500, MaxTime: 650, OOOLastRef: 0x1000003, OOOLastMinTime: 550, OOOLastMaxTime: 650},
+			expChunks: []chunkInterval{
+				{0, 100, 250},
+				{1, 500, 650},
 			},
 		},
 		{
-			name:      "If all chunks overlap, single big chunk is returned",
+			name:      "Test5: If all chunks overlap, single big chunk is returned",
 			queryMinT: 0,
 			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 200},
-				{200, 300},
-				{300, 400},
-				{400, 500},
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 200},
+				{1, 200, 300},
+				{2, 300, 400},
+				{3, 400, 500},
 			},
 			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000              [-------------------]
-			// Chunk 1: 0x1000001                                  [-------------------]
-			// Chunk 2: 0x1000002                                                      [-------------------]
-			// Chunk 3: 0x1000003                                                                          [------------------]
+			// Chunk 0:                        [-------------------]
+			// Chunk 1:                                            [-------------------]
+			// Chunk 2:                                                                [-------------------]
+			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------------------------------------------------------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 500, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 500},
+			expChunks: []chunkInterval{
+				{0, 100, 500},
 			},
 		},
 		{
-			name:      "If no chunks overlap, all chunks are returned",
+			name:      "Test6: If no chunks overlap, all chunks are returned",
 			queryMinT: 0,
 			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 199},
-				{200, 299},
-				{300, 399},
-				{400, 499},
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 199},
+				{1, 200, 299},
+				{2, 300, 399},
+				{3, 400, 499},
 			},
 			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000              [------------------]
-			// Chunk 1: 0x1000001                                  [------------------]
-			// Chunk 2: 0x1000002                                                      [------------------]
-			// Chunk 3: 0x1000003                                                                          [------------------]
+			// Chunk 0:                        [------------------]
+			// Chunk 1:                                            [------------------]
+			// Chunk 2:                                                                [------------------]
+			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000, 0x1000001, 0x1000002, 0x1000003] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------][------------------][------------------][------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 199, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
-				{Ref: 0x1000001, Chunk: chunkenc.Chunk(nil), MinTime: 200, MaxTime: 299, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
-				{Ref: 0x1000002, Chunk: chunkenc.Chunk(nil), MinTime: 300, MaxTime: 399, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
-				{Ref: 0x1000003, Chunk: chunkenc.Chunk(nil), MinTime: 400, MaxTime: 499, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
+			expChunks: []chunkInterval{
+				{0, 100, 199},
+				{1, 200, 299},
+				{2, 300, 399},
+				{3, 400, 499},
 			},
 		},
 		{
-			name:      "chunks can overlap in increasing order",
-			queryMinT: 0,
-			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 200},
-				{200, 299},
-				{300, 400},
-				{400, 499},
-			},
-			expSeriesError: false,
-			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
-			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000              [-------------------]
-			// Chunk 1: 0x1000001                                  [------------------]
-			// Chunk 2: 0x1000002                                                      [-------------------]
-			// Chunk 3: 0x1000003                                                                          [------------------]
-			// Expected Output  [0x1000000, 0x1000002] with OOOLastReferences pointing to 0x1000003
-			// Output Graphically              [--------------------------------------][--------------------------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 299, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
-				{Ref: 0x1000002, Chunk: chunkenc.Chunk(nil), MinTime: 300, MaxTime: 499, OOOLastRef: 0x1000003, OOOLastMinTime: 400, OOOLastMaxTime: 499},
-			},
-		},
-		{
-			name:      "chunks can overlap in decreasing order",
-			queryMinT: 0,
-			queryMaxT: 700,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{400, 499},
-				{300, 400},
-				{200, 299},
-				{100, 200},
-			},
-			expSeriesError: false,
-			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
-			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000                                                                          [-------------------]
-			// Chunk 1: 0x1000001                                                      [-------------------]
-			// Chunk 2: 0x1000002                                  [------------------]
-			// Chunk 3: 0x1000003              [-------------------]
-			// Expected Output  [0x1000001, 0x1000003] with OOOLastReferences pointing to 0x1000003
-			// Output Graphically              [--------------------------------------][--------------------------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000003, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 299, OOOLastRef: 0x1000003, OOOLastMinTime: 100, OOOLastMaxTime: 200},
-				{Ref: 0x1000001, Chunk: chunkenc.Chunk(nil), MinTime: 300, MaxTime: 499, OOOLastRef: 0x1000003, OOOLastMinTime: 100, OOOLastMaxTime: 200},
-			},
-		},
-		{
-			name:      "When a subsequent chunk encompasses another chunk the chunk id matches the chunk with the lower mintime",
+			name:      "Test7: a full overlap pair and disjointed triplet",
 			queryMinT: 0,
 			queryMaxT: 900,
-			inputChunkIntervals: []struct{ mint, maxt int64 }{
-				{100, 300},
-				{770, 850},
-				{150, 250},
-				{650, 750},
-				{600, 800},
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 300},
+				{1, 770, 850},
+				{2, 150, 250},
+				{3, 650, 750},
+				{4, 600, 800},
 			},
 			expSeriesError: false,
 			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700       750       800       850
 			// Query Interval        [---------------------------------------------------------------------------------------------------------------------------------------------------------------]
-			// Chunk 0: 0x1000000              [---------------------------------------]
-			// Chunk 1: 0x1000001                                                                                                                                                     [--------------]
-			// Chunk 2: 0x1000002                        [-------------------]
-			// Chunk 3: 0x1000003                                                                                                                            [-------------------]
-			// Chunk 4: 0x1000004                                                                                                                   [---------------------------------------]
+			// Chunk 0:                        [---------------------------------------]
+			// Chunk 1:                                                                                                                                                               [--------------]
+			// Chunk 2:                                  [-------------------]
+			// Chunk 3:                                                                                                                                      [-------------------]
+			// Chunk 4:                                                                                                                             [---------------------------------------]
 			// Expected Output  [0x1000000, 0x1000004] With OOOLastReferences pointing to 0v1000004
 			// Output Graphically              [---------------------------------------]                                                            [------------------------------------------------]
-			expChunks: []chunks.Meta{
-				{Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 300, OOOLastRef: 0x1000004, OOOLastMinTime: 600, OOOLastMaxTime: 800},
-				{Ref: 0x1000004, Chunk: chunkenc.Chunk(nil), MinTime: 600, MaxTime: 850, OOOLastRef: 0x1000004, OOOLastMinTime: 600, OOOLastMaxTime: 800},
+			expChunks: []chunkInterval{
+				{0, 100, 300},
+				{4, 600, 850},
 			},
 		},
 	}
@@ -199,47 +189,76 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 	s1Lset := labels.FromStrings("foo", "bar")
 	s1ID := uint64(1)
 
-	for _, headChunk := range []bool{false, true} {
-		for _, tc := range tests {
-			t.Run(fmt.Sprintf("name=%s, headChunk=%t", tc.name, headChunk), func(t *testing.T) {
-				h, _ := newTestHead(t, 1000, false)
-				defer func() {
-					require.NoError(t, h.Close())
-				}()
-				require.NoError(t, h.Init(0))
+	for _, tc := range tests {
+		permutations := permutateChunkIntervals(tc.inputChunkIntervals, nil, 0, len(tc.inputChunkIntervals)-1)
+		for perm, intervals := range permutations {
+			for _, headChunk := range []bool{false, true} {
+				t.Run(fmt.Sprintf("name=%s, permutation=%d, headChunk=%t", tc.name, perm, headChunk), func(t *testing.T) {
+					h, _ := newTestHead(t, 1000, false)
+					defer func() {
+						require.NoError(t, h.Close())
+					}()
+					require.NoError(t, h.Init(0))
 
-				s1, _, _ := h.getOrCreate(s1ID, s1Lset)
+					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
 
-				if headChunk && len(tc.inputChunkIntervals) > 0 {
-					// Put the last interval in the head chunk
-					s1.oooHeadChunk = &oooHeadChunk{
-						minTime: tc.inputChunkIntervals[len(tc.inputChunkIntervals)-1].mint,
-						maxTime: tc.inputChunkIntervals[len(tc.inputChunkIntervals)-1].maxt,
+					// define our expected chunks, by looking at the expected ChunkIntervals and setting...
+					var expChunks []chunks.Meta
+					for _, e := range tc.expChunks {
+						meta := chunks.Meta{
+							Chunk:   chunkenc.Chunk(nil),
+							MinTime: e.mint,
+							MaxTime: e.maxt,
+							// 1) markers corresponding to the last chunk within this permutation.
+							OOOLastMinTime: intervals[len(intervals)-1].mint,
+							OOOLastMaxTime: intervals[len(intervals)-1].maxt,
+							// 2) LastRef to simply be whatever was the highest ref seen, always
+							OOOLastRef: chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(uint64(len(intervals)-1)))),
+						}
+
+						// 3) Ref to whatever Ref the chunk has, that we refer to by ID
+						for ref, c := range intervals {
+							if c.ID == e.ID {
+								meta.Ref = chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
+								break
+							}
+						}
+						expChunks = append(expChunks, meta)
 					}
-					tc.inputChunkIntervals = tc.inputChunkIntervals[:len(tc.inputChunkIntervals)-1]
-				}
 
-				for _, ic := range tc.inputChunkIntervals {
-					s1.oooMmappedChunks = append(s1.oooMmappedChunks, &mmappedChunk{
-						minTime: ic.mint,
-						maxTime: ic.maxt,
-					})
-				}
+					if headChunk && len(intervals) > 0 {
+						// Put the last interval in the head chunk
+						//t.Logf("headchunk %v", intervals[len(intervals)-1])
+						s1.oooHeadChunk = &oooHeadChunk{
+							minTime: intervals[len(intervals)-1].mint,
+							maxTime: intervals[len(intervals)-1].maxt,
+						}
+						intervals = intervals[:len(intervals)-1]
+					}
 
-				ir := NewOOOHeadIndexReader(h, tc.queryMinT, tc.queryMaxT)
+					for _, ic := range intervals {
+						s1.oooMmappedChunks = append(s1.oooMmappedChunks, &mmappedChunk{
+							minTime: ic.mint,
+							maxTime: ic.maxt,
+						})
+						//t.Logf("     chunk %v", ic)
+					}
 
-				var chks []chunks.Meta
-				var respLset labels.Labels
-				err := ir.Series(storage.SeriesRef(s1ID), &respLset, &chks)
-				if tc.expSeriesError {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-				}
-				require.Equal(t, s1Lset, respLset)
+					ir := NewOOOHeadIndexReader(h, tc.queryMinT, tc.queryMaxT)
 
-				require.Equal(t, tc.expChunks, chks)
-			})
+					var chks []chunks.Meta
+					var respLset labels.Labels
+					err := ir.Series(storage.SeriesRef(s1ID), &respLset, &chks)
+					if tc.expSeriesError {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+					require.Equal(t, s1Lset, respLset)
+
+					require.Equal(t, expChunks, chks)
+				})
+			}
 		}
 	}
 }

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -20,23 +20,6 @@ type chunkInterval struct {
 	maxt int64
 }
 
-// GetChunkInterval returs the chunkInterval with matching ID, as well as what its chunkRef would be
-func GetChunkInterval(in []chunkInterval, ID int) (chunkInterval, chunks.ChunkRef) {
-	for ref, c := range in {
-		if c.ID == ID {
-			return c, chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
-		}
-	}
-	return chunkInterval{}, 0
-}
-
-type chunkOut struct {
-	ID     int // to match on the input chunk we're based on
-	lastID int // to match on the last matching chunk that dictates the markers
-	mint   int64
-	maxt   int64
-}
-
 // permutateChunkIntervals returns all possible orders of the given chunkIntervals
 func permutateChunkIntervals(in []chunkInterval, out [][]chunkInterval, left, right int) [][]chunkInterval {
 	if left == right {
@@ -64,7 +47,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		queryMaxT           int64
 		inputChunkIntervals []chunkInterval
 		expSeriesError      bool
-		expChunks           []chunkOut
+		expChunks           []chunkInterval
 	}{
 		{
 			name:           "Test1: Empty result and no error when head is empty",
@@ -113,8 +96,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Query Interval                [-----------------------------------------------------------]
 			// Chunk 0:                                 [---------------------------------------]
 			// Expected Output  Empty
-			expChunks: []chunkOut{
-				{0, 0, 150, 350},
+			expChunks: []chunkInterval{
+				{0, 150, 350},
 			},
 		},
 		{
@@ -129,8 +112,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Query Interval:                          [---------------------------------------]
 			// Chunk 0:                       [-----------------------------------------------------------]
 			// Expected Output  Empty
-			expChunks: []chunkOut{
-				{0, 0, 100, 400},
+			expChunks: []chunkInterval{
+				{0, 100, 400},
 			},
 		},
 		{
@@ -152,9 +135,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                                                  [-------------------]
 			// Expected Output  [0x1000000, 0x1000001] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [-----------------------------]                                                 [-----------------------------]
-			expChunks: []chunkOut{
-				{0, 3, 100, 250},
-				{1, 3, 500, 650},
+			expChunks: []chunkInterval{
+				{0, 100, 250},
+				{1, 500, 650},
 			},
 		},
 		{
@@ -176,8 +159,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------------------------------------------------------------------]
-			expChunks: []chunkOut{
-				{0, 3, 100, 500},
+			expChunks: []chunkInterval{
+				{0, 100, 500},
 			},
 		},
 		{
@@ -199,11 +182,11 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000, 0x1000001, 0x1000002, 0x1000003] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------][------------------][------------------][------------------]
-			expChunks: []chunkOut{
-				{0, 3, 100, 199},
-				{1, 3, 200, 299},
-				{2, 3, 300, 399},
-				{3, 3, 400, 499},
+			expChunks: []chunkInterval{
+				{0, 100, 199},
+				{1, 200, 299},
+				{2, 300, 399},
+				{3, 400, 499},
 			},
 		},
 		{
@@ -225,8 +208,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                             [------------------]
 			// Expected Output  [0x1000000, 0x1000001, 0x1000002] with OOOLastReferences pointing to 0x1000002
 			// Output Graphically              [-----------------------------------------------]
-			expChunks: []chunkOut{
-				{0, 2, 100, 350},
+			expChunks: []chunkInterval{
+				{0, 100, 350},
 			},
 		},
 		{
@@ -250,9 +233,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 4:                                                                                                                             [---------------------------------------]
 			// Expected Output  [0x1000000, 0x1000004] With OOOLastReferences pointing to 0v1000004
 			// Output Graphically              [---------------------------------------]                                                            [------------------------------------------------]
-			expChunks: []chunkOut{
-				{0, 4, 100, 300},
-				{4, 4, 600, 850},
+			expChunks: []chunkInterval{
+				{0, 100, 300},
+				{4, 600, 850},
 			},
 		},
 	}
@@ -281,23 +264,38 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 
 					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
 
-					// define our expected chunks, one for each defined expected chunk interval
-					// find the marker properties for last chunk, as well as the chunk Ref,
-					// by matching the chunks on their ID fields
+					var markerChunk chunkInterval
+					var markerPos int
+
+					// the marker should be set based on whichever is the last chunk/interval that overlaps with the query range
+					for i, interv := range intervals {
+						if overlapsClosedInterval(interv.mint, interv.maxt, tc.queryMinT, tc.queryMaxT) {
+							markerChunk = interv
+							markerPos = i
+						}
+					}
+					markerRef := chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(uint64(markerPos))))
+
+					// define our expected chunks, by looking at the expected ChunkIntervals and setting...
 					var expChunks []chunks.Meta
 					for _, e := range tc.expChunks {
-						lastChunk, lastRef := GetChunkInterval(intervals, e.lastID)
 						meta := chunks.Meta{
-							Chunk:          chunkenc.Chunk(nil),
-							MinTime:        e.mint,
-							MaxTime:        e.maxt,
-							OOOLastMinTime: lastChunk.mint,
-							OOOLastMaxTime: lastChunk.maxt,
-							OOOLastRef:     lastRef,
+							Chunk:   chunkenc.Chunk(nil),
+							MinTime: e.mint,
+							MaxTime: e.maxt,
+							// 1) markers based on the last chunk we found above
+							OOOLastMinTime: markerChunk.mint,
+							OOOLastMaxTime: markerChunk.maxt,
+							OOOLastRef:     markerRef,
 						}
 
-						_, meta.Ref = GetChunkInterval(intervals, e.ID)
-
+						// 3) Ref to whatever Ref the chunk has, that we refer to by ID
+						for ref, c := range intervals {
+							if c.ID == e.ID {
+								meta.Ref = chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
+								break
+							}
+						}
 						expChunks = append(expChunks, meta)
 					}
 

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -85,7 +85,39 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			expChunks: nil,
 		},
 		{
-			name:      "Test4: Pairwise overlaps should return the references of the first of each pair",
+			name:      "Test4: If query interval exceeds the existing chunk, it is returned",
+			queryMinT: 100,
+			queryMaxT: 400,
+			inputChunkIntervals: []chunkInterval{
+				{0, 150, 350},
+			},
+			expSeriesError: false,
+			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
+			// Query Interval                [-----------------------------------------------------------]
+			// Chunk 0:                                 [---------------------------------------]
+			// Expected Output  Empty
+			expChunks: []chunkInterval{
+				{0, 150, 350},
+			},
+		},
+		{
+			name:      "Test5: If chunk exceeds the query interval, it is returned",
+			queryMinT: 150,
+			queryMaxT: 350,
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 400},
+			},
+			expSeriesError: false,
+			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
+			// Query Interval:                          [---------------------------------------]
+			// Chunk 0:                       [-----------------------------------------------------------]
+			// Expected Output  Empty
+			expChunks: []chunkInterval{
+				{0, 100, 400},
+			},
+		},
+		{
+			name:      "Test6: Pairwise overlaps should return the references of the first of each pair",
 			queryMinT: 0,
 			queryMaxT: 700,
 			inputChunkIntervals: []chunkInterval{

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -20,6 +20,23 @@ type chunkInterval struct {
 	maxt int64
 }
 
+// GetChunkInterval returs the chunkInterval with matching ID, as well as what its chunkRef would be
+func GetChunkInterval(in []chunkInterval, ID int) (chunkInterval, chunks.ChunkRef) {
+	for ref, c := range in {
+		if c.ID == ID {
+			return c, chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
+		}
+	}
+	return chunkInterval{}, 0
+}
+
+type chunkOut struct {
+	ID     int // to match on the input chunk we're based on
+	lastID int // to match on the last matching chunk that dictates the markers
+	mint   int64
+	maxt   int64
+}
+
 // permutateChunkIntervals returns all possible orders of the given chunkIntervals
 func permutateChunkIntervals(in []chunkInterval, out [][]chunkInterval, left, right int) [][]chunkInterval {
 	if left == right {
@@ -47,7 +64,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		queryMaxT           int64
 		inputChunkIntervals []chunkInterval
 		expSeriesError      bool
-		expChunks           []chunkInterval
+		expChunks           []chunkOut
 	}{
 		{
 			name:           "Test1: Empty result and no error when head is empty",
@@ -96,8 +113,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Query Interval                [-----------------------------------------------------------]
 			// Chunk 0:                                 [---------------------------------------]
 			// Expected Output  Empty
-			expChunks: []chunkInterval{
-				{0, 150, 350},
+			expChunks: []chunkOut{
+				{0, 0, 150, 350},
 			},
 		},
 		{
@@ -112,8 +129,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Query Interval:                          [---------------------------------------]
 			// Chunk 0:                       [-----------------------------------------------------------]
 			// Expected Output  Empty
-			expChunks: []chunkInterval{
-				{0, 100, 400},
+			expChunks: []chunkOut{
+				{0, 0, 100, 400},
 			},
 		},
 		{
@@ -135,9 +152,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                                                  [-------------------]
 			// Expected Output  [0x1000000, 0x1000001] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [-----------------------------]                                                 [-----------------------------]
-			expChunks: []chunkInterval{
-				{0, 100, 250},
-				{1, 500, 650},
+			expChunks: []chunkOut{
+				{0, 3, 100, 250},
+				{1, 3, 500, 650},
 			},
 		},
 		{
@@ -159,8 +176,8 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------------------------------------------------------------------]
-			expChunks: []chunkInterval{
-				{0, 100, 500},
+			expChunks: []chunkOut{
+				{0, 3, 100, 500},
 			},
 		},
 		{
@@ -182,11 +199,34 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 3:                                                                                    [------------------]
 			// Expected Output  [0x1000000, 0x1000001, 0x1000002, 0x1000003] with OOOLastReferences pointing to 0x1000003
 			// Output Graphically              [------------------][------------------][------------------][------------------]
-			expChunks: []chunkInterval{
-				{0, 100, 199},
-				{1, 200, 299},
-				{2, 300, 399},
-				{3, 400, 499},
+			expChunks: []chunkOut{
+				{0, 3, 100, 199},
+				{1, 3, 200, 299},
+				{2, 3, 300, 399},
+				{3, 3, 400, 499},
+			},
+		},
+		{
+			name:      "Test9: Triplet with pairwise overlaps, query range covers all, and distractor extra chunk",
+			queryMinT: 0,
+			queryMaxT: 400,
+			inputChunkIntervals: []chunkInterval{
+				{0, 100, 200},
+				{1, 150, 300},
+				{2, 250, 350},
+				{3, 450, 550},
+			},
+			expSeriesError: false,
+			// ts                    0       100       150       200       250       300       350       400       450       500       550       600       650       700
+			// Query Interval        [--------------------------------------------------------------------]
+			// Chunk 0:                        [------------------]
+			// Chunk 1:                                 [-----------------------------]
+			// Chunk 2:                                                     [------------------]
+			// Chunk 3:                                                                                             [------------------]
+			// Expected Output  [0x1000000, 0x1000001, 0x1000002] with OOOLastReferences pointing to 0x1000002
+			// Output Graphically              [-----------------------------------------------]
+			expChunks: []chunkOut{
+				{0, 2, 100, 350},
 			},
 		},
 		{
@@ -210,9 +250,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 			// Chunk 4:                                                                                                                             [---------------------------------------]
 			// Expected Output  [0x1000000, 0x1000004] With OOOLastReferences pointing to 0v1000004
 			// Output Graphically              [---------------------------------------]                                                            [------------------------------------------------]
-			expChunks: []chunkInterval{
-				{0, 100, 300},
-				{4, 600, 850},
+			expChunks: []chunkOut{
+				{0, 4, 100, 300},
+				{4, 4, 600, 850},
 			},
 		},
 	}
@@ -241,27 +281,23 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 
 					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
 
-					// define our expected chunks, by looking at the expected ChunkIntervals and setting...
+					// define our expected chunks, one for each defined expected chunk interval
+					// find the marker properties for last chunk, as well as the chunk Ref,
+					// by matching the chunks on their ID fields
 					var expChunks []chunks.Meta
 					for _, e := range tc.expChunks {
+						lastChunk, lastRef := GetChunkInterval(intervals, e.lastID)
 						meta := chunks.Meta{
-							Chunk:   chunkenc.Chunk(nil),
-							MinTime: e.mint,
-							MaxTime: e.maxt,
-							// 1) markers corresponding to the last chunk within this permutation.
-							OOOLastMinTime: intervals[len(intervals)-1].mint,
-							OOOLastMaxTime: intervals[len(intervals)-1].maxt,
-							// 2) LastRef to simply be whatever was the highest ref seen, always
-							OOOLastRef: chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(uint64(len(intervals)-1)))),
+							Chunk:          chunkenc.Chunk(nil),
+							MinTime:        e.mint,
+							MaxTime:        e.maxt,
+							OOOLastMinTime: lastChunk.mint,
+							OOOLastMaxTime: lastChunk.maxt,
+							OOOLastRef:     lastRef,
 						}
 
-						// 3) Ref to whatever Ref the chunk has, that we refer to by ID
-						for ref, c := range intervals {
-							if c.ID == e.ID {
-								meta.Ref = chunks.ChunkRef(chunks.NewHeadChunkRef(1, chunks.HeadChunkID(ref)))
-								break
-							}
-						}
+						_, meta.Ref = GetChunkInterval(intervals, e.ID)
+
 						expChunks = append(expChunks, meta)
 					}
 


### PR DESCRIPTION
We thought about a few more cases that we think the Series() method
should be able to support. https://github.com/grafana/mimir-prometheus/pull/163#issuecomment-1088588894

This particular commit brings one where 4 chunks overlap in pairs in
decreasing order (the first case mentioned in the comment above)

I think we need to review the assumption we made about leaving the head chunk
max time set to maxint again because if the head chunk contains the oldest
samples in the interval then our algorithm fails.

In this commit I'm setting the maxtime to the headchunk's existing maxtime
instead.