### PR TITLE
WaitForIdle only sleep within select

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -722,7 +722,12 @@ func (h *Head) Init(minValidTime int64) error {
 		}
 		h.startWALReplayStatus(startFrom, endAt)
 
+		replayStart := time.Now()
+		segmentCount := 0
 		for i := startFrom; i <= endAt; i++ {
+			fmt.Printf("Segment #%d\n", segmentCount)
+			segmentCount++
+			segmentReplayStart := time.Now()
 			s, err := wal.OpenReadSegment(wal.SegmentName(h.oooWbl.Dir(), i))
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("open OOO WAL segment: %d", i))
@@ -738,7 +743,11 @@ func (h *Head) Init(minValidTime int64) error {
 			}
 			level.Info(h.logger).Log("msg", "OOO WAL segment loaded", "segment", i, "maxSegment", endAt)
 			h.updateWALReplayStatusRead(i)
+
+			fmt.Printf("Segment replay time:  %s\n", time.Since(segmentReplayStart))
 		}
+
+		fmt.Printf("Total replay time %s\n", time.Since(replayStart))
 	}
 
 	oooWalReplayDuration := time.Since(oooWalReplayStart)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -713,13 +713,14 @@ func (wp *oooWalSubsetProcessor) waitUntilIdle() {
 	default:
 	}
 	wp.input <- []record.RefSample{}
+	ticker := time.NewTicker(10 * time.Microsecond)
 	for len(wp.input) != 0 {
-		time.Sleep(10 * time.Microsecond)
 		select {
 		case <-wp.output: // Allow output side to drain to avoid deadlock.
-		default:
+		case <-ticker.C:
 		}
 	}
+	ticker.Stop()
 }
 
 const (

--- a/tsdb/head_wal_test.go
+++ b/tsdb/head_wal_test.go
@@ -1,0 +1,30 @@
+package tsdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOOOWBLReplayDuration(t *testing.T) {
+	dir := "/tmp/test-1-417626"
+
+	opts := DefaultOptions()
+	opts.OOOCapMin = 4
+	opts.OOOCapMax = 32
+	opts.OOOAllowance = 2 * time.Hour.Milliseconds()
+	opts.AllowOverlappingQueries = true
+	opts.AllowOverlappingCompaction = true
+
+	now := time.Now()
+
+	db, err := Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+	db.DisableCompactions()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	t.Logf("TSBB Open duration: %s", time.Since(now))
+}


### PR DESCRIPTION
Before everytime within the loop we would sleep for 10 microseconds, now
we're only sleeping if output has drained but there are still input
samples.

@ywwg came up with this idea in https://raintank-corp.slack.com/archives/C02ME6ZS2NQ/p1655390202442689?thread_ts=1655372958.069319&cid=C02ME6ZS2NQ