### PR TITLE
Bunch of OOO Head enhancements and fixes

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3473,6 +3473,8 @@ func TestOOOWALWrite(t *testing.T) {
 	app = db.Appender(context.Background())
 	appendSample(app, s2, 45)
 	appendSample(app, s1, 35)
+	appendSample(app, s1, 36) // m-maps.
+	appendSample(app, s1, 37)
 	require.NoError(t, app.Commit())
 
 	// OOO for s1 but not for s2 in the same commit.
@@ -3510,9 +3512,16 @@ func TestOOOWALWrite(t *testing.T) {
 			{Ref: 2, T: minutes(45), V: 45},
 			{Ref: 1, T: minutes(35), V: 35},
 		},
-
 		[]record.RefMmapMarker{ // 3rd sample, hence m-mapped.
 			{Ref: 1, MmapRef: 4294967304},
+		},
+		[]record.RefSample{
+			{Ref: 1, T: minutes(36), V: 36},
+			{Ref: 1, T: minutes(37), V: 37},
+		},
+
+		[]record.RefMmapMarker{ // 3rd sample, hence m-mapped.
+			{Ref: 1, MmapRef: 4294967354},
 		},
 		[]record.RefSample{ // Does not contain the in-order sample here.
 			{Ref: 1, T: minutes(50), V: 50},
@@ -3520,14 +3529,14 @@ func TestOOOWALWrite(t *testing.T) {
 
 		// Single commit but multiple OOO records.
 		[]record.RefMmapMarker{
-			{Ref: 2, MmapRef: 4294967354},
+			{Ref: 2, MmapRef: 4294967403},
 		},
 		[]record.RefSample{
 			{Ref: 2, T: minutes(50), V: 50},
 			{Ref: 2, T: minutes(51), V: 51},
 		},
 		[]record.RefMmapMarker{
-			{Ref: 2, MmapRef: 4294967403},
+			{Ref: 2, MmapRef: 4294967452},
 		},
 		[]record.RefSample{
 			{Ref: 2, T: minutes(52), V: 52},
@@ -3553,6 +3562,8 @@ func TestOOOWALWrite(t *testing.T) {
 		[]record.RefSample{
 			{Ref: 2, T: minutes(45), V: 45},
 			{Ref: 1, T: minutes(35), V: 35},
+			{Ref: 1, T: minutes(36), V: 36},
+			{Ref: 1, T: minutes(37), V: 37},
 		},
 		[]record.RefSample{ // Contains both in-order and ooo sample.
 			{Ref: 1, T: minutes(50), V: 50},

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -127,6 +127,7 @@ func (h *Head) appender() *headAppender {
 		minValidTime:          h.appendableMinValidTime(),
 		mint:                  math.MaxInt64,
 		maxt:                  math.MinInt64,
+		headMaxt:              h.MaxTime(),
 		samples:               h.getAppendBuffer(),
 		sampleSeries:          h.getSeriesBuffer(),
 		exemplars:             exemplarsBuf,
@@ -238,6 +239,7 @@ type headAppender struct {
 	head         *Head
 	minValidTime int64 // No samples below this timestamp are allowed.
 	mint, maxt   int64
+	headMaxt     int64 // We track it here to not take the lock for every sample appended.
 
 	series       []record.RefSeries      // New series held by this appender.
 	samples      []record.RefSample      // New samples held by this appender.
@@ -283,7 +285,9 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s.Lock()
-	if delta, err := s.appendable(t, v); err != nil {
+	// TODO: if we definitely know at this point that the sample is ooo, then optimise
+	// to skip that sample from the WAL and write only in the WBL.
+	if _, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime); err != nil {
 		s.Unlock()
 		if err == storage.ErrOutOfOrderSample {
 			a.head.metrics.outOfOrderSamples.Inc()                     // TODO: should we keep reporting this even when we accept the OOO insert?
@@ -314,25 +318,39 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 }
 
 // appendable checks whether the given sample is valid for appending to the series.
-func (s *memSeries) appendable(t int64, v float64) (int64, error) {
-	c := s.head()
-	if c == nil {
-		return 0, nil
-	}
-	if t > c.maxTime {
-		return 0, nil
-	}
-
-	if t < c.maxTime-s.oooAllowance {
-		if s.oooAllowance > 0 {
-			return c.maxTime - t, storage.ErrTooOldSample
+// If the returned boolean is true, then the sample belongs to the out of order chunk.
+func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime int64) (bool, int64, error) {
+	msMaxt := s.maxTime()
+	if msMaxt == math.MinInt64 {
+		// The series has no sample and was freshly created.
+		if t >= minValidTime {
+			// We can append it in the in-order chunk.
+			return false, 0, nil
 		}
-		return c.maxTime - t, storage.ErrOutOfOrderSample
+
+		// We cannot append it in the in-order head. So we check the oooAllowance
+		// w.r.t. the head's maxt.
+		// -1 because for the first sample in the Head, headMaxt will be equal to t.
+		msMaxt = headMaxt - 1
 	}
 
-	if t != c.maxTime {
-		// Sample is ooo and within allowance.
-		return c.maxTime - t, nil
+	if t > msMaxt {
+		return false, 0, nil
+	}
+
+	if t < msMaxt-s.oooAllowance {
+		if s.oooAllowance > 0 {
+			return true, msMaxt - t, storage.ErrTooOldSample
+		}
+		if t < minValidTime {
+			return false, msMaxt - t, storage.ErrOutOfBounds
+		}
+		return false, msMaxt - t, storage.ErrOutOfOrderSample
+	}
+
+	if t != msMaxt || s.head() == nil {
+		// Sample is ooo and within allowance OR series has no active chunk to check for duplicate sample.
+		return true, msMaxt - t, nil
 	}
 
 	// We are allowing exact duplicates as we can encounter them in valid cases
@@ -340,9 +358,9 @@ func (s *memSeries) appendable(t int64, v float64) (int64, error) {
 	// this only checks against the latest in-order sample.
 	// the OOO headchunk has its own method to detect these duplicates
 	if math.Float64bits(s.sampleBuf[3].v) != math.Float64bits(v) {
-		return 0, storage.ErrDuplicateSampleForTimestamp
+		return false, 0, storage.ErrDuplicateSampleForTimestamp
 	}
-	return 0, nil
+	return false, 0, nil
 }
 
 // AppendExemplar for headAppender assumes the series ref already exists, and so it doesn't
@@ -530,65 +548,60 @@ func (a *headAppender) Commit() (err error) {
 		series = a.sampleSeries[i]
 		series.Lock()
 
-		maxT := series.maxTime()
-		delta := maxT - s.T
+		oooSample, delta, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime)
+		switch err {
+		case storage.ErrOutOfOrderSample:
+			total--
+			ooo++
+		case storage.ErrOutOfBounds:
+			total--
+			oob++
+		case storage.ErrTooOldSample:
+			total--
+			tooOld++
+		case nil:
+			// Do nothing.
+		default:
+			total--
+		}
 
 		var ok, chunkCreated bool
 
-		if s.T < maxT && series.oooAllowance > 0 {
-			// Sample is OOO and OOO handling is enabled...
-
-			if delta <= series.oooAllowance {
-				// ... and the delta is within the OOO tolerance
-				var mmapRef chunks.ChunkDiskMapperRef
-				ok, chunkCreated, mmapRef = series.insert(s.T, s.V, a.head.chunkDiskMapper)
-				if chunkCreated {
-					if oooMmapMarkers[series.ref] != 0 { // TODO(ganesh) Remove this condition. There could be a case where there are samples in the slice and no markers and we want to collect the samples.
-						// We have already m-mapped a chunk for this series in the same Commit().
-						// Hence, before we m-map again, we should add the samples and m-map markers
-						// seen till now to the WBL records.
-						collectOOORecords()
-					}
-
-					if oooMmapMarkers == nil {
-						oooMmapMarkers = make(map[chunks.HeadSeriesRef]chunks.ChunkDiskMapperRef)
-					}
-					oooMmapMarkers[series.ref] = mmapRef
+		if err == nil && oooSample {
+			// Sample is OOO and OOO handling is enabled
+			// and the delta is within the OOO tolerance.
+			var mmapRef chunks.ChunkDiskMapperRef
+			ok, chunkCreated, mmapRef = series.insert(s.T, s.V, a.head.chunkDiskMapper)
+			if chunkCreated {
+				if oooMmapMarkers[series.ref] != 0 { // TODO(ganesh) Remove this condition. There could be a case where there are samples in the slice and no markers and we want to collect the samples.
+					// We have already m-mapped a chunk for this series in the same Commit().
+					// Hence, before we m-map again, we should add the samples and m-map markers
+					// seen till now to the WBL records.
+					collectOOORecords()
 				}
-				if ok {
-					oooWblSamples = append(oooWblSamples, s)
-					if s.T < ooomint {
-						ooomint = s.T
-					}
-					if s.T > ooomaxt {
-						ooomaxt = s.T
-					}
-					oooTotal++
-				} else {
-					// the sample was an attempted update.
-					// note that we can only detect updates if they clash with a sample in the OOOHeadChunk,
-					// not with samples in already flushed OOO chunks.
-					// TODO: error reporting? depends on addressing https://github.com/prometheus/prometheus/discussions/10305
-					total--
+
+				if oooMmapMarkers == nil {
+					oooMmapMarkers = make(map[chunks.HeadSeriesRef]chunks.ChunkDiskMapperRef)
 				}
+				oooMmapMarkers[series.ref] = mmapRef
+			}
+			if ok {
+				oooWblSamples = append(oooWblSamples, s)
+				if s.T < ooomint {
+					ooomint = s.T
+				}
+				if s.T > ooomaxt {
+					ooomaxt = s.T
+				}
+				oooTotal++
 			} else {
-				// ...but the delta is beyond the OOO tolerance
+				// the sample was an attempted update.
+				// note that we can only detect updates if they clash with a sample in the OOOHeadChunk,
+				// not with samples in already flushed OOO chunks.
+				// TODO: error reporting? depends on addressing https://github.com/prometheus/prometheus/discussions/10305
 				total--
-				tooOld++
 			}
-		} else {
-			// Sample is in order and/or OOO handling is disabled
-			// if OOO is enabled, then Append() skipped this test. We must run it now.
-			if a.head.opts.OOOAllowance > 0 && s.T < a.minValidTime {
-				// Here, we know for sure the sample is in order.
-				// TODO: if OOO inserts are enabled, we could support the "lagging series" (offset clock) use case here.
-				// Even if the sample is in order, we could insert it into an OOO chunk
-				// Not sure yet if we want to support that.  It may increase the volume of OOO chunk data
-				// significantly. So for now, be conservative (reject), we may open this use case later.
-				total--
-				oob++
-				continue
-			}
+		} else if err == nil {
 			delta, ok, chunkCreated = series.append(s.T, s.V, a.appendID, a.head.chunkDiskMapper)
 			// TODO: handle overwrite.
 			// this would be storage.ErrDuplicateSampleForTimestamp, it has no attached counter

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -319,7 +319,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 
 // appendable checks whether the given sample is valid for appending to the series.
 // If the returned boolean is true, then the sample belongs to the out of order chunk.
-func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime int64) (bool, int64, error) {
+func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime int64) (isOutOfOrder bool, delta int64, err error) {
 	msMaxt := s.maxTime()
 	if msMaxt == math.MinInt64 {
 		// The series has no sample and was freshly created.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3270,6 +3270,12 @@ func TestOOOWalReplay(t *testing.T) {
 	appendSample(59, true)
 	appendSample(31, true)
 
+	// Check that Head's time ranges are set properly.
+	require.Equal(t, 60*time.Minute.Milliseconds(), h.MinTime())
+	require.Equal(t, 60*time.Minute.Milliseconds(), h.MaxTime())
+	require.Equal(t, 31*time.Minute.Milliseconds(), h.MinOOOTime())
+	require.Equal(t, 59*time.Minute.Milliseconds(), h.MaxOOOTime())
+
 	// Restart head.
 	require.NoError(t, h.Close())
 	wlog, err = wal.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, true)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3605,3 +3605,84 @@ func TestReplayAfterMmapReplayError(t *testing.T) {
 
 	require.NoError(t, h.Close())
 }
+
+func TestOOOAppendWithNoSeries(t *testing.T) {
+	dir := t.TempDir()
+	wlog, err := wal.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, true)
+	require.NoError(t, err)
+	oooWlog, err := wal.NewSize(nil, nil, filepath.Join(dir, wal.OOOWblDirName), 32768, true)
+	require.NoError(t, err)
+
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.OOOCapMax = 30
+	opts.OOOAllowance = 120 * time.Minute.Milliseconds()
+
+	h, err := NewHead(nil, nil, wlog, oooWlog, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, h.Close())
+	})
+	require.NoError(t, h.Init(0))
+
+	appendSample := func(lbls labels.Labels, ts int64) {
+		app := h.Appender(context.Background())
+		_, err := app.Append(0, lbls, ts*time.Minute.Milliseconds(), float64(ts))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}
+
+	verifyOOOSamples := func(lbls labels.Labels, expSamples int) {
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.NotNil(t, ms)
+
+		require.Nil(t, ms.headChunk)
+		require.NotNil(t, ms.oooHeadChunk)
+		require.Equal(t, expSamples, ms.oooHeadChunk.chunk.NumSamples())
+	}
+
+	verifyInOrderSamples := func(lbls labels.Labels, expSamples int) {
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.NotNil(t, ms)
+
+		require.Nil(t, ms.oooHeadChunk)
+		require.NotNil(t, ms.headChunk)
+		require.Equal(t, expSamples, ms.headChunk.chunk.NumSamples())
+	}
+
+	newLabels := func(idx int) labels.Labels { return labels.FromStrings("foo", fmt.Sprintf("%d", idx)) }
+
+	s1 := newLabels(1)
+	appendSample(s1, 300) // At 300m.
+	verifyInOrderSamples(s1, 1)
+
+	// At 239m, the sample cannot be appended to in-order chunk since it is
+	// beyond the minValidTime. So it should go in OOO chunk.
+	// Series does not exist for s2 yet.
+	s2 := newLabels(2)
+	appendSample(s2, 239) // OOO sample.
+	verifyOOOSamples(s2, 1)
+
+	// Similar for 180m.
+	s3 := newLabels(3)
+	appendSample(s3, 180) // OOO sample.
+	verifyOOOSamples(s3, 1)
+
+	// Now 179m is too old.
+	s4 := newLabels(4)
+	app := h.Appender(context.Background())
+	_, err = app.Append(0, s4, 179*time.Minute.Milliseconds(), float64(179))
+	require.Equal(t, storage.ErrTooOldSample, err)
+	require.NoError(t, app.Rollback())
+	verifyOOOSamples(s3, 1)
+
+	// Samples still go into in-order chunk for samples within
+	// appendable minValidTime.
+	s5 := newLabels(5)
+	appendSample(s5, 240)
+	verifyInOrderSamples(s5, 1)
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -858,6 +858,7 @@ func TestHeadDeleteSimple(t *testing.T) {
 		t.Run(fmt.Sprintf("compress=%t", compress), func(t *testing.T) {
 			for _, c := range cases {
 				head, w := newTestHead(t, 1000, compress)
+				require.NoError(t, head.Init(0))
 
 				app := head.Appender(context.Background())
 				for _, smpl := range smplsAll {


### PR DESCRIPTION
This PR brings in multiple enhancements/fixes

1. Setting in-order mint/maxt of the Head properly.
2. Append ooo samples when no series exist for it in the Head. We take Head's maxt for the OOOAllowance check in that case.
3. Fix some m-map marker stuff. It was a TODO in the comment.

Unit tests exist for all of the fixes.

It will be easier to review 1 commit at a time instead of PR as a whole.