### PR TITLE
OOOChunkReader returns consistent queries after head keeps expanding

### DIFF
--- a/tsdb/chunkenc/ooo.go
+++ b/tsdb/chunkenc/ooo.go
@@ -4,49 +4,49 @@ import (
 	"sort"
 )
 
-type sample struct {
-	t int64
-	v float64
+type Sample struct {
+	T int64
+	V float64
 }
 
-// OOOChunk maintains samples in time-ascending order.
+// OOOChunk maintains Samples in time-ascending order.
 // Inserts for timestamps already seen, are dropped.
 // Samples are stored uncompressed to allow easy sorting.
 // Perhaps we can be more efficient later.
 type OOOChunk struct {
-	samples []sample
+	Samples []Sample
 }
 
 func NewOOOChunk(capacity int) *OOOChunk {
-	return &OOOChunk{samples: make([]sample, 0, capacity)}
+	return &OOOChunk{Samples: make([]Sample, 0, capacity)}
 }
 
-// Insert inserts the sample such that order is maintained.
+// Insert inserts the Sample such that order is maintained.
 // Returns false if insert was not possible due to the same timestamp already existing.
 func (o *OOOChunk) Insert(t int64, v float64) bool {
-	// find index of sample we should replace
-	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
+	// find index of Sample we should replace
+	i := sort.Search(len(o.Samples), func(i int) bool { return o.Samples[i].T >= t })
 
-	if i >= len(o.samples) {
+	if i >= len(o.Samples) {
 		// none found. append it at the end
-		o.samples = append(o.samples, sample{t, v})
+		o.Samples = append(o.Samples, Sample{t, v})
 		return true
 	}
 
-	if o.samples[i].t == t {
+	if o.Samples[i].T == t {
 		return false
 	}
 
-	// expand length by 1 to make room. use a zero sample, we will overwrite it anyway
-	o.samples = append(o.samples, sample{})
-	copy(o.samples[i+1:], o.samples[i:])
-	o.samples[i] = sample{t, v}
+	// expand length by 1 to make room. use a zero Sample, we will overwrite it anyway
+	o.Samples = append(o.Samples, Sample{})
+	copy(o.Samples[i+1:], o.Samples[i:])
+	o.Samples[i] = Sample{t, v}
 
 	return true
 }
 
 func (o *OOOChunk) NumSamples() int {
-	return len(o.samples)
+	return len(o.Samples)
 }
 
 func (o *OOOChunk) ToXor() (*XORChunk, error) {
@@ -55,8 +55,8 @@ func (o *OOOChunk) ToXor() (*XORChunk, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, s := range o.samples {
-		app.Append(s.t, s.v)
+	for _, s := range o.Samples {
+		app.Append(s.T, s.V)
 	}
 	return x, nil
 }
@@ -67,7 +67,7 @@ func (o *OOOChunk) ToXor() (*XORChunk, error) {
 // func (c *OOOChunk) NumSamples() int {
 // func (c *OOOChunk) Compact() {
 
-// func (it *oooIterator) Seek(t int64) bool {
+// func (it *oooIterator) Seek(T int64) bool {
 // func (it *oooIterator) At() (int64, float64) {
 // func (it *oooIterator) Err() error {
 // func (it *oooIterator) Next() bool {

--- a/tsdb/chunkenc/ooo.go
+++ b/tsdb/chunkenc/ooo.go
@@ -9,7 +9,7 @@ type sample struct {
 	v float64
 }
 
-// OOOChunk maintains Samples in time-ascending order.
+// OOOChunk maintains samples in time-ascending order.
 // Inserts for timestamps already seen, are dropped.
 // Samples are stored uncompressed to allow easy sorting.
 // Perhaps we can be more efficient later.

--- a/tsdb/chunkenc/ooo_test.go
+++ b/tsdb/chunkenc/ooo_test.go
@@ -12,72 +12,72 @@ const testMaxSize int = 32
 func valPre(pos int) int { return pos*2 + 2 } // s[0]=2, s[1]=4, s[2]=6, ..., s[31]=64 // predictable pre-existing values
 func valNew(pos int) int { return pos*2 + 1 } // s[0]=1, s[1]=3, s[2]=5, ..., s[31]=63 // new values will interject at chosen position because they sort before the pre-existing vals
 
-func samplify(v int) Sample { return Sample{int64(v), float64(v)} }
+func samplify(v int) sample { return sample{int64(v), float64(v)} }
 
-func makePre(n int) []Sample {
-	s := make([]Sample, n)
+func makePre(n int) []sample {
+	s := make([]sample, n)
 	for i := 0; i < n; i++ {
 		s[i] = samplify(valPre(i))
 	}
 	return s
 }
 
-// TesttoooInsert tests the following cases:
-// number of pre-existing Samples anywhere from 0 to testMaxSize-1
-// insert new Sample before first pre-existing Samples, after the last, and anywhere in between
+// testtoooInsert tests the following cases:
+// number of pre-existing samples anywhere from 0 to testMaxSize-1
+// insert new sample before first pre-existing samples, after the last, and anywhere in between
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
-// Note: in all Samples used, T always equals V in numeric value. when we talk about 'value' we just refer to a value that will be used for both Sample.T and Sample.V
+// Note: in all samples used, t always equals v in numeric value. when we talk about 'value' we just refer to a value that will be used for both sample.t and sample.v
 func TestOOOInsert(t *testing.T) {
 	for numPre := 0; numPre <= testMaxSize; numPre++ {
 		// for example, if we have numPre 2, then:
-		// chunk.Samples indexes filled        0   1
-		// chunk.Samples with these values     2   4     // valPre
+		// chunk.samples indexes filled        0   1
+		// chunk.samples with these values     2   4     // valPre
 		// we want to test inserting at index  0   1   2 // insertPos=0..numPre
 		// we can do this by using values      1,  3   5 // valNew(insertPos)
 
 		for insertPos := 0; insertPos <= numPre; insertPos++ {
 			for capacity := range []int{testMaxSize / 8, testMaxSize} {
 				chunk := NewOOOChunk(capacity)
-				chunk.Samples = makePre(numPre)
+				chunk.samples = makePre(numPre)
 				newSample := samplify(valNew(insertPos))
-				chunk.Insert(newSample.T, newSample.V)
+				chunk.Insert(newSample.t, newSample.v)
 
-				var expSamples []Sample
-				// our expected new Samples slice, will be first the original Samples...
+				var expsamples []sample
+				// our expected new samples slice, will be first the original samples...
 				for i := 0; i < insertPos; i++ {
-					expSamples = append(expSamples, samplify(valPre(i)))
+					expsamples = append(expsamples, samplify(valPre(i)))
 				}
-				// ... then the new Sample ...
-				expSamples = append(expSamples, newSample)
-				// ... followed by any original Samples that were pushed back by the new one
+				// ... then the new sample ...
+				expsamples = append(expsamples, newSample)
+				// ... followed by any original samples that were pushed back by the new one
 				for i := insertPos; i < numPre; i++ {
-					expSamples = append(expSamples, samplify(valPre(i)))
+					expsamples = append(expsamples, samplify(valPre(i)))
 				}
 
-				require.Equal(t, expSamples, chunk.Samples, "numPre %d, insertPos %d", numPre, insertPos)
+				require.Equal(t, expsamples, chunk.samples, "numPre %d, insertPos %d", numPre, insertPos)
 			}
 		}
 	}
 }
 
-// TesttoooInsertDuplicate tests the correct behavior when inserting a Sample that is a duplicate of any
-// pre-existing Samples, with between 1 and testMaxSize pre-existing Samples and
+// testtoooInsertDuplicate tests the correct behavior when inserting a sample that is a duplicate of any
+// pre-existing samples, with between 1 and testMaxSize pre-existing samples and
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
 func TestOOOInsertDuplicate(t *testing.T) {
 	for numPre := 1; numPre <= testMaxSize; numPre++ {
 		for dupPos := 0; dupPos < numPre; dupPos++ {
 			for capacity := range []int{testMaxSize / 8, testMaxSize} {
 				chunk := NewOOOChunk(capacity)
-				chunk.Samples = makePre(numPre)
+				chunk.samples = makePre(numPre)
 
-				dupSample := chunk.Samples[dupPos]
-				dupSample.V = 0.123 // unmistakeably different from any of the pre-existing values, so we can properly detect the correct value below
+				dupSample := chunk.samples[dupPos]
+				dupSample.v = 0.123 // unmistakeably different from any of the pre-existing values, so we can properly detect the correct value below
 
-				ok := chunk.Insert(dupSample.T, dupSample.V)
+				ok := chunk.Insert(dupSample.t, dupSample.v)
 
-				expSamples := makePre(numPre) // we expect no change
+				expsamples := makePre(numPre) // we expect no change
 				require.False(t, ok)
-				require.Equal(t, expSamples, chunk.Samples, "numPre %d, dupPos %d", numPre, dupPos)
+				require.Equal(t, expsamples, chunk.samples, "numPre %d, dupPos %d", numPre, dupPos)
 			}
 		}
 	}

--- a/tsdb/chunkenc/ooo_test.go
+++ b/tsdb/chunkenc/ooo_test.go
@@ -12,10 +12,10 @@ const testMaxSize int = 32
 func valPre(pos int) int { return pos*2 + 2 } // s[0]=2, s[1]=4, s[2]=6, ..., s[31]=64 // predictable pre-existing values
 func valNew(pos int) int { return pos*2 + 1 } // s[0]=1, s[1]=3, s[2]=5, ..., s[31]=63 // new values will interject at chosen position because they sort before the pre-existing vals
 
-func samplify(v int) sample { return sample{int64(v), float64(v)} }
+func samplify(v int) Sample { return Sample{int64(v), float64(v)} }
 
-func makePre(n int) []sample {
-	s := make([]sample, n)
+func makePre(n int) []Sample {
+	s := make([]Sample, n)
 	for i := 0; i < n; i++ {
 		s[i] = samplify(valPre(i))
 	}
@@ -23,61 +23,61 @@ func makePre(n int) []sample {
 }
 
 // TesttoooInsert tests the following cases:
-// number of pre-existing samples anywhere from 0 to testMaxSize-1
-// insert new sample before first pre-existing samples, after the last, and anywhere in between
+// number of pre-existing Samples anywhere from 0 to testMaxSize-1
+// insert new Sample before first pre-existing Samples, after the last, and anywhere in between
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
-// Note: in all samples used, t always equals v in numeric value. when we talk about 'value' we just refer to a value that will be used for both sample.t and sample.v
+// Note: in all Samples used, T always equals V in numeric value. when we talk about 'value' we just refer to a value that will be used for both Sample.T and Sample.V
 func TestOOOInsert(t *testing.T) {
 	for numPre := 0; numPre <= testMaxSize; numPre++ {
 		// for example, if we have numPre 2, then:
-		// chunk.samples indexes filled        0   1
-		// chunk.samples with these values     2   4     // valPre
+		// chunk.Samples indexes filled        0   1
+		// chunk.Samples with these values     2   4     // valPre
 		// we want to test inserting at index  0   1   2 // insertPos=0..numPre
 		// we can do this by using values      1,  3   5 // valNew(insertPos)
 
 		for insertPos := 0; insertPos <= numPre; insertPos++ {
 			for capacity := range []int{testMaxSize / 8, testMaxSize} {
 				chunk := NewOOOChunk(capacity)
-				chunk.samples = makePre(numPre)
+				chunk.Samples = makePre(numPre)
 				newSample := samplify(valNew(insertPos))
-				chunk.Insert(newSample.t, newSample.v)
+				chunk.Insert(newSample.T, newSample.V)
 
-				var expSamples []sample
-				// our expected new samples slice, will be first the original samples...
+				var expSamples []Sample
+				// our expected new Samples slice, will be first the original Samples...
 				for i := 0; i < insertPos; i++ {
 					expSamples = append(expSamples, samplify(valPre(i)))
 				}
-				// ... then the new sample ...
+				// ... then the new Sample ...
 				expSamples = append(expSamples, newSample)
-				// ... followed by any original samples that were pushed back by the new one
+				// ... followed by any original Samples that were pushed back by the new one
 				for i := insertPos; i < numPre; i++ {
 					expSamples = append(expSamples, samplify(valPre(i)))
 				}
 
-				require.Equal(t, expSamples, chunk.samples, "numPre %d, insertPos %d", numPre, insertPos)
+				require.Equal(t, expSamples, chunk.Samples, "numPre %d, insertPos %d", numPre, insertPos)
 			}
 		}
 	}
 }
 
-// TesttoooInsertDuplicate tests the correct behavior when inserting a sample that is a duplicate of any
-// pre-existing samples, with between 1 and testMaxSize pre-existing samples and
+// TesttoooInsertDuplicate tests the correct behavior when inserting a Sample that is a duplicate of any
+// pre-existing Samples, with between 1 and testMaxSize pre-existing Samples and
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
 func TestOOOInsertDuplicate(t *testing.T) {
 	for numPre := 1; numPre <= testMaxSize; numPre++ {
 		for dupPos := 0; dupPos < numPre; dupPos++ {
 			for capacity := range []int{testMaxSize / 8, testMaxSize} {
 				chunk := NewOOOChunk(capacity)
-				chunk.samples = makePre(numPre)
+				chunk.Samples = makePre(numPre)
 
-				dupSample := chunk.samples[dupPos]
-				dupSample.v = 0.123 // unmistakeably different from any of the pre-existing values, so we can properly detect the correct value below
+				dupSample := chunk.Samples[dupPos]
+				dupSample.V = 0.123 // unmistakeably different from any of the pre-existing values, so we can properly detect the correct value below
 
-				ok := chunk.Insert(dupSample.t, dupSample.v)
+				ok := chunk.Insert(dupSample.T, dupSample.V)
 
 				expSamples := makePre(numPre) // we expect no change
 				require.False(t, ok)
-				require.Equal(t, expSamples, chunk.samples, "numPre %d, dupPos %d", numPre, dupPos)
+				require.Equal(t, expSamples, chunk.Samples, "numPre %d, dupPos %d", numPre, dupPos)
 			}
 		}
 	}

--- a/tsdb/chunkenc/ooo_test.go
+++ b/tsdb/chunkenc/ooo_test.go
@@ -22,7 +22,7 @@ func makePre(n int) []sample {
 	return s
 }
 
-// testtoooInsert tests the following cases:
+// TestOOOInsert tests the following cases:
 // number of pre-existing samples anywhere from 0 to testMaxSize-1
 // insert new sample before first pre-existing samples, after the last, and anywhere in between
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
@@ -42,25 +42,25 @@ func TestOOOInsert(t *testing.T) {
 				newSample := samplify(valNew(insertPos))
 				chunk.Insert(newSample.t, newSample.v)
 
-				var expsamples []sample
+				var expSamples []sample
 				// our expected new samples slice, will be first the original samples...
 				for i := 0; i < insertPos; i++ {
-					expsamples = append(expsamples, samplify(valPre(i)))
+					expSamples = append(expSamples, samplify(valPre(i)))
 				}
 				// ... then the new sample ...
-				expsamples = append(expsamples, newSample)
+				expSamples = append(expSamples, newSample)
 				// ... followed by any original samples that were pushed back by the new one
 				for i := insertPos; i < numPre; i++ {
-					expsamples = append(expsamples, samplify(valPre(i)))
+					expSamples = append(expSamples, samplify(valPre(i)))
 				}
 
-				require.Equal(t, expsamples, chunk.samples, "numPre %d, insertPos %d", numPre, insertPos)
+				require.Equal(t, expSamples, chunk.samples, "numPre %d, insertPos %d", numPre, insertPos)
 			}
 		}
 	}
 }
 
-// testtoooInsertDuplicate tests the correct behavior when inserting a sample that is a duplicate of any
+// TestOOOInsertDuplicate tests the correct behavior when inserting a sample that is a duplicate of any
 // pre-existing samples, with between 1 and testMaxSize pre-existing samples and
 // with a chunk initial capacity of testMaxSize/8 and testMaxSize, which lets us test non-full and full chunks, and chunks that need to expand themselves.
 func TestOOOInsertDuplicate(t *testing.T) {
@@ -75,9 +75,9 @@ func TestOOOInsertDuplicate(t *testing.T) {
 
 				ok := chunk.Insert(dupSample.t, dupSample.v)
 
-				expsamples := makePre(numPre) // we expect no change
+				expSamples := makePre(numPre) // we expect no change
 				require.False(t, ok)
-				require.Equal(t, expsamples, chunk.samples, "numPre %d, dupPos %d", numPre, dupPos)
+				require.Equal(t, expSamples, chunk.samples, "numPre %d, dupPos %d", numPre, dupPos)
 			}
 		}
 	}

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -125,7 +125,7 @@ type Meta struct {
 
 	// OOOLastRef, OOOLastMinTime and OOOLastMaxTime are kept as markers for
 	// overlapping chunks.
-	// These fields point to the last created out of order Chunk that existed
+	// These fields point to the last created out of order Chunk (the head) that existed
 	// when Series() was called and was overlapping.
 	// Series() and Chunk() method responses should be consistent for the same
 	// query even if new data is added in between the calls.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -459,7 +459,8 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 					}
 				} else {
 					// We need to remove samples that are outside of the markers
-					oooChunk := chunkenc.NewOOOChunk(s.oooHeadChunk.chunk.NumSamples())
+					xor = chunkenc.NewXORChunk()
+					a, _ := xor.Appender()
 					for _, sample := range s.oooHeadChunk.chunk.Samples {
 						if sample.T < meta.OOOLastMinTime {
 							continue
@@ -467,11 +468,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 						if sample.T > meta.OOOLastMaxTime {
 							break
 						}
-						oooChunk.Insert(sample.T, sample.V)
-					}
-					xor, err = oooChunk.ToXor()
-					if err != nil {
-						return nil, errors.Wrap(err, "failed to convert oooChunk to xor chunk")
+						a.Append(sample.T, sample.V)
 					}
 				}
 				c.meta.Chunk = xor

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -1,0 +1,104 @@
+package tsdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+func TestBoundedChunk_Bytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputChunk chunkenc.Chunk
+		inputMinT  int64
+		inputMaxT  int64
+		expBytes   []byte
+	}{
+		{
+			name:       "if there are no samples only expect first two bytes",
+			inputChunk: newTestChunk(0),
+			expBytes:   []byte{0x0, 0x0},
+		},
+		{
+			name:       "if there are no bounds only first sample is returned",
+			inputChunk: newTestChunk(10),
+			expBytes:   []byte{0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		},
+		{
+			name:       "if there are bounds only bytes from samples included are returned",
+			inputChunk: newTestChunk(10),
+			inputMinT:  1,
+			inputMaxT:  8,
+			expBytes:   []byte{0x0, 0x8, 0x2, 0x3f, 0xf0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0xc2, 0x5f, 0xff, 0x6c, 0x6, 0xd6, 0x16, 0xda, 0xd, 0xb0, 0x2d, 0x2d, 0x42, 0x78},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
+			chunk := boundedChunk{tc.inputChunk, tc.inputMinT, tc.inputMaxT}
+			require.Equal(t, tc.expBytes, chunk.Bytes())
+		})
+	}
+}
+
+func TestBoundedChunk_Iterator(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputChunk chunkenc.Chunk
+		inputMinT  int64
+		inputMaxT  int64
+		expSamples []sample
+	}{
+		{
+			name:       "if there are no samples it returns nothing",
+			inputChunk: newTestChunk(0),
+			expSamples: nil,
+		},
+		{
+			name:       "if there are no bounds set only sample at ts 0 is returned",
+			inputChunk: newTestChunk(1),
+			expSamples: []sample{
+				{0, 0},
+			},
+		},
+		{
+			name:       "if there are bounds set only samples within them are returned",
+			inputChunk: newTestChunk(10),
+			inputMinT:  1,
+			inputMaxT:  8,
+			expSamples: []sample{
+				{1, 1},
+				{2, 2},
+				{3, 3},
+				{4, 4},
+				{5, 5},
+				{6, 6},
+				{7, 7},
+				{8, 8},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
+			chunk := boundedChunk{tc.inputChunk, tc.inputMinT, tc.inputMaxT}
+			it := chunk.Iterator(nil)
+			var samples []sample
+			for it.Next() {
+				t, v := it.At()
+				samples = append(samples, sample{t, v})
+			}
+			require.Equal(t, tc.expSamples, samples)
+		})
+	}
+}
+
+func newTestChunk(numSamples int) chunkenc.Chunk {
+	xor := chunkenc.NewXORChunk()
+	a, _ := xor.Appender()
+	for i := 0; i < numSamples; i++ {
+		a.Append(int64(i), float64(i))
+	}
+	return xor
+}

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -126,11 +126,12 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, lbls *labels.Labels,
 }
 
 type chunkMetaAndChunkDiskMapperRef struct {
-	meta chunks.Meta
-	ref  chunks.ChunkDiskMapperRef
+	meta     chunks.Meta
+	ref      chunks.ChunkDiskMapperRef
+	origMinT int64
+	origMaxT int64
 }
 
-// TODO See if we can reuse the sort implementation below
 type byMinTimeAndMinRef []chunkMetaAndChunkDiskMapperRef
 
 func (b byMinTimeAndMinRef) Len() int { return len(b) }

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -391,7 +391,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 		queryMinT            int64
 		queryMaxT            int64
 		firstInOrderSampleAt int64
-		dbOpts               *Options
 		inputSamples         tsdbutil.SampleSlice
 		expChunkError        bool
 		expChunksSamples     []tsdbutil.SampleSlice
@@ -401,7 +400,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				sample{t: minutes(30), v: float64(0)},
 				sample{t: minutes(40), v: float64(0)},
@@ -423,7 +421,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// opts.OOOCapMax is 5 so these will be mmapped to the first mmapped chunk
 				sample{t: minutes(41), v: float64(0)},
@@ -459,7 +456,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(10), v: float64(0)},
@@ -518,7 +514,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(40), v: float64(0)},
@@ -577,7 +572,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(10), v: float64(0)},
@@ -642,7 +636,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(10), v: float64(0)},
@@ -686,7 +679,6 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			queryMinT:            minutes(12),
 			queryMaxT:            minutes(33),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			inputSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(10), v: float64(0)},
@@ -729,7 +721,7 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
-			db := newTestDBWithOpts(t, tc.dbOpts)
+			db := newTestDBWithOpts(t, opts)
 
 			app := db.Appender(context.Background())
 			s1Ref := appendSample(app, s1, tc.firstInOrderSampleAt, float64(tc.firstInOrderSampleAt/1*time.Minute.Milliseconds()))
@@ -796,7 +788,6 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 		queryMinT              int64
 		queryMaxT              int64
 		firstInOrderSampleAt   int64
-		dbOpts                 *Options
 		initialSamples         tsdbutil.SampleSlice
 		samplesAfterSeriesCall tsdbutil.SampleSlice
 		expChunkError          bool
@@ -807,7 +798,6 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			initialSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(20), v: float64(0)},
@@ -826,7 +816,7 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			},
 			expChunkError: false,
 			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
-			// Query Interval                       [----------------------]
+			// Query Interval          [-----------------------------------]
 			// Chunk 0:                                  [--------] (5 samples)
 			// Chunk 1: Current Head                          [-------] (2 samples)
 			// New samples added after Series()
@@ -850,7 +840,6 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			queryMinT:            minutes(0),
 			queryMaxT:            minutes(100),
 			firstInOrderSampleAt: minutes(120),
-			dbOpts:               opts,
 			initialSamples: tsdbutil.SampleSlice{
 				// Chunk 0
 				sample{t: minutes(20), v: float64(0)},
@@ -872,7 +861,7 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			},
 			expChunkError: false,
 			// ts (in minutes)         0       10       20       30       40       50       60       70       80       90       100
-			// Query Interval                       [----------------------]
+			// Query Interval          [-----------------------------------]
 			// Chunk 0:                                  [--------] (5 samples)
 			// Chunk 1: Current Head                          [-------] (2 samples)
 			// New samples added after Series()
@@ -896,7 +885,7 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("name=%s", tc.name), func(t *testing.T) {
-			db := newTestDBWithOpts(t, tc.dbOpts)
+			db := newTestDBWithOpts(t, opts)
 
 			app := db.Appender(context.Background())
 			s1Ref := appendSample(app, s1, tc.firstInOrderSampleAt, float64(tc.firstInOrderSampleAt/1*time.Minute.Milliseconds()))

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -935,8 +935,6 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 				it := c.Iterator(nil)
 				for it.Next() {
 					ts, v := it.At()
-					// t.Logf("Equivalence %d=%d", ts, ts/time.Minute.Milliseconds())
-					t.Logf("Got %d:%f", ts/time.Minute.Milliseconds(), v)
 					resultSamples = append(resultSamples, sample{t: ts, v: v})
 				}
 				require.Equal(t, tc.expChunksSamples[i], resultSamples)


### PR DESCRIPTION
Alright! This PR brings query consistency in the case that the head keeps receiving samples in between Series() and Chunk() calls.

This came up from the scenarios @codesome thought about in https://github.com/grafana/mimir-prometheus/issues/147#issuecomment-1098018961 In particular case 5 and case 6.

<details>
<summary>Case 5 and 6 detailed:</summary>

Here starts the more interesting bit: ingesting more samples to the Head _after_ calling Series()

5) Current head gets an old sample and new sample after the Series() call

During Series()
```
Query Interval                                 [-----------------]

Chunk 0                                             [--------]

Chunk 1: Current Head                                      [--------]
```
Hence Series() would return chunk(0) based on mint.

Now after Series() call, Head gets an old sample, a newer sample, *and also a sample that is within the old chunk range* and it becomes like

```
Query Interval                                 [-----------------]

Chunk 0                                             [--------]

Chunk 1: Current Head                       [----------------------------------]
```

So in the result, we should still get the samples from both chunks. _But_, for chunk(1), it must not include samples beyond the lastmint and lastmaxt as seen during Series() call since it could overlap with other chunks. But it includes the new samples that came in later but is within the [lastmint, lastmaxt]. I think this bit is not taken care yet.
Another thing that it tests is that, because we will request chunk(0) here, it should still get a merged chunk, which tests if we are taking care of sorting them based on the last ooo chunk's mint as seen during Series() call.

---
6) A little more interesting one. Here, after Series() call, we not only get an old and new sample like above case, but we also end up m-mapping that chunk and create a new head chunk that overlaps with chunk(0).

During Series()
```
Query Interval                                 [-----------------]

Chunk 0                                             [--------]

Chunk 1: Current Head                                      [--------]
```
Hence Series() would return chunk(0) based on mint.

Now after Series() call, Head gets an old sample, a new sample, also a sample that is within the old chunk range, and many more samples such that chunk(1) is mmapped and chunk(2) is born as shown that overlaps with chunk(0)

```
Query Interval                                 [-----------------]

Chunk 0                                             [--------]

Chunk 1:                                    [----------------------------------]

Chunk 2: Current Head                             [--------------]
```

So the result of this should be similar to the above case and only include chunk(0) and chunk(1) and no samples outside lastmint and lastmaxt from chunk(1) but include the new samples in chunk(1) within the range (here it tests the last chunk being a m-mapped chunk, unlike the head chunk above) and _must not_ include chunk(2) since it was after the last ooo chunk.
</details>

## What this PR does

This PR makes a few changes to the logic in ChunkReader and
oooMergedChunk.

1. If the memory mapped chunk we're iterating was the previous head, it
   will be appended with the OOOLastMinT and OOOLastMaxT markers.
2. When chunks are loaded from disk, if they are the previously known
   head, the chunk will be loaded and then wrapped into a boundedChunk
   so that when its iterated, only samples within the OOOLastMinT and
   OOOLastMaxT markers are returned.
3. Two new structs:
  - boundedChunk wraps a chunk and overrides Bytes() and Iterator()
  - boundedIterator wraps an Iterator and overrides the methods to
    return only truthful answers for samples within bounds.
4. Unit test cases for scenarios 5 and 6