### PR TITLE
Add compaction for out of order samples in the Head

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -563,7 +563,7 @@ func (db *DB) truncate(mint int64) error {
 
 	// Start a new segment so low ingestion volume instances don't have more WAL
 	// than needed.
-	err = db.wal.NextSegment()
+	_, err = db.wal.NextSegment()
 	if err != nil {
 		return errors.Wrap(err, "next segment")
 	}

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -93,6 +93,12 @@ func (ref ChunkDiskMapperRef) GreaterThanOrEqualTo(r ChunkDiskMapperRef) bool {
 	return s1 > s2 || (s1 == s2 && o1 >= o2)
 }
 
+func (ref ChunkDiskMapperRef) GreaterThan(r ChunkDiskMapperRef) bool {
+	s1, o1 := ref.Unpack()
+	s2, o2 := r.Unpack()
+	return s1 > s2 || (s1 == s2 && o1 > o2)
+}
+
 // CorruptionErr is an error that's returned when corruption is encountered.
 type CorruptionErr struct {
 	Dir       string

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -87,6 +87,12 @@ func (ref ChunkDiskMapperRef) Unpack() (seq, offset int) {
 	return seq, offset
 }
 
+func (ref ChunkDiskMapperRef) GreaterThanOrEqualTo(r ChunkDiskMapperRef) bool {
+	s1, o1 := ref.Unpack()
+	s2, o2 := r.Unpack()
+	return s1 > s2 || (s1 == s2 && o1 >= o2)
+}
+
 // CorruptionErr is an error that's returned when corruption is encountered.
 type CorruptionErr struct {
 	Dir       string

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -547,8 +547,9 @@ func (c *LeveledCompactor) compact(dest string, dirs []string, open []*Block, sh
 
 // CompactOOOWithSplitting splits the input OOO Head into shardCount number of output blocks
 // per possible block range, and returns slice of block IDs. In result[i][j],
-// 'j' corresponds to the shard index while 'i' corresponds to a single time range of blocks.
+// 'i' corresponds to a single time range of blocks while 'j' corresponds to the shard index.
 // If given output block has no series, corresponding block ID will be zero ULID value.
+// TODO: write tests for this.
 func (c *LeveledCompactor) CompactOOOWithSplitting(dest string, oooHead *OOOCompactionHead, shardCount uint64) (result [][]ulid.ULID, _ error) {
 	return c.compactOOO(dest, oooHead, shardCount)
 }

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -992,6 +992,11 @@ func (db *DB) Compact() (returnErr error) {
 			"block_range", db.head.chunkRange.Load(),
 		)
 	}
+
+	if err := db.compactOOOHead(); err != nil {
+		return errors.Wrap(err, "compact ooo head")
+	}
+
 	return db.compactBlocks()
 }
 
@@ -1007,6 +1012,36 @@ func (db *DB) CompactHead(head *RangeHead) error {
 	if err := db.head.truncateWAL(head.BlockMaxTime()); err != nil {
 		return errors.Wrap(err, "WAL truncation")
 	}
+	return nil
+}
+
+func (db *DB) compactOOOHead() error {
+	oooHead, err := NewOOOCompactionHead(db.head)
+	if err != nil {
+		return errors.Wrap(err, "get ooo compaction head")
+	}
+
+	ulids, err := db.compactor.CompactOOO(db.dir, oooHead)
+	if err != nil {
+		return errors.Wrap(err, "compact ooo head")
+	}
+	if err := db.reloadBlocks(); err != nil {
+		errs := tsdb_errors.NewMulti(err)
+		for _, uid := range ulids {
+			if errRemoveAll := os.RemoveAll(filepath.Join(db.dir, uid.String())); errRemoveAll != nil {
+				errs.Add(errRemoveAll)
+			}
+		}
+		return errors.Wrap(errs.Err(), "reloadBlocks blocks after failed compact ooo head")
+	}
+
+	lastWBLFile, minOOOMmapRef := oooHead.LastWBLFile(), oooHead.LastMmapRef()
+	if lastWBLFile != 0 || minOOOMmapRef != 0 {
+		if err := db.head.truncateOOO(lastWBLFile, minOOOMmapRef); err != nil {
+			return errors.Wrap(err, "truncate ooo wbl")
+		}
+	}
+
 	return nil
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -993,8 +993,11 @@ func (db *DB) Compact() (returnErr error) {
 		)
 	}
 
-	if err := db.compactOOOHead(); err != nil {
-		return errors.Wrap(err, "compact ooo head")
+	if lastBlockMaxt != math.MinInt64 {
+		// The head was compacted, so we compact OOO head as well.
+		if err := db.compactOOOHead(); err != nil {
+			return errors.Wrap(err, "compact ooo head")
+		}
 	}
 
 	return db.compactBlocks()
@@ -1013,6 +1016,14 @@ func (db *DB) CompactHead(head *RangeHead) error {
 		return errors.Wrap(err, "WAL truncation")
 	}
 	return nil
+}
+
+// CompactOOOHead compacts the OOO Head.
+func (db *DB) CompactOOOHead() error {
+	db.cmtx.Lock()
+	defer db.cmtx.Unlock()
+
+	return db.compactOOOHead()
 }
 
 func (db *DB) compactOOOHead() error {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1391,6 +1391,9 @@ func (c *mockCompactorFailing) Write(dest string, b BlockReader, mint, maxt int6
 func (*mockCompactorFailing) Compact(string, []string, []*Block) (ulid.ULID, error) {
 	return ulid.ULID{}, nil
 }
+func (*mockCompactorFailing) CompactOOO(dest string, oooHead *OOOCompactionHead) (result []ulid.ULID, err error) {
+	return nil, nil
+}
 
 func TestTimeRetention(t *testing.T) {
 	db := openTestDB(t, nil, []int64{1000})
@@ -3121,7 +3124,8 @@ func TestOneCheckpointPerCompactCall(t *testing.T) {
 		_, err = app.Append(0, lbls, (blockRange*i)+blockRange/2, rand.Float64())
 		require.NoError(t, err)
 		// Rotate the WAL file so that there is >3 files for checkpoint to happen.
-		require.NoError(t, db.head.wal.NextSegment())
+		_, err = db.head.wal.NextSegment()
+		require.NoError(t, err)
 	}
 	require.NoError(t, app.Commit())
 
@@ -3691,4 +3695,138 @@ func TestOOOWALWrite(t *testing.T) {
 	// The OOO WAL.
 	actRecs = getRecords(path.Join(dir, wal.OOOWblDirName))
 	require.Equal(t, oooRecords, actRecs)
+}
+
+// TODO(codesome): Add more tests for the following cases
+// * More samples incoming once compaction has started. To verify new samples after the start
+//   are not included in this compaction.
+// * OOO compaction is done after the normal head's compaction in db.Compact().
+func TestOOOCompaction(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := DefaultOptions()
+	opts.OOOCapMin = 2
+	opts.OOOCapMax = 30
+	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.AllowOverlappingBlocks = true
+
+	db, err := Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+	db.DisableCompactions() // We want to manually call it.
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	series1 := labels.FromStrings("foo", "bar1")
+	series2 := labels.FromStrings("foo", "bar2")
+
+	addSample := func(fromMins, toMins int64) {
+		app := db.Appender(context.Background())
+		for min := fromMins; min <= toMins; min++ {
+			ts := min * time.Minute.Milliseconds()
+			_, err := app.Append(0, series1, ts, float64(ts))
+			require.NoError(t, err)
+			_, err = app.Append(0, series2, ts, float64(2*ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+	}
+
+	// Add an in-order samples.
+	addSample(250, 350)
+
+	// Verify that the in-memory ooo chunk is empty.
+	checkEmptyOOOChunk := func(lbls labels.Labels) {
+		ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Nil(t, ms.oooHeadChunk)
+		require.Equal(t, 0, len(ms.oooMmappedChunks))
+	}
+	checkEmptyOOOChunk(series1)
+	checkEmptyOOOChunk(series2)
+
+	// Add ooo samples that creates multiple chunks.
+	// 90 to 300 spans across 3 block ranges: [0, 120), [120, 240), [240, 360)
+	addSample(90, 310)
+	// Adding same samples to create overlapping chunks.
+	// Since the active chunk won't start at 90 again, all the new
+	// chunks will have different time ranges than the previous chunks.
+	addSample(90, 310)
+
+	// Verify that the in-memory ooo chunk is not empty.
+	checkNonEmptyOOOChunk := func(lbls labels.Labels) {
+		ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Greater(t, ms.oooHeadChunk.chunk.NumSamples(), 0)
+		require.Equal(t, 14, len(ms.oooMmappedChunks)) // 7 original, 7 duplicate.
+	}
+	checkNonEmptyOOOChunk(series1)
+	checkNonEmptyOOOChunk(series2)
+
+	// No blocks before compaction.
+	require.Equal(t, len(db.Blocks()), 0)
+
+	// There is a 0th WBL file.
+	files, err := ioutil.ReadDir(db.head.oooWbl.Dir())
+	require.Len(t, files, 1)
+	require.Equal(t, "00000000", files[0].Name())
+	require.Greater(t, files[0].Size(), int64(100))
+
+	// OOO compaction happens here.
+	require.NoError(t, db.CompactOOOHead())
+
+	// 3 blocks exist now. [0, 120), [120, 240), [240, 360)
+	require.Equal(t, len(db.Blocks()), 3)
+
+	// 0th WBL file will be deleted and 1st will be the only present.
+	files, err = ioutil.ReadDir(db.head.oooWbl.Dir())
+	require.Len(t, files, 1)
+	require.Equal(t, "00000001", files[0].Name())
+	require.Equal(t, int64(0), files[0].Size())
+
+	// OOO stuff should not be present in the Head now.
+	checkEmptyOOOChunk(series1)
+	checkEmptyOOOChunk(series2)
+
+	verifySamples := func(block *Block, fromMins, toMins int64) {
+		series1Samples := make([]tsdbutil.Sample, 0, toMins-fromMins+1)
+		series2Samples := make([]tsdbutil.Sample, 0, toMins-fromMins+1)
+		for min := fromMins; min <= toMins; min++ {
+			ts := min * time.Minute.Milliseconds()
+			series1Samples = append(series1Samples, sample{ts, float64(ts)})
+			series2Samples = append(series2Samples, sample{ts, float64(2 * ts)})
+		}
+		expRes := map[string][]tsdbutil.Sample{
+			series1.String(): series1Samples,
+			series2.String(): series2Samples,
+		}
+
+		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+
+		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
+		require.Equal(t, expRes, actRes)
+	}
+
+	// Checking for expected data in the blocks.
+	verifySamples(db.Blocks()[0], 90, 119)
+	verifySamples(db.Blocks()[1], 120, 239)
+	verifySamples(db.Blocks()[2], 240, 310)
+
+	// Compact the in-order head and expect another block.
+	// Since this is a forced compaction, this block is not aligned with 2h.
+	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	require.NoError(t, err)
+	require.Equal(t, len(db.Blocks()), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
+	verifySamples(db.Blocks()[3], 250, 350)
+
+	// This will merge overlapping block.
+	require.NoError(t, db.Compact())
+
+	require.Equal(t, len(db.Blocks()), 3) // [0, 120), [120, 240), [240, 360)
+	verifySamples(db.Blocks()[0], 90, 119)
+	verifySamples(db.Blocks()[1], 120, 239)
+	verifySamples(db.Blocks()[2], 240, 350) // Merged block.
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1391,6 +1391,7 @@ func (c *mockCompactorFailing) Write(dest string, b BlockReader, mint, maxt int6
 func (*mockCompactorFailing) Compact(string, []string, []*Block) (ulid.ULID, error) {
 	return ulid.ULID{}, nil
 }
+
 func (*mockCompactorFailing) CompactOOO(dest string, oooHead *OOOCompactionHead) (result []ulid.ULID, err error) {
 	return nil, nil
 }
@@ -3770,6 +3771,7 @@ func TestOOOCompaction(t *testing.T) {
 
 	// There is a 0th WBL file.
 	files, err := ioutil.ReadDir(db.head.oooWbl.Dir())
+	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Equal(t, "00000000", files[0].Name())
 	require.Greater(t, files[0].Size(), int64(100))
@@ -3782,6 +3784,7 @@ func TestOOOCompaction(t *testing.T) {
 
 	// 0th WBL file will be deleted and 1st will be the only present.
 	files, err = ioutil.ReadDir(db.head.oooWbl.Dir())
+	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Equal(t, "00000001", files[0].Name())
 	require.Equal(t, int64(0), files[0].Size())

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1697,6 +1697,8 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
+
+	oooBlockRanges map[int64]struct{}
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, hash uint64, chunkRange, oooAllowance, oooCapMin, oooCapMax int64, chunkEndTimeVariance float64, memChunkPool *sync.Pool, isolationDisabled bool) *memSeries {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -981,7 +981,7 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 
 	// Truncate the chunk m-mapper.
 	if err := h.chunkDiskMapper.Truncate(minMmapFile); err != nil {
-		return errors.Wrap(err, "truncate by file no chunks.HeadReadWriter")
+		return errors.Wrap(err, "truncate chunks.HeadReadWriter by file number")
 	}
 	return nil
 }
@@ -1166,7 +1166,7 @@ func (h *Head) truncateOOO(lastWBLFile int, minOOOMmapRef chunks.ChunkDiskMapper
 
 		// Truncate the chunk m-mapper.
 		if err := h.chunkDiskMapper.Truncate(minMmapFile); err != nil {
-			return errors.Wrap(err, "truncate by file no chunks.HeadReadWriter in truncateOOO")
+			return errors.Wrap(err, "truncate chunks.HeadReadWriter by file number in truncateOOO")
 		}
 	}
 
@@ -1784,12 +1784,12 @@ func (s *memSeries) maxTime() int64 {
 // truncateChunksBefore removes all chunks from the series that
 // have no timestamp at or after mint.
 // Chunk IDs remain unchanged.
-func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (removed int) {
+func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
 	var removedInOrder int
 	if s.headChunk != nil && s.headChunk.maxTime < mint {
 		// If head chunk is truncated, we can truncate all mmapped chunks.
 		removedInOrder = 1 + len(s.mmappedChunks)
-		s.firstChunkID += chunks.HeadChunkID(removed)
+		s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 		s.headChunk = nil
 		s.mmappedChunks = nil
 	}
@@ -1800,7 +1800,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			}
 			removedInOrder = i + 1
 		}
-		s.mmappedChunks = append(s.mmappedChunks[:0], s.mmappedChunks[removed:]...)
+		s.mmappedChunks = append(s.mmappedChunks[:0], s.mmappedChunks[removedInOrder:]...)
 		s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1812,7 +1812,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			}
 			removedOOO = i + 1
 		}
-		s.oooMmappedChunks = append(s.oooMmappedChunks[:0], s.oooMmappedChunks[removed:]...)
+		s.oooMmappedChunks = append(s.oooMmappedChunks[:0], s.oooMmappedChunks[removedOOO:]...)
 		s.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1697,8 +1697,6 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
-
-	oooBlockRanges map[int64]struct{}
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, hash uint64, chunkRange, oooAllowance, oooCapMin, oooCapMax int64, chunkEndTimeVariance float64, memChunkPool *sync.Pool, isolationDisabled bool) *memSeries {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -636,11 +636,6 @@ func (s *memSeries) insert(t int64, v float64, chunkDiskMapper chunkDiskMapper) 
 		if chunkCreated || t > c.maxTime {
 			c.maxTime = t
 		}
-		if s.oooBlockRanges == nil {
-			s.oooBlockRanges = make(map[int64]struct{})
-		}
-		blockIdx := t / s.chunkRange
-		s.oooBlockRanges[blockIdx] = struct{}{}
 	}
 	return ok, chunkCreated, mmapRef
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -636,6 +636,11 @@ func (s *memSeries) insert(t int64, v float64, chunkDiskMapper chunkDiskMapper) 
 		if chunkCreated || t > c.maxTime {
 			c.maxTime = t
 		}
+		if s.oooBlockRanges == nil {
+			s.oooBlockRanges = make(map[int64]struct{})
+		}
+		blockIdx := t / s.chunkRange
+		s.oooBlockRanges[blockIdx] = struct{}{}
 	}
 	return ok, chunkCreated, mmapRef
 }
@@ -789,6 +794,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper chunkDiskMapper) chu
 		minTime:    s.oooHeadChunk.minTime,
 		maxTime:    s.oooHeadChunk.maxTime,
 	})
+	s.oooHeadChunk = nil
 	return chunkRef
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -765,7 +765,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	require.NotNil(t, chk)
 	require.NoError(t, err)
 
-	s.truncateChunksBefore(2000)
+	s.truncateChunksBefore(2000, 0)
 
 	require.Equal(t, int64(2000), s.mmappedChunks[0].minTime)
 	_, _, err = s.chunk(0, chunkDiskMapper)

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -354,7 +354,6 @@ type OOOCompactionHeadIndexReader struct {
 
 func NewOOOCompactionHeadIndexReader(ch *OOOCompactionHead) IndexReader {
 	return &OOOCompactionHeadIndexReader{ch: ch}
-
 }
 
 func (ir *OOOCompactionHeadIndexReader) Symbols() index.StringIter {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -239,10 +239,6 @@ type OOOCompactionHead struct {
 // All the above together have a bit of CPU and memory overhead, and can have a bit of impact
 // on the sample append latency. So call NewOOOCompactionHead only right before compaction.
 func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
-	// TODO:
-	// 1. M-map all in-memory chunk.
-	// 2. Track the last m-map chunk.
-
 	newWBLFile, err := head.oooWbl.NextSegment()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds compaction to generate multiple blocks out of OOO Head as per [this design doc](https://docs.google.com/document/d/1Kppm7qL9C-BJB1j6yb6-9ObG3AbdZnFUBYPNNWwDBYM/edit#heading=h.f3vr8krap9ta).

Since our aim is to support a relatively smaller OOOAllowance, the approach used here is to iterate over all possible block ranges for OOO Head and do compaction one at a time. For example if OOO Head had samples from 1.5h to 4.5h. It will try compaction for these 3 ranges one after another - [0h, 2h), [2h, 4h), [4h, 6) - while querying for all OOO series during each iteration.

But this step is done only once for all blocks together: 

At the start:
1. Cut a new WBL file and record the last WBL file seen at that time.
2. M-map all the active ooo chunks and keep track of the last m-map chunk ref seen.

<then the writing of blocks happen as per above>

After blocks have been written:
1. OOO m-map chunks are garbage collected for all ooo m-map chunks that are before the last m-map chunks seen above. Empty series are also garbage collected here.
2. WBL files before the above seen file number are deleted.
 