### PR TITLE
Reduce sleeping time when reading WBL

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -714,7 +714,7 @@ func (wp *oooWalSubsetProcessor) waitUntilIdle() {
 	}
 	wp.input <- []record.RefSample{}
 	for len(wp.input) != 0 {
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(10 * time.Microsecond)
 		select {
 		case <-wp.output: // Allow output side to drain to avoid deadlock.
 		default:


### PR DESCRIPTION
Following with the improvement in https://github.com/grafana/mimir-prometheus/pull/264/commits/542b9ecdbd758009d52402f6a486d1237a6647b7 this commit aims to do the same for the OOO WBL replay.
