### PR TITLE
Covering more scenarios in out of order chunkreader

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -432,11 +432,6 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 
 	oc := &mergedOOOChunks{}
 	for _, c := range tmpChks {
-		// TODO(Jesus.vazquez) Note that chunks are sorted by mintime but the head could get an old enough sample and this condition would make us discard overlapping chunks
-		// if c.Ref < meta.Ref {
-		// 	continue
-		// }
-
 		if c.Ref == meta.Ref || len(oc.chunks) > 0 && c.MinTime <= oc.chunks[len(oc.chunks)-1].MaxTime {
 
 			if c.Ref == oooHeadRef {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -410,7 +410,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
 			// Query Interval          [------------------------------------------------------------------------------------------]
 			// Chunk 0: Current Head                              [--------] (With 2 samples)
-			// Expected Output
 			// Output Graphically                                 [--------] (With 2 samples)
 			expChunksSamples: []tsdbutil.SampleSlice{
 				{
@@ -442,7 +441,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			// Query Interval          [------------------------------------------------------------------------------------------]
 			// Chunk 0                                                     [---] (With 5 samples)
 			// Chunk 1: Current Head                              [-----------------] (With 2 samples)
-			// Expected Output  [Chunk 1] With 7 samples
 			// Output Graphically                                 [-----------------] (With 7 samples)
 			expChunksSamples: []tsdbutil.SampleSlice{
 				{
@@ -492,7 +490,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			// Chunk 1                                   [-------]
 			// Chunk 2                                            [--------]
 			// Chunk 3: Current Head                                       [--------]
-			// Expected Output  [Chunk 0] (With samples between minute 10 and minute 29) and [Chunk 3] (With samples between minute 30 and minute 50)
 			// Output Graphically               [----------------][-----------------]
 			expChunksSamples: []tsdbutil.SampleSlice{
 				{
@@ -552,7 +549,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			// Chunk 1                                   [-------]
 			// Chunk 2                                            [-------]
 			// Chunk 3: Current Head                                       [-------]
-			// Expected Output  All chunks separated since they dont overlap
 			// Output Graphically               [-------][-------][-------][--------]
 			expChunksSamples: []tsdbutil.SampleSlice{
 				{

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -684,7 +684,7 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 		{
 			name:                 "Query interval partially overlaps with a triplet of chunks but still returns a single merged chunk",
 			queryMinT:            minutes(12),
-			queryMaxT:            minutes(48),
+			queryMaxT:            minutes(33),
 			firstInOrderSampleAt: minutes(120),
 			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
@@ -706,7 +706,7 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			},
 			expChunkError: false,
 			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
-			// Query Interval                     [------------------------------]
+			// Query Interval                     [------------------]
 			// Chunk 0                          [-----------------]
 			// Chunk 1                                   [--------------------]
 			// Chunk 2 Current Head                                  [--------------]

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -637,6 +637,50 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                 "Triplet of chunks overlapping returns a single merged chunk",
+			queryMinT:            minutes(0),
+			queryMaxT:            minutes(100),
+			firstInOrderSampleAt: minutes(120),
+			dbOpts:               opts,
+			inputSamples: tsdbutil.SampleSlice{
+				// Chunk 0
+				sample{t: minutes(10), v: float64(0)},
+				sample{t: minutes(15), v: float64(0)},
+				sample{t: minutes(20), v: float64(0)},
+				sample{t: minutes(25), v: float64(0)},
+				sample{t: minutes(30), v: float64(0)},
+				// Chunk 1
+				sample{t: minutes(20), v: float64(1)},
+				sample{t: minutes(25), v: float64(1)},
+				sample{t: minutes(30), v: float64(1)},
+				sample{t: minutes(35), v: float64(1)},
+				sample{t: minutes(42), v: float64(1)},
+				// Chunk 2 Head
+				sample{t: minutes(32), v: float64(2)},
+				sample{t: minutes(50), v: float64(2)},
+			},
+			expChunkError: false,
+			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
+			// Query Interval          [------------------------------------------------------------------------------------------]
+			// Chunk 0                          [-----------------]
+			// Chunk 1                                   [--------------------]
+			// Chunk 2 Current Head                                  [--------------]
+			// Output Graphically               [-----------------------------------]
+			expChunksSamples: []tsdbutil.SampleSlice{
+				{
+					sample{t: minutes(10), v: float64(0)},
+					sample{t: minutes(15), v: float64(0)},
+					sample{t: minutes(20), v: float64(1)},
+					sample{t: minutes(25), v: float64(1)},
+					sample{t: minutes(30), v: float64(1)},
+					sample{t: minutes(32), v: float64(2)},
+					sample{t: minutes(35), v: float64(1)},
+					sample{t: minutes(42), v: float64(1)},
+					sample{t: minutes(50), v: float64(2)},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Following with the comment https://github.com/grafana/mimir-prometheus/issues/147#issuecomment-1098018961 and the fantastic work done by @Dieterbe  in https://github.com/grafana/mimir-prometheus/pull/190, this PR aims at bringing a few more unit tests to the out of order chunkreader implementation.

I'm thinking we could have this PR to bring tests for cases 1 to 4 (See https://github.com/grafana/mimir-prometheus/issues/147#issuecomment-1098018961 for more context). And then open a new one for cases 5 and 6 which are probably going to require some changes.

Also, note that the tests for Series() and Chunk() are slightly different since Chunk() requires actually appending samples to then make sure that the returned merged chunk does have the expected content.