### PR TITLE
Extend chunkquerier to read from the ooo head

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1735,7 +1735,7 @@ func (db *DB) ChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQu
 		var err error
 		outOfOrderHeadQuerier, err = NewBlockChunkQuerier(rh, mint, maxt)
 		if err != nil {
-			return nil, errors.Wrapf(err, "open block querier for ooo head %s", rh)
+			return nil, errors.Wrapf(err, "open block chunk querier for ooo head %s", rh)
 		}
 	}
 


### PR DESCRIPTION
Mimir uses ChunkQuerier to read from the TSDB. In https://github.com/grafana/mimir-prometheus/pull/222 we forgot to extend ChunkQuerier to also read form the out of order head. Both PRs are pretty similar.

This one also adds unit tests.