### PR TITLE
Add TestOOOCompactionFailure to test compaction failure

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1328,6 +1328,7 @@ func intersection(oldBlocks, actualBlocks []string) (intersection []string) {
 }
 
 // mockCompactorFailing creates a new empty block on every write and fails when reached the max allowed total.
+// For CompactOOO, it always fails.
 type mockCompactorFailing struct {
 	t      *testing.T
 	blocks []*Block
@@ -1367,7 +1368,7 @@ func (*mockCompactorFailing) Compact(string, []string, []*Block) (ulid.ULID, err
 }
 
 func (*mockCompactorFailing) CompactOOO(dest string, oooHead *OOOCompactionHead) (result []ulid.ULID, err error) {
-	return nil, nil
+	return nil, fmt.Errorf("mock compaction failing CompactOOO")
 }
 
 func TestTimeRetention(t *testing.T) {
@@ -4471,4 +4472,142 @@ func TestOOOWALAndMmapReplay(t *testing.T) {
 		require.NoError(t, err)
 		testQuery(expSamples)
 	})
+}
+
+func TestOOOCompactionFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := DefaultOptions()
+	opts.OOOCapMin = 2
+	opts.OOOCapMax = 30
+	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.AllowOverlappingQueries = true
+	opts.AllowOverlappingCompaction = true
+
+	db, err := Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+	db.DisableCompactions() // We want to manually call it.
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	series1 := labels.FromStrings("foo", "bar1")
+
+	addSample := func(fromMins, toMins int64) {
+		app := db.Appender(context.Background())
+		for min := fromMins; min <= toMins; min++ {
+			ts := min * time.Minute.Milliseconds()
+			_, err := app.Append(0, series1, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+	}
+
+	// Add an in-order samples.
+	addSample(250, 350)
+
+	// Add ooo samples that creates multiple chunks.
+	addSample(90, 310)
+
+	// No blocks before compaction.
+	require.Equal(t, len(db.Blocks()), 0)
+
+	// There is a 0th WBL file.
+	verifyFirstWBLFileIs0 := func(count int) {
+		files, err := ioutil.ReadDir(db.head.oooWbl.Dir())
+		require.NoError(t, err)
+		require.Len(t, files, count)
+		require.Equal(t, "00000000", files[0].Name())
+		require.Greater(t, files[0].Size(), int64(100))
+	}
+	verifyFirstWBLFileIs0(1)
+
+	verifyMmapFiles := func(exp ...string) {
+		mmapDir := mmappedChunksDir(db.head.opts.ChunkDirRoot)
+		files, err := ioutil.ReadDir(mmapDir)
+		require.NoError(t, err)
+		require.Len(t, files, len(exp))
+		for i, f := range files {
+			require.Equal(t, exp[i], f.Name())
+		}
+	}
+
+	verifyMmapFiles("000001")
+
+	// OOO compaction fails 5 times.
+	originalCompactor := db.compactor
+	db.compactor = &mockCompactorFailing{t: t}
+	for i := 0; i < 5; i++ {
+		require.Error(t, db.CompactOOOHead())
+	}
+	require.Equal(t, len(db.Blocks()), 0)
+
+	// M-map files don't change after failed compaction.
+	verifyMmapFiles("000001")
+
+	// Because of 5 compaction attempts, there are 6 files now.
+	verifyFirstWBLFileIs0(6)
+
+	db.compactor = originalCompactor
+	require.NoError(t, db.CompactOOOHead())
+	oldBlocks := db.Blocks()
+	require.Equal(t, len(db.Blocks()), 3)
+
+	// Check that the ooo chunks were removed.
+	ms, created, err := db.head.getOrCreate(series1.Hash(), series1)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.Nil(t, ms.oooHeadChunk)
+	require.Len(t, ms.oooMmappedChunks, 0)
+
+	// The failed compaction should not have left the ooo Head corrupted.
+	// Hence, expect no new blocks with another OOO compaction call.
+	require.NoError(t, db.CompactOOOHead())
+	require.Equal(t, len(db.Blocks()), 3)
+	require.Equal(t, oldBlocks, db.Blocks())
+
+	// Because of OOO compaction, we have a second m-map file now
+	// All the chunks are only in the first file.
+	verifyMmapFiles("000001", "000002")
+
+	// All but last WBL file will be deleted.
+	// 8 files in total (starting at 0) because of 7 compaction calls.
+	files, err := ioutil.ReadDir(db.head.oooWbl.Dir())
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "00000007", files[0].Name())
+	require.Equal(t, int64(0), files[0].Size())
+
+	verifySamples := func(block *Block, fromMins, toMins int64) {
+		series1Samples := make([]tsdbutil.Sample, 0, toMins-fromMins+1)
+		for min := fromMins; min <= toMins; min++ {
+			ts := min * time.Minute.Milliseconds()
+			series1Samples = append(series1Samples, sample{ts, float64(ts)})
+		}
+		expRes := map[string][]tsdbutil.Sample{
+			series1.String(): series1Samples,
+		}
+
+		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+
+		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
+		require.Equal(t, expRes, actRes)
+	}
+
+	// Checking for expected data in the blocks.
+	verifySamples(db.Blocks()[0], 90, 119)
+	verifySamples(db.Blocks()[1], 120, 239)
+	verifySamples(db.Blocks()[2], 240, 310)
+
+	// Compact the in-order head and expect another block.
+	// Since this is a forced compaction, this block is not aligned with 2h.
+	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	require.NoError(t, err)
+	require.Equal(t, len(db.Blocks()), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
+	verifySamples(db.Blocks()[3], 250, 350)
+
+	// The compaction also clears out the old m-map files. Including
+	// the file that has ooo chunks.
+	verifyMmapFiles("000002")
 }

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -275,11 +275,14 @@ func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
 		ms.Lock()
 
 		mmapRef := ms.mmapCurrentOOOHeadChunk(head.chunkDiskMapper)
+		if mmapRef == 0 && len(ms.oooMmappedChunks) > 0 {
+			// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
+			mmapRef = ms.oooMmappedChunks[len(ms.oooMmappedChunks)-1].ref
+		}
 		seq, off := mmapRef.Unpack()
 		if seq > lastSeq || (seq == lastSeq && off > lastOff) {
 			ch.lastMmapRef, lastSeq, lastOff = mmapRef, seq, off
 		}
-
 		if len(ms.oooMmappedChunks) > 0 {
 			ch.postings = append(ch.postings, seriesRef)
 			for _, c := range ms.oooMmappedChunks {


### PR DESCRIPTION
Covers this point from https://github.com/grafana/mimir-prometheus/issues/237
*  When compaction fails multiple times, m-map files and wbl is still cleared properly only after a successful compaction

The test makes sure that a failed compaction does not leave the
OOO Head corrupted. And eventually when a compaction works, the
blocks are created properly and the m-map files, WBL files and
the OOO Head are cleared properly.
