### PR TITLE
Update db Querier to read from the ooo range head

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1657,7 +1657,7 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 	}
 
 	var outOfOrderHeadQuerier storage.Querier
-	if maxt >= db.head.minOOOTime.Load() {
+	if overlapsClosedInterval(mint, maxt, db.head.MinOOOTime(), db.head.MaxOOOTime()) {
 		rh := NewOOORangeHead(db.head, mint, maxt)
 		var err error
 		outOfOrderHeadQuerier, err = NewBlockQuerier(rh, mint, maxt)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1657,7 +1657,6 @@ func (db *DB) Querier(_ context.Context, mint, maxt int64) (storage.Querier, err
 	}
 
 	var outOfOrderHeadQuerier storage.Querier
-	db.head.MinTime()
 	if maxt >= db.head.minOOOTime.Load() {
 		rh := NewOOORangeHead(db.head, mint, maxt)
 		var err error

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -322,31 +322,32 @@ func (h *Head) resetInMemoryState() error {
 }
 
 type headMetrics struct {
-	activeAppenders          prometheus.Gauge
-	series                   prometheus.GaugeFunc
-	seriesCreated            prometheus.Counter
-	seriesRemoved            prometheus.Counter
-	seriesNotFound           prometheus.Counter
-	chunks                   prometheus.Gauge
-	chunksCreated            prometheus.Counter
-	chunksRemoved            prometheus.Counter
-	gcDuration               prometheus.Summary
-	samplesAppended          prometheus.Counter
-	outOfBoundSamples        prometheus.Counter
-	outOfOrderSamples        prometheus.Counter
-	tooOldSamples            prometheus.Counter
-	walTruncateDuration      prometheus.Summary
-	walCorruptionsTotal      prometheus.Counter
-	dataTotalReplayDuration  prometheus.Gauge
-	headTruncateFail         prometheus.Counter
-	headTruncateTotal        prometheus.Counter
-	checkpointDeleteFail     prometheus.Counter
-	checkpointDeleteTotal    prometheus.Counter
-	checkpointCreationFail   prometheus.Counter
-	checkpointCreationTotal  prometheus.Counter
-	mmapChunkCorruptionTotal prometheus.Counter
-	snapshotReplayErrorTotal prometheus.Counter // Will be either 0 or 1.
-	oooHistogram             prometheus.Histogram
+	activeAppenders           prometheus.Gauge
+	series                    prometheus.GaugeFunc
+	seriesCreated             prometheus.Counter
+	seriesRemoved             prometheus.Counter
+	seriesNotFound            prometheus.Counter
+	chunks                    prometheus.Gauge
+	chunksCreated             prometheus.Counter
+	chunksRemoved             prometheus.Counter
+	gcDuration                prometheus.Summary
+	samplesAppended           prometheus.Counter
+	outOfOrderSamplesAppended prometheus.Counter
+	outOfBoundSamples         prometheus.Counter
+	outOfOrderSamples         prometheus.Counter
+	tooOldSamples             prometheus.Counter
+	walTruncateDuration       prometheus.Summary
+	walCorruptionsTotal       prometheus.Counter
+	dataTotalReplayDuration   prometheus.Gauge
+	headTruncateFail          prometheus.Counter
+	headTruncateTotal         prometheus.Counter
+	checkpointDeleteFail      prometheus.Counter
+	checkpointDeleteTotal     prometheus.Counter
+	checkpointCreationFail    prometheus.Counter
+	checkpointCreationTotal   prometheus.Counter
+	mmapChunkCorruptionTotal  prometheus.Counter
+	snapshotReplayErrorTotal  prometheus.Counter // Will be either 0 or 1.
+	oooHistogram              prometheus.Histogram
 }
 
 func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
@@ -404,6 +405,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 		samplesAppended: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_samples_appended_total",
 			Help: "Total number of appended samples.",
+		}),
+		outOfOrderSamplesAppended: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_head_out_of_order_samples_appended_total",
+			Help: "Total number of appended out of order samples.",
 		}),
 		outOfBoundSamples: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_out_of_bound_samples_total",
@@ -480,6 +485,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.walCorruptionsTotal,
 			m.dataTotalReplayDuration,
 			m.samplesAppended,
+			m.outOfOrderSamplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,
 			m.tooOldSamples,

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -314,8 +314,8 @@ func (h *Head) resetInMemoryState() error {
 	h.chunkRange.Store(h.opts.ChunkRange)
 	h.minTime.Store(math.MaxInt64)
 	h.maxTime.Store(math.MinInt64)
-	h.minOOOTime.Store(math.MaxInt64) // TODO(jesus.vazquez) Review this value
-	h.maxOOOTime.Store(math.MinInt64) // TODO(jesus.vazquez) Review this value
+	h.minOOOTime.Store(math.MinInt64) // TODO(jesus.vazquez) Review this value
+	h.maxOOOTime.Store(math.MaxInt64) // TODO(jesus.vazquez) Review this value
 	h.lastWALTruncationTime.Store(math.MinInt64)
 	h.lastMemoryTruncationTime.Store(math.MinInt64)
 	return nil

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -477,6 +477,7 @@ func (a *headAppender) Commit() (err error) {
 
 	var (
 		total            = len(a.samples)
+		oooTotal         = 0
 		oob, ooo, tooOld int   // out of bounds, out of order, too old
 		ooomint          int64 = math.MaxInt64
 		ooomaxt          int64 = math.MinInt64
@@ -560,6 +561,7 @@ func (a *headAppender) Commit() (err error) {
 					if s.T > ooomaxt {
 						ooomaxt = s.T
 					}
+					oooTotal++
 				} else {
 					// the sample was an attempted update.
 					// note that we can only detect updates if they clash with a sample in the OOOHeadChunk,
@@ -612,6 +614,7 @@ func (a *headAppender) Commit() (err error) {
 	a.head.metrics.outOfBoundSamples.Add(float64(oob))
 	a.head.metrics.tooOldSamples.Add(float64(tooOld))
 	a.head.metrics.samplesAppended.Add(float64(total))
+	a.head.metrics.outOfOrderSamplesAppended.Add(float64(oooTotal))
 	a.head.updateMinMaxTime(a.mint, a.maxt)
 	a.head.updateMinOOOMaxOOOTime(ooomint, ooomaxt)
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -536,6 +536,7 @@ func (a *headAppender) Commit() (err error) {
 			if delta <= series.oooAllowance {
 				// ... and the delta is within the OOO tolerance
 				var mmapRef chunks.ChunkDiskMapperRef
+				// TODO (jesus.vazquez) Should we track here new values for head ooo mint and maxt?
 				ok, chunkCreated, mmapRef = series.insert(s.T, s.V, a.head.chunkDiskMapper)
 				if chunkCreated {
 					if oooMmapMarkers[series.ref] != 0 { // TODO(ganesh) Remove this condition. There could be a case where there are samples in the slice and no markers and we want to collect the samples.

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -3,7 +3,6 @@ package tsdb
 import (
 	"fmt"
 
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
@@ -38,7 +37,7 @@ func (oh *OOORangeHead) Chunks() (ChunkReader, error) {
 func (oh *OOORangeHead) Tombstones() (tombstones.Reader, error) {
 	// As stated in the design doc https://docs.google.com/document/d/1Kppm7qL9C-BJB1j6yb6-9ObG3AbdZnFUBYPNNWwDBYM/edit?usp=sharing
 	// Tombstones are not supported for out of order metrics.
-	return noopTombstoneReader{}, nil
+	return tombstones.NewMemTombstones(), nil
 }
 
 func (oh *OOORangeHead) Meta() BlockMeta {
@@ -74,25 +73,4 @@ func (oh *OOORangeHead) MinTime() int64 {
 
 func (oh *OOORangeHead) MaxTime() int64 {
 	return oh.maxt
-}
-
-var _ tombstones.Reader = &noopTombstoneReader{}
-
-// noopTombstoneReader is a no operation implementation of tombstone.Reader
-type noopTombstoneReader struct{}
-
-func (n noopTombstoneReader) Get(ref storage.SeriesRef) (tombstones.Intervals, error) {
-	return nil, nil
-}
-
-func (n noopTombstoneReader) Iter(f func(storage.SeriesRef, tombstones.Intervals) error) error {
-	return nil
-}
-
-func (n noopTombstoneReader) Total() uint64 {
-	return 0
-}
-
-func (n noopTombstoneReader) Close() error {
-	return nil
 }

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -44,8 +44,8 @@ func (oh *OOORangeHead) Meta() BlockMeta {
 	var id [16]byte
 	copy(id[:], "____ooo_head____")
 	return BlockMeta{
-		MinTime: oh.head.MinOOOTime(),
-		MaxTime: oh.head.MaxOOOTime(),
+		MinTime: oh.mint,
+		MaxTime: oh.maxt,
 		ULID:    id,
 		Stats: BlockStats{
 			NumSeries: oh.head.NumSeries(),

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -79,8 +79,7 @@ func (oh *OOORangeHead) MaxTime() int64 {
 var _ tombstones.Reader = &noopTombstoneReader{}
 
 // noopTombstoneReader is a no operation implementation of tombstone.Reader
-type noopTombstoneReader struct {
-}
+type noopTombstoneReader struct{}
 
 func (n noopTombstoneReader) Get(ref storage.SeriesRef) (tombstones.Intervals, error) {
 	return nil, nil


### PR DESCRIPTION
The way the querier reads from the tsdb is that it iterates all the existing blocks that overlap with the query interval (mint,maxt). And blocks can be 1) persistent blocks 2) in order head implementing block reader and now 3) out of order head implementing block reader :tada: 

What this PR does:
- Extends the db querier to also read form the out of order range head.
- Implement noop tombstone reader for the ooo range head. As stated in the design doc, we're not supporting tombstones for out of order.
- Add to the head a tracker for minOOOTime and maxOOOTime so that we know how much does the out of order head expand in time. 
  - Note: We also need to make sure that this markers are properly tracked and updated during the ingestion of new ooo samples and compaction.