### PR TITLE
Set AllowOverlappingBlocks to true if ooo allowance is configured

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -314,7 +314,7 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.wal-compression", "Compress the tsdb WAL.").
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
-	serverOnlyFlag(a, "storage.tsdb.ooo-allowance", "Allow upto this much out-of-order.  Supported units: h, m, s").
+	serverOnlyFlag(a, "storage.tsdb.ooo-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. Also if the value is greater than AllowOverlappingBlocks's will be overrided and set to true since out-of-order head compaction can potentially create overlapping blocks.").
 		Hidden().Default("0s").SetValue(&cfg.tsdb.OOOAllowance)
 
 	serverOnlyFlag(a, "storage.tsdb.ooo-cap-min", "Minimum capacity for OOO chunks (in samples. between 0 and 255.)").

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -314,7 +314,7 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.wal-compression", "Compress the tsdb WAL.").
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
-	serverOnlyFlag(a, "storage.tsdb.ooo-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. Also if the value is greater than AllowOverlappingBlocks's will be overrided and set to true since out-of-order head compaction can potentially create overlapping blocks.").
+	serverOnlyFlag(a, "storage.tsdb.ooo-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. If the value is non-zero, then storage.tsdb.allow-overlapping-blocks will be set to true since out-of-order data can potentially overlap with other data.").
 		Hidden().Default("0s").SetValue(&cfg.tsdb.OOOAllowance)
 
 	serverOnlyFlag(a, "storage.tsdb.ooo-cap-min", "Minimum capacity for OOO chunks (in samples. between 0 and 255.)").

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -629,6 +629,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.MinBlockDuration > opts.MaxBlockDuration {
 		opts.MaxBlockDuration = opts.MinBlockDuration
 	}
+	if opts.OOOAllowance > 0 {
+		opts.AllowOverlappingBlocks = true
+	}
 
 	if len(rngs) == 0 {
 		// Start with smallest block duration and create exponential buckets until the exceed the


### PR DESCRIPTION
Relates to https://github.com/grafana/mimir-ooo/issues/15

When out of order is enabled, compaction can potentially create overlapping blocks with the in order blocks. Because of this we want to make sure that Prometheus's option `AllowOverlappingBlocks` is always true if OOOAllowance is set.