### PR TITLE
Write some unit tests for out of order

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -398,9 +398,13 @@ func (db *DBReadOnly) FlushWAL(dir string) (returnErr error) {
 	if err != nil {
 		return err
 	}
-	ooow, err := wal.Open(db.logger, filepath.Join(db.dir, wal.OOOWblDirName))
-	if err != nil {
-		return err
+	var ooow *wal.WAL
+	oooWblDir := filepath.Join(db.dir, wal.OOOWblDirName)
+	if _, err := os.Stat(oooWblDir); !os.IsNotExist(err) {
+		ooow, err = wal.Open(db.logger, oooWblDir)
+		if err != nil {
+			return err
+		}
 	}
 	opts := DefaultHeadOptions()
 	opts.ChunkDirRoot = db.dir
@@ -479,9 +483,13 @@ func (db *DBReadOnly) loadDataAsQueryable(maxt int64) (storage.SampleAndChunkQue
 		if err != nil {
 			return nil, err
 		}
-		ooow, err := wal.Open(db.logger, filepath.Join(db.dir, wal.OOOWblDirName))
-		if err != nil {
-			return nil, err
+		var ooow *wal.WAL
+		oooWblDir := filepath.Join(db.dir, wal.OOOWblDirName)
+		if _, err := os.Stat(oooWblDir); !os.IsNotExist(err) {
+			ooow, err = wal.Open(db.logger, oooWblDir)
+			if err != nil {
+				return nil, err
+			}
 		}
 		opts := DefaultHeadOptions()
 		opts.ChunkDirRoot = db.dir

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -748,9 +748,11 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		if err != nil {
 			return nil, err
 		}
-		oooWlog, err = wal.NewSize(l, r, oooWalDir, segmentSize, opts.WALCompression)
-		if err != nil {
-			return nil, err
+		if opts.OOOAllowance > 0 {
+			oooWlog, err = wal.NewSize(l, r, oooWalDir, segmentSize, opts.WALCompression)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1042,6 +1044,9 @@ func (db *DB) CompactOOOHead() error {
 }
 
 func (db *DB) compactOOOHead() error {
+	if db.opts.OOOAllowance <= 0 {
+		return nil
+	}
 	oooHead, err := NewOOOCompactionHead(db.head)
 	if err != nil {
 		return errors.Wrap(err, "get ooo compaction head")

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3997,3 +3997,79 @@ func Test_ChunkQuerier_OOOQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestOOOAppendAndQuery(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OOOCapMin = 2
+	opts.OOOCapMax = 30
+	opts.OOOAllowance = 4 * time.Hour.Milliseconds()
+	opts.AllowOverlappingQueries = true
+
+	db := openTestDB(t, opts, nil)
+	db.DisableCompactions()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	s1 := labels.FromStrings("foo", "bar1")
+	s2 := labels.FromStrings("foo", "bar2")
+
+	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
+	expSamples := make(map[string][]tsdbutil.Sample)
+	totalSamples := 0
+	addSample := func(lbls labels.Labels, fromMins, toMins int64, faceError bool) {
+		app := db.Appender(context.Background())
+		key := lbls.String()
+		from, to := minutes(fromMins), minutes(toMins)
+		for min := from; min <= to; min += time.Minute.Milliseconds() {
+			val := rand.Float64()
+			_, err := app.Append(0, lbls, min, val)
+			if faceError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				expSamples[key] = append(expSamples[key], sample{t: min, v: val})
+				totalSamples++
+			}
+		}
+		if faceError {
+			require.NoError(t, app.Rollback())
+		} else {
+			require.NoError(t, app.Commit())
+		}
+	}
+
+	// In-order samples.
+	addSample(s1, 300, 300, false)
+	addSample(s2, 290, 290, false)
+
+	// Some ooo samples.
+	addSample(s1, 250, 260, false)
+	addSample(s2, 255, 265, false)
+
+	// Out of allowance.
+	addSample(s1, 59, 59, true)
+	addSample(s2, 49, 49, true)
+
+	// At the edge of allowance, also it would be "out of bound" without the ooo support.
+	addSample(s1, 60, 65, false)
+	addSample(s2, 50, 55, false)
+
+	// Out of allowance again.
+	addSample(s1, 59, 59, true)
+	addSample(s2, 49, 49, true)
+
+	querier, err := db.Querier(context.TODO(), math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+
+	seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar."))
+
+	for k, v := range expSamples {
+		sort.Slice(v, func(i, j int) bool {
+			return v[i].T() < v[j].T()
+		})
+		expSamples[k] = v
+	}
+	require.Equal(t, expSamples, seriesSet)
+	require.GreaterOrEqual(t, float64(totalSamples-2), prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamplesAppended), "number of ooo appended samples mismatch")
+}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -445,8 +445,9 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 	sort.Sort(byMinTimeAndMinRef(tmpChks))
 
 	mc := &mergedOOOChunks{}
+	absoluteMax := int64(math.MinInt64)
 	for _, c := range tmpChks {
-		if c.meta.Ref == meta.Ref || len(mc.chunks) > 0 && c.meta.MinTime <= mc.chunks[len(mc.chunks)-1].MaxTime {
+		if c.meta.Ref == meta.Ref || len(mc.chunks) > 0 && c.meta.MinTime <= absoluteMax {
 			if c.meta.Ref == oooHeadRef {
 				var xor *chunkenc.XORChunk
 				// If head chunk min and max time match the meta OOO markers
@@ -482,6 +483,9 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm chunkDiskMapper, mint, 
 				}
 			}
 			mc.chunks = append(mc.chunks, c.meta)
+			if c.meta.MaxTime > absoluteMax {
+				absoluteMax = c.meta.MaxTime
+			}
 		}
 	}
 


### PR DESCRIPTION
Part of https://github.com/grafana/mimir-prometheus/pull/237

* Appending samples out of order and out of bound and working properly.
* No OOO artifacts are created when OOOAllowance is 0
    * Including, no in-memory ooo chunk is created when ooo sample is discarded in this case
    * Old metrics are incremented and not the new ones