### PR TITLE
When removing start/end text op in regexp, don't break the contract.

### DIFF
--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -86,6 +86,16 @@ func TestMatcher(t *testing.T) {
 			value:   "foo-bar",
 			match:   false,
 		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "bar^+"),
+			value:   "foo-bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "$+bar"),
+			value:   "foo-bar",
+			match:   false,
+		},
 	}
 
 	for _, test := range tests {

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -81,6 +81,11 @@ func TestMatcher(t *testing.T) {
 			value:   "foo-bar",
 			match:   false,
 		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "$*bar"),
+			value:   "foo-bar",
+			match:   false,
+		},
 	}
 
 	for _, test := range tests {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -163,6 +163,9 @@ func clearBeginEndText(re *syntax.Regexp) {
 	}
 	if len(re.Sub) == 1 {
 		if re.Sub[0].Op == syntax.OpBeginText || re.Sub[0].Op == syntax.OpEndText {
+			// We need to remove this element. Since it's the only one, we convert into a matcher of an empty string.
+			// OpEmptyMatch is regexp's nop operator.
+			re.Op = syntax.OpEmptyMatch
 			re.Sub = nil
 			return
 		}


### PR DESCRIPTION
We can't remove the only Sub from regexp, since the contract for some operations says that there's at least one Sub, like OpStar or OpPlus.

In order to convert a single-sub element into a no-op, we change the operation to OpEmptyString. You can see the same trick being used by standard regexp code when simplifying `x{0}`: https://github.com/golang/go/blob/cf7ec0fa098a46c3b75cc3d625f5d7528fe6e984/src/regexp/syntax/simplify.go#L41-L46

Relates to https://github.com/grafana/mimir/issues/1866