### PR TITLE
Enable changing OutOfOrderAllowance during runtime

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -314,14 +314,14 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.wal-compression", "Compress the tsdb WAL.").
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
-	serverOnlyFlag(a, "storage.tsdb.ooo-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. If the value is non-zero, then storage.tsdb.allow-overlapping-blocks will be set to true since out-of-order data can potentially overlap with other data.").
-		Hidden().Default("0s").SetValue(&cfg.tsdb.OOOAllowance)
+	serverOnlyFlag(a, "storage.tsdb.out-of-order-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. If the value is non-zero, then overlapping queries will be enabled (but not overlapping compaction) since out-of-order data can potentially overlap with other data.").
+		Default("0s").SetValue(&cfg.tsdb.OutOfOrderAllowance)
 
-	serverOnlyFlag(a, "storage.tsdb.ooo-cap-min", "Minimum capacity for OOO chunks (in samples. between 0 and 255.)").
-		Hidden().Default("4").IntVar(&cfg.tsdb.OOOCapMin)
+	serverOnlyFlag(a, "storage.tsdb.out-of-order-cap-min", "Minimum capacity for out of order chunks (in samples. between 0 and 255.)").
+		Hidden().Default("4").IntVar(&cfg.tsdb.OutOfOrderCapMin)
 
-	serverOnlyFlag(a, "storage.tsdb.ooo-cap-max", "Maximum capacity for OOO chunks (in samples. between 1 and 255.)").
-		Hidden().Default("32").IntVar(&cfg.tsdb.OOOCapMax)
+	serverOnlyFlag(a, "storage.tsdb.out-of-order-cap-max", "Maximum capacity for out of order chunks (in samples. between 1 and 255.)").
+		Hidden().Default("32").IntVar(&cfg.tsdb.OutOfOrderCapMax)
 
 	serverOnlyFlag(a, "storage.tsdb.head-chunks-write-queue-size", "Size of the queue through which head chunks are written to the disk to be m-mapped, 0 disables the queue completely. Experimental.").
 		Default("0").IntVar(&cfg.tsdb.HeadChunksWriteQueueSize)
@@ -1535,9 +1535,9 @@ type tsdbOptions struct {
 	StripeSize                     int
 	MinBlockDuration               model.Duration
 	MaxBlockDuration               model.Duration
-	OOOAllowance                   model.Duration
-	OOOCapMin                      int
-	OOOCapMax                      int
+	OutOfOrderAllowance            model.Duration
+	OutOfOrderCapMin               int
+	OutOfOrderCapMax               int
 	EnableExemplarStorage          bool
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
@@ -1560,9 +1560,9 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableExemplarStorage:          opts.EnableExemplarStorage,
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
-		OOOAllowance:                   int64(time.Duration(opts.OOOAllowance) / time.Millisecond),
-		OOOCapMin:                      int64(opts.OOOCapMin),
-		OOOCapMax:                      int64(opts.OOOCapMax),
+		OutOfOrderAllowance:            int64(time.Duration(opts.OutOfOrderAllowance) / time.Millisecond),
+		OutOfOrderCapMin:               int64(opts.OutOfOrderCapMin),
+		OutOfOrderCapMax:               int64(opts.OutOfOrderCapMax),
 	}
 }
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -314,9 +314,6 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.wal-compression", "Compress the tsdb WAL.").
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
-	serverOnlyFlag(a, "storage.tsdb.out-of-order-allowance", "Allow samples to be this old for out-of-order.  Supported units: h, m, s. If the value is non-zero, then overlapping queries will be enabled (but not overlapping compaction) since out-of-order data can potentially overlap with other data.").
-		Default("0s").SetValue(&cfg.tsdb.OutOfOrderAllowance)
-
 	serverOnlyFlag(a, "storage.tsdb.out-of-order-cap-min", "Minimum capacity for out of order chunks (in samples. between 0 and 255.)").
 		Hidden().Default("4").IntVar(&cfg.tsdb.OutOfOrderCapMin)
 
@@ -464,6 +461,9 @@ func main() {
 			cfgFile.StorageConfig.ExemplarsConfig = &config.DefaultExemplarsConfig
 		}
 		cfg.tsdb.MaxExemplars = int64(cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars)
+	}
+	if cfgFile.StorageConfig.TSDBConfig != nil {
+		cfg.tsdb.OutOfOrderAllowance = cfgFile.StorageConfig.TSDBConfig.OutOfOrderAllowance
 	}
 
 	// Now that the validity of the config is established, set the config

--- a/config/config.go
+++ b/config/config.go
@@ -501,7 +501,22 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 
 // StorageConfig configures runtime reloadable configuration options.
 type StorageConfig struct {
+	TSDBConfig      *TSDBConfig      `yaml:"tsdb,omitempty"`
 	ExemplarsConfig *ExemplarsConfig `yaml:"exemplars,omitempty"`
+}
+
+// TSDBConfig configures runtime reloadable configuration options.
+type TSDBConfig struct {
+	// OutOfOrderAllowance sets how long back in time an out-of-order sample can be inserted
+	// into the TSDB.
+	// OutOfOrderAllowance is a Duration only for convenience. TSDB will use OutOfOrderAllowance.Milliseconds()
+	// as the final value for the allowance. If you use milliseconds as the unit of time, then you can use
+	// the duration as an actual duration. But if you use some other unit for time, then you have to choose
+	// the duration whose .Milliseconds() will give you the desired value.
+	// For example, if your unit was in milliseconds, then setting this to '1s' does mean 1 second allowance.
+	// But if your time unit was in seconds, then setting this to '1s' means 1000 seconds allowance. So to get 1s
+	// allowance you will have to set it to '1ms' in this case.
+	OutOfOrderAllowance model.Duration `yaml:"out_of_order_allowance,omitempty"`
 }
 
 type TracingClientType string

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -989,7 +989,7 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 		if db.opts.WALSegmentSize > 0 {
 			segmentSize = db.opts.WALSegmentSize
 		}
-		oooWalDir := filepath.Join(db.dir, wal.OOOWblDirName)
+		oooWalDir := filepath.Join(db.dir, wal.WblDirName)
 		wblog, err = wal.NewSize(db.logger, db.registerer, oooWalDir, segmentSize, db.opts.WALCompression)
 		if err != nil {
 			return err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -671,6 +671,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.OutOfOrderCapMax <= 0 {
 		opts.OutOfOrderCapMax = DefaultOutOfOrderCapMax
 	}
+	if opts.OutOfOrderAllowance < 0 {
+		opts.OutOfOrderAllowance = 0
+	}
 
 	if len(rngs) == 0 {
 		// Start with smallest block duration and create exponential buckets until the exceed the
@@ -977,7 +980,7 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 	}
 
 	if oooAllowance < 0 {
-		return errors.Errorf("OOOAllowance invalid %d . must be >= 0", oooAllowance)
+		oooAllowance = 0
 	}
 
 	// Create WBL if it was not present and if OOO is enabled with WAL enabled.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -33,6 +33,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus/prometheus/config"
@@ -85,6 +86,8 @@ func DefaultOptions() *Options {
 		IsolationDisabled:          defaultIsolationDisabled,
 		HeadChunksEndTimeVariance:  0,
 		HeadChunksWriteQueueSize:   chunks.DefaultWriteQueueSize,
+		OutOfOrderCapMin:           DefaultOutOfOrderCapMin,
+		OutOfOrderCapMax:           DefaultOutOfOrderCapMax,
 	}
 }
 
@@ -119,6 +122,7 @@ type Options struct {
 	// Querying on overlapping blocks are allowed if AllowOverlappingQueries is true.
 	// Since querying is a required operation for TSDB, if there are going to be
 	// overlapping blocks, then this should be set to true.
+	// NOTE: Do not use this directly in DB. Use it via DB.AllowOverlappingQueries().
 	AllowOverlappingQueries bool
 
 	// Compaction of overlapping blocks are allowed if AllowOverlappingCompaction is true.
@@ -178,14 +182,18 @@ type Options struct {
 	// If nil, the cache won't be used.
 	SeriesHashCache *hashcache.SeriesHashCache
 
-	// how much out of order is allowed, if any.
-	OOOAllowance int64
+	// OutOfOrderAllowance specifies how much out of order is allowed, if any.
+	// This can change during run-time, so this value from here should only be used
+	// while initialising.
+	OutOfOrderAllowance int64
 
-	// minimum capacity for OOO chunks (in samples)
-	OOOCapMin int64
+	// OutOfOrderCapMin minimum capacity for OOO chunks (in samples).
+	// If it is <=0, the default value is assumed.
+	OutOfOrderCapMin int64
 
-	// maximum capacity for OOO chunks (in samples)
-	OOOCapMax int64
+	// OutOfOrderCapMax is maximum capacity for OOO chunks (in samples).
+	// If it is <=0, the default value is assumed.
+	OutOfOrderCapMax int64
 
 	// Temporary flag which we use to select whether we want to use the new or the old chunk disk mapper.
 	NewChunkDiskMapper bool
@@ -226,6 +234,13 @@ type DB struct {
 
 	// Cancel a running compaction when a shutdown is initiated.
 	compactCancel context.CancelFunc
+
+	// oooWasEnabled is true if out of order support was enabled at least one time
+	// during the time TSDB was up. In which case we need to keep supporting
+	// out-of-order compaction and vertical queries.
+	oooWasEnabled atomic.Bool
+
+	registerer prometheus.Registerer
 }
 
 type dbMetrics struct {
@@ -647,8 +662,14 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.MinBlockDuration > opts.MaxBlockDuration {
 		opts.MaxBlockDuration = opts.MinBlockDuration
 	}
-	if opts.OOOAllowance > 0 {
+	if opts.OutOfOrderAllowance > 0 {
 		opts.AllowOverlappingQueries = true
+	}
+	if opts.OutOfOrderCapMin <= 0 {
+		opts.OutOfOrderCapMin = DefaultOutOfOrderCapMin
+	}
+	if opts.OutOfOrderCapMax <= 0 {
+		opts.OutOfOrderCapMax = DefaultOutOfOrderCapMax
 	}
 
 	if len(rngs) == 0 {
@@ -717,6 +738,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		autoCompact:    true,
 		chunkPool:      chunkenc.NewPool(),
 		blocksToDelete: opts.BlocksToDelete,
+		registerer:     r,
 	}
 	defer func() {
 		// Close files if startup fails somewhere.
@@ -767,14 +789,14 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		if err != nil {
 			return nil, err
 		}
-		if opts.OOOAllowance > 0 {
+		if opts.OutOfOrderAllowance > 0 {
 			wblog, err = wal.NewSize(l, r, wblDir, segmentSize, opts.WALCompression)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
-
+	db.oooWasEnabled.Store(opts.OutOfOrderAllowance > 0)
 	headOpts := DefaultHeadOptions()
 	headOpts.ChunkRange = rngs[0]
 	headOpts.ChunkDirRoot = dir
@@ -787,9 +809,9 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.EnableExemplarStorage = opts.EnableExemplarStorage
 	headOpts.MaxExemplars.Store(opts.MaxExemplars)
 	headOpts.EnableMemorySnapshotOnShutdown = opts.EnableMemorySnapshotOnShutdown
-	headOpts.OOOAllowance = opts.OOOAllowance
-	headOpts.OOOCapMin = opts.OOOCapMin
-	headOpts.OOOCapMax = opts.OOOCapMax
+	headOpts.OutOfOrderAllowance.Store(opts.OutOfOrderAllowance)
+	headOpts.OutOfOrderCapMin.Store(opts.OutOfOrderCapMin)
+	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	headOpts.NewChunkDiskMapper = opts.NewChunkDiskMapper
 	if opts.IsolationDisabled {
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.
@@ -858,6 +880,48 @@ func removeBestEffortTmpDirs(l log.Logger, dir string) error {
 			level.Info(l).Log("msg", "Found and deleted tmp block dir", "dir", filepath.Join(dir, f.Name()))
 		}
 	}
+	return nil
+}
+
+// SetOutOfOrderAllowance updates the out-of-order allowance for the DB.
+// This method must not be called concurrently.
+// OOO enabled = oooAllowance > 0. OOO disabled = oooAllowance is 0.
+// 1) Before: OOO disabled, Now: OOO enabled =>
+//    * A new WBL is created for the head block.
+//    * OOO compaction is enabled.
+//    * Overlapping queries are enabled.
+// 2) Before: OOO enabled, Now: OOO enabled =>
+//    * Only the allowance is updated.
+// 3) Before: OOO enabled, Now: OOO disabled =>
+//    * Allowance set to 0. So no new OOO samples will be allowed.
+//    * OOO WBL will stay and follow the usual cleanup until a restart.
+//    * OOO Compaction and overlapping queries will remain enabled until a restart.
+// 4) Before: OOO disabled, Now: OOO disabled => no-op.
+func (db *DB) SetOutOfOrderAllowance(oooAllowance int64) (err error) {
+	if oooAllowance < 0 {
+		return errors.Errorf("OOOAllowance invalid %d . must be >= 0", oooAllowance)
+	}
+
+	// Create WBL if it was not present and if OOO is enabled with WAL enabled.
+	var oooWlog *wal.WAL
+	if !db.oooWasEnabled.Load() && oooAllowance > 0 && db.opts.WALSegmentSize >= 0 {
+		segmentSize := wal.DefaultSegmentSize
+		// Wal is set to a custom size.
+		if db.opts.WALSegmentSize > 0 {
+			segmentSize = db.opts.WALSegmentSize
+		}
+		oooWalDir := filepath.Join(db.dir, wal.OOOWblDirName)
+		oooWlog, err = wal.NewSize(db.logger, db.registerer, oooWalDir, segmentSize, db.opts.WALCompression)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !db.oooWasEnabled.Load() {
+		db.oooWasEnabled.Store(oooAllowance > 0)
+	}
+
+	db.head.SetOutOfOrderAllowance(oooAllowance, oooWlog)
 	return nil
 }
 
@@ -1063,7 +1127,7 @@ func (db *DB) CompactOOOHead() error {
 }
 
 func (db *DB) compactOOOHead() error {
-	if db.opts.OOOAllowance <= 0 {
+	if !db.oooWasEnabled.Load() {
 		return nil
 	}
 	oooHead, err := NewOOOCompactionHead(db.head)
@@ -1252,7 +1316,7 @@ func (db *DB) reloadBlocks() (err error) {
 	sort.Slice(toLoad, func(i, j int) bool {
 		return toLoad[i].Meta().MinTime < toLoad[j].Meta().MinTime
 	})
-	if !db.opts.AllowOverlappingQueries {
+	if !db.AllowOverlappingQueries() {
 		if err := validateBlockSequence(toLoad); err != nil {
 			return errors.Wrap(err, "invalid block sequence")
 		}
@@ -1280,6 +1344,10 @@ func (db *DB) reloadBlocks() (err error) {
 		return errors.Wrapf(err, "delete %v blocks", len(deletable))
 	}
 	return nil
+}
+
+func (db *DB) AllowOverlappingQueries() bool {
+	return db.opts.AllowOverlappingQueries || db.oooWasEnabled.Load()
 }
 
 func openBlocks(l log.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool, cache *hashcache.SeriesHashCache) (blocks []*Block, corrupted map[ulid.ULID]error, err error) {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -5023,7 +5023,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		verifySamples(t, db, allSamples)
 	})
 
-	t.Run("decrease allowance", func(t *testing.T) {
+	t.Run("decrease allowance and increase again", func(t *testing.T) {
 		var allSamples []tsdbutil.Sample
 		db := getDB(60 * time.Minute.Milliseconds())
 
@@ -5047,6 +5047,16 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Equal(t, oldWblPtr, newWblPtr)
 
 		verifySamples(t, db, allSamples)
+
+		// Increase allowance again and check
+		err = db.ApplyConfig(makeConfig(60))
+		require.NoError(t, err)
+		allSamples = addSamples(t, db, 261, 270, true, allSamples)
+		verifySamples(t, db, allSamples)
+
+		// WBL does not change.
+		newWblPtr = fmt.Sprintf("%p", db.head.wbl)
+		require.Equal(t, oldWblPtr, newWblPtr)
 
 		doOOOCompaction(t, db)
 		verifySamples(t, db, allSamples)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3442,9 +3442,9 @@ func TestOOOWALWrite(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 2
-	opts.OOOAllowance = 30 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 2
+	opts.OutOfOrderAllowance = 30 * time.Minute.Milliseconds()
 
 	db, err := Open(dir, nil, nil, opts, nil)
 	require.NoError(t, err)
@@ -3693,9 +3693,9 @@ func TestOOOCompaction(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 300 * time.Minute.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = true
 
@@ -3876,9 +3876,9 @@ func TestOOOCompactionWithNormalCompaction(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 300 * time.Minute.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = true
 
@@ -3974,9 +3974,9 @@ func TestOOOCompactionWithNormalCompaction(t *testing.T) {
 
 func Test_Querier_OOOQuery(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 24 * time.Hour.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 24 * time.Hour.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = false
 
@@ -4061,9 +4061,9 @@ func Test_Querier_OOOQuery(t *testing.T) {
 
 func Test_ChunkQuerier_OOOQuery(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 24 * time.Hour.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 24 * time.Hour.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = false
 
@@ -4156,9 +4156,9 @@ func Test_ChunkQuerier_OOOQuery(t *testing.T) {
 
 func TestOOOAppendAndQuery(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 4 * time.Hour.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 4 * time.Hour.Milliseconds()
 	opts.AllowOverlappingQueries = true
 
 	db := openTestDB(t, opts, nil)
@@ -4248,7 +4248,7 @@ func TestOOOAppendAndQuery(t *testing.T) {
 
 func TestOOODisabled(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOAllowance = 0
+	opts.OutOfOrderAllowance = 0
 	db := openTestDB(t, opts, nil)
 	db.DisableCompactions()
 	t.Cleanup(func() {
@@ -4314,9 +4314,9 @@ func TestOOODisabled(t *testing.T) {
 
 func TestWBLAndMmapReplay(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 4 * time.Hour.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 4 * time.Hour.Milliseconds()
 	opts.AllowOverlappingQueries = true
 
 	db := openTestDB(t, opts, nil)
@@ -4441,7 +4441,7 @@ func TestWBLAndMmapReplay(t *testing.T) {
 		resetWBLToOriginal()
 		resetMmapToOriginal()
 
-		opts.OOOCapMax = 60
+		opts.OutOfOrderCapMax = 60
 		db, err = Open(db.dir, nil, nil, opts, nil)
 		require.NoError(t, err)
 		testQuery(expSamples)
@@ -4451,7 +4451,7 @@ func TestWBLAndMmapReplay(t *testing.T) {
 	t.Run("Restart DB with WBL+Mmap while decreasing the OOOCapMax", func(t *testing.T) {
 		resetMmapToOriginal() // We need to reset because new duplicate chunks can be written above.
 
-		opts.OOOCapMax = 10
+		opts.OutOfOrderCapMax = 10
 		db, err = Open(db.dir, nil, nil, opts, nil)
 		require.NoError(t, err)
 		testQuery(expSamples)
@@ -4483,7 +4483,7 @@ func TestWBLAndMmapReplay(t *testing.T) {
 		require.NoError(t, os.RemoveAll(wblDir))
 		require.NoError(t, os.Rename(newWbl.Dir(), wblDir))
 
-		opts.OOOCapMax = 30
+		opts.OutOfOrderCapMax = 30
 		db, err = Open(db.dir, nil, nil, opts, nil)
 		require.NoError(t, err)
 		testQuery(expSamples)
@@ -4504,9 +4504,9 @@ func TestOOOCompactionFailure(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 300 * time.Minute.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = true
 
@@ -4646,9 +4646,9 @@ func TestWBLCorruption(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 30
+	opts.OutOfOrderAllowance = 300 * time.Minute.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = true
 
@@ -4793,9 +4793,9 @@ func TestOOOMmapCorruption(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := DefaultOptions()
-	opts.OOOCapMin = 2
-	opts.OOOCapMax = 10
-	opts.OOOAllowance = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 2
+	opts.OutOfOrderCapMax = 10
+	opts.OutOfOrderAllowance = 300 * time.Minute.Milliseconds()
 	opts.AllowOverlappingQueries = true
 	opts.AllowOverlappingCompaction = true
 
@@ -4913,4 +4913,213 @@ func TestOOOMmapCorruption(t *testing.T) {
 	db, err = Open(db.dir, nil, nil, opts, nil)
 	require.NoError(t, err)
 	verifySamples(allSamples)
+}
+
+func TestOutOfOrderRuntimeConfig(t *testing.T) {
+	getDB := func(oooAllowance int64) *DB {
+		dir := t.TempDir()
+
+		opts := DefaultOptions()
+		opts.OutOfOrderAllowance = oooAllowance
+
+		db, err := Open(dir, nil, nil, opts, nil)
+		require.NoError(t, err)
+		db.DisableCompactions()
+		t.Cleanup(func() {
+			require.NoError(t, db.Close())
+		})
+
+		return db
+	}
+
+	series1 := labels.FromStrings("foo", "bar1")
+	addSamples := func(t *testing.T, db *DB, fromMins, toMins int64, success bool, allSamples []tsdbutil.Sample) []tsdbutil.Sample {
+		app := db.Appender(context.Background())
+		for min := fromMins; min <= toMins; min++ {
+			ts := min * time.Minute.Milliseconds()
+			_, err := app.Append(0, series1, ts, float64(ts))
+			if success {
+				require.NoError(t, err)
+				allSamples = append(allSamples, sample{t: ts, v: float64(ts)})
+			} else {
+				require.Error(t, err)
+			}
+		}
+		require.NoError(t, app.Commit())
+		return allSamples
+	}
+
+	verifySamples := func(t *testing.T, db *DB, expSamples []tsdbutil.Sample) {
+		sort.Slice(expSamples, func(i, j int) bool {
+			return expSamples[i].T() < expSamples[j].T()
+		})
+
+		expRes := map[string][]tsdbutil.Sample{
+			series1.String(): expSamples,
+		}
+
+		q, err := db.Querier(context.Background(), math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+
+		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
+		require.Equal(t, expRes, actRes)
+	}
+
+	doOOOCompaction := func(t *testing.T, db *DB) {
+		// WBL is not empty.
+		size, err := db.head.oooWbl.Size()
+		require.NoError(t, err)
+		require.Greater(t, size, int64(0))
+
+		require.Len(t, db.Blocks(), 0)
+		require.NoError(t, db.compactOOOHead())
+		require.Greater(t, len(db.Blocks()), 0)
+
+		// WBL is empty.
+		size, err = db.head.oooWbl.Size()
+		require.NoError(t, err)
+		require.Equal(t, int64(0), size)
+	}
+
+	t.Run("increase allowance", func(t *testing.T) {
+		var allSamples []tsdbutil.Sample
+		db := getDB(30 * time.Minute.Milliseconds())
+
+		// In-order.
+		allSamples = addSamples(t, db, 300, 310, true, allSamples)
+
+		// OOO upto 30m old is success.
+		allSamples = addSamples(t, db, 281, 290, true, allSamples)
+
+		// OOO of 59m old fails.
+		s := addSamples(t, db, 251, 260, false, nil)
+		require.Len(t, s, 0)
+		verifySamples(t, db, allSamples)
+
+		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+
+		// Increase allowance and try adding again.
+		err := db.SetOutOfOrderAllowance(60 * time.Minute.Milliseconds())
+		require.NoError(t, err)
+		allSamples = addSamples(t, db, 251, 260, true, allSamples)
+
+		// WBL does not change.
+		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		require.Equal(t, oldWblPtr, newWblPtr)
+
+		doOOOCompaction(t, db)
+		verifySamples(t, db, allSamples)
+	})
+
+	t.Run("decrease allowance", func(t *testing.T) {
+		var allSamples []tsdbutil.Sample
+		db := getDB(60 * time.Minute.Milliseconds())
+
+		// In-order.
+		allSamples = addSamples(t, db, 300, 310, true, allSamples)
+
+		// OOO upto 59m old is success.
+		allSamples = addSamples(t, db, 251, 260, true, allSamples)
+
+		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		// Decrease allowance.
+		err := db.SetOutOfOrderAllowance(30 * time.Minute.Milliseconds())
+		require.NoError(t, err)
+
+		// OOO of 49m old fails.
+		s := addSamples(t, db, 261, 270, false, nil)
+		require.Len(t, s, 0)
+
+		// WBL does not change.
+		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		require.Equal(t, oldWblPtr, newWblPtr)
+
+		verifySamples(t, db, allSamples)
+
+		doOOOCompaction(t, db)
+		verifySamples(t, db, allSamples)
+	})
+
+	t.Run("disabled to enabled", func(t *testing.T) {
+		var allSamples []tsdbutil.Sample
+		db := getDB(0)
+
+		// In-order.
+		allSamples = addSamples(t, db, 300, 310, true, allSamples)
+
+		// OOO fails.
+		s := addSamples(t, db, 251, 260, false, nil)
+		require.Len(t, s, 0)
+		verifySamples(t, db, allSamples)
+
+		require.Nil(t, db.head.oooWbl)
+
+		// Increase allowance and try adding again.
+		err := db.SetOutOfOrderAllowance(60 * time.Minute.Milliseconds())
+		require.NoError(t, err)
+		allSamples = addSamples(t, db, 251, 260, true, allSamples)
+
+		// WBL gets created.
+		require.NotNil(t, db.head.oooWbl)
+
+		verifySamples(t, db, allSamples)
+
+		// OOO compaction works now.
+		doOOOCompaction(t, db)
+		verifySamples(t, db, allSamples)
+	})
+
+	t.Run("enabled to disabled", func(t *testing.T) {
+		var allSamples []tsdbutil.Sample
+		db := getDB(60 * time.Minute.Milliseconds())
+
+		// In-order.
+		allSamples = addSamples(t, db, 300, 310, true, allSamples)
+
+		// OOO upto 59m old is success.
+		allSamples = addSamples(t, db, 251, 260, true, allSamples)
+
+		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		// Allowance to 0, hence disabled.
+		err := db.SetOutOfOrderAllowance(0)
+		require.NoError(t, err)
+
+		// OOO within old allowance fails.
+		s := addSamples(t, db, 290, 309, false, nil)
+		require.Len(t, s, 0)
+
+		// WBL does not change and is not removed.
+		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		require.Equal(t, oldWblPtr, newWblPtr)
+
+		verifySamples(t, db, allSamples)
+
+		// Compaction still works after disabling with WBL cleanup.
+		doOOOCompaction(t, db)
+		verifySamples(t, db, allSamples)
+	})
+
+	t.Run("disabled to disabled", func(t *testing.T) {
+		var allSamples []tsdbutil.Sample
+		db := getDB(0)
+
+		// In-order.
+		allSamples = addSamples(t, db, 300, 310, true, allSamples)
+
+		// OOO fails.
+		s := addSamples(t, db, 290, 309, false, nil)
+		require.Len(t, s, 0)
+		verifySamples(t, db, allSamples)
+		require.Nil(t, db.head.oooWbl)
+
+		// Allowance to 0.
+		err := db.SetOutOfOrderAllowance(0)
+		require.NoError(t, err)
+
+		// OOO still fails.
+		s = addSamples(t, db, 290, 309, false, nil)
+		require.Len(t, s, 0)
+		verifySamples(t, db, allSamples)
+		require.Nil(t, db.head.oooWbl)
+	})
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4979,7 +4979,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 
 	doOOOCompaction := func(t *testing.T, db *DB) {
 		// WBL is not empty.
-		size, err := db.head.oooWbl.Size()
+		size, err := db.head.wbl.Size()
 		require.NoError(t, err)
 		require.Greater(t, size, int64(0))
 
@@ -4988,7 +4988,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Greater(t, len(db.Blocks()), 0)
 
 		// WBL is empty.
-		size, err = db.head.oooWbl.Size()
+		size, err = db.head.wbl.Size()
 		require.NoError(t, err)
 		require.Equal(t, int64(0), size)
 	}
@@ -5008,7 +5008,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Len(t, s, 0)
 		verifySamples(t, db, allSamples)
 
-		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		oldWblPtr := fmt.Sprintf("%p", db.head.wbl)
 
 		// Increase allowance and try adding again.
 		err := db.ApplyConfig(makeConfig(60))
@@ -5016,7 +5016,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		allSamples = addSamples(t, db, 251, 260, true, allSamples)
 
 		// WBL does not change.
-		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		newWblPtr := fmt.Sprintf("%p", db.head.wbl)
 		require.Equal(t, oldWblPtr, newWblPtr)
 
 		doOOOCompaction(t, db)
@@ -5033,7 +5033,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		// OOO upto 59m old is success.
 		allSamples = addSamples(t, db, 251, 260, true, allSamples)
 
-		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		oldWblPtr := fmt.Sprintf("%p", db.head.wbl)
 		// Decrease allowance.
 		err := db.ApplyConfig(makeConfig(30))
 		require.NoError(t, err)
@@ -5043,7 +5043,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Len(t, s, 0)
 
 		// WBL does not change.
-		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		newWblPtr := fmt.Sprintf("%p", db.head.wbl)
 		require.Equal(t, oldWblPtr, newWblPtr)
 
 		verifySamples(t, db, allSamples)
@@ -5064,7 +5064,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Len(t, s, 0)
 		verifySamples(t, db, allSamples)
 
-		require.Nil(t, db.head.oooWbl)
+		require.Nil(t, db.head.wbl)
 
 		// Increase allowance and try adding again.
 		err := db.ApplyConfig(makeConfig(60))
@@ -5072,7 +5072,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		allSamples = addSamples(t, db, 251, 260, true, allSamples)
 
 		// WBL gets created.
-		require.NotNil(t, db.head.oooWbl)
+		require.NotNil(t, db.head.wbl)
 
 		verifySamples(t, db, allSamples)
 
@@ -5091,7 +5091,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		// OOO upto 59m old is success.
 		allSamples = addSamples(t, db, 251, 260, true, allSamples)
 
-		oldWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		oldWblPtr := fmt.Sprintf("%p", db.head.wbl)
 		// Allowance to 0, hence disabled.
 		err := db.ApplyConfig(makeConfig(0))
 		require.NoError(t, err)
@@ -5101,7 +5101,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		require.Len(t, s, 0)
 
 		// WBL does not change and is not removed.
-		newWblPtr := fmt.Sprintf("%p", db.head.oooWbl)
+		newWblPtr := fmt.Sprintf("%p", db.head.wbl)
 		require.Equal(t, oldWblPtr, newWblPtr)
 
 		verifySamples(t, db, allSamples)
@@ -5122,7 +5122,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		s := addSamples(t, db, 290, 309, false, nil)
 		require.Len(t, s, 0)
 		verifySamples(t, db, allSamples)
-		require.Nil(t, db.head.oooWbl)
+		require.Nil(t, db.head.wbl)
 
 		// Allowance to 0.
 		err := db.ApplyConfig(makeConfig(0))
@@ -5132,6 +5132,6 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		s = addSamples(t, db, 290, 309, false, nil)
 		require.Len(t, s, 0)
 		verifySamples(t, db, allSamples)
-		require.Nil(t, db.head.oooWbl)
+		require.Nil(t, db.head.wbl)
 	})
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -913,14 +913,13 @@ func (h *Head) ApplyConfig(cfg *config.Config, wbl *wal.WAL) {
 
 	migrated := h.exemplars.(*CircularExemplarStorage).Resize(newSize)
 	level.Info(h.logger).Log("msg", "Exemplar storage resized", "from", prevSize, "to", newSize, "migrated", migrated)
-	return
 }
 
 // SetOutOfOrderAllowance updates the out of order related parameters.
-// If the Head already has a WBL set, then the oooWbl will be ignored.
-func (h *Head) SetOutOfOrderAllowance(oooAllowance int64, oooWbl *wal.WAL) {
-	if oooAllowance > 0 && h.oooWbl == nil {
-		h.oooWbl = oooWbl
+// If the Head already has a WBL set, then the wbl will be ignored.
+func (h *Head) SetOutOfOrderAllowance(oooAllowance int64, wbl *wal.WAL) {
+	if oooAllowance > 0 && h.wbl == nil {
+		h.wbl = wbl
 	}
 
 	h.opts.OutOfOrderAllowance.Store(oooAllowance)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -215,7 +215,7 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal, wbl *wal.WAL, opts *Hea
 	}
 
 	if opts.OutOfOrderAllowance.Load() < 0 {
-		return nil, errors.Errorf("OOOAllowance invalid %d . must be >= 0", opts.OutOfOrderAllowance.Load())
+		opts.OutOfOrderAllowance.Store(0)
 	}
 
 	// Allowance can be set on runtime. So the capMin and capMax should be valid
@@ -892,6 +892,9 @@ func (h *Head) ApplyConfig(cfg *config.Config, wbl *wal.WAL) {
 		// But if your time unit was in seconds, then setting this to '1s' means 1000 seconds allowance. So to get 1s
 		// allowance you will have to set it to '1ms' in this case.
 		oooAllowance = time.Duration(cfg.StorageConfig.TSDBConfig.OutOfOrderAllowance).Milliseconds()
+	}
+	if oooAllowance < 0 {
+		oooAllowance = 0
 	}
 
 	h.SetOutOfOrderAllowance(oooAllowance, wbl)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -253,7 +253,8 @@ type headAppender struct {
 func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	// For OOO inserts, this restriction is irrelevant and will be checked later once we confirm the sample is an in-order append.
 	// If OOO inserts are disabled, we may as well as check this as early as we can and avoid more work.
-	if a.head.opts.OOOAllowance == 0 && t < a.minValidTime {
+	oooAllowance := a.head.opts.OutOfOrderAllowance.Load()
+	if oooAllowance == 0 && t < a.minValidTime {
 		a.head.metrics.outOfBoundSamples.Inc()
 		return 0, storage.ErrOutOfBounds
 	}
@@ -287,7 +288,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	s.Lock()
 	// TODO: if we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
-	_, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime)
+	_, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, oooAllowance)
 	if err == nil {
 		s.pendingCommit = true
 	}
@@ -324,7 +325,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 // appendable checks whether the given sample is valid for appending to the series. (if we return false and no error)
 // The sample belongs to the out of order chunk if we return true and no error.
 // An error signifies the sample cannot be handled.
-func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime int64) (isOutOfOrder bool, delta int64, err error) {
+func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooAllowance int64) (isOutOfOrder bool, delta int64, err error) {
 	msMaxt := s.maxTime()
 	if msMaxt == math.MinInt64 {
 		// The series has no sample and was freshly created.
@@ -343,8 +344,8 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime int64)
 		return false, 0, nil
 	}
 
-	if t < msMaxt-s.oooAllowance {
-		if s.oooAllowance > 0 {
+	if t < msMaxt-oooAllowance {
+		if oooAllowance > 0 {
 			return true, msMaxt - t, storage.ErrTooOldSample
 		}
 		if t < minValidTime {
@@ -553,11 +554,12 @@ func (a *headAppender) Commit() (err error) {
 		oooWblSamples = nil
 		oooMmapMarkers = nil
 	}
+	oooAllowance := a.head.opts.OutOfOrderAllowance.Load()
 	for i, s := range a.samples {
 		series = a.sampleSeries[i]
 		series.Lock()
 
-		oooSample, delta, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime)
+		oooSample, delta, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, oooAllowance)
 		switch err {
 		case storage.ErrOutOfOrderSample:
 			samplesAppended--

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -511,7 +511,7 @@ func (a *headAppender) Commit() (err error) {
 		inOrderMaxt     int64 = math.MinInt64
 		ooomint         int64 = math.MaxInt64
 		ooomaxt         int64 = math.MinInt64
-		oooWblSamples   []record.RefSample
+		wblSamples      []record.RefSample
 		oooMmapMarkers  map[chunks.HeadSeriesRef]chunks.ChunkDiskMapperRef
 		oooRecords      [][]byte
 		series          *memSeries
@@ -525,7 +525,7 @@ func (a *headAppender) Commit() (err error) {
 	collectOOORecords := func() {
 		if a.head.wbl == nil {
 			// WBL is not enabled. So no need to collect.
-			oooWblSamples = nil
+			wblSamples = nil
 			oooMmapMarkers = nil
 			return
 		}
@@ -546,12 +546,12 @@ func (a *headAppender) Commit() (err error) {
 			oooRecords = append(oooRecords, r)
 		}
 
-		if len(oooWblSamples) > 0 {
-			r := enc.Samples(oooWblSamples, a.head.getBytesBuffer())
+		if len(wblSamples) > 0 {
+			r := enc.Samples(wblSamples, a.head.getBytesBuffer())
 			oooRecords = append(oooRecords, r)
 		}
 
-		oooWblSamples = nil
+		wblSamples = nil
 		oooMmapMarkers = nil
 	}
 	oooAllowance := a.head.opts.OutOfOrderAllowance.Load()
@@ -601,7 +601,7 @@ func (a *headAppender) Commit() (err error) {
 				oooMmapMarkers[series.ref] = mmapRef
 			}
 			if ok {
-				oooWblSamples = append(oooWblSamples, s)
+				wblSamples = append(wblSamples, s)
 				if s.T < ooomint {
 					ooomint = s.T
 				}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -223,7 +223,7 @@ func BenchmarkLoadWAL(b *testing.B) {
 						for k := 0; k < c.batches*c.seriesPerBatch; k++ {
 							// Create one mmapped chunk per series, with one sample at the given time.
 							lbls := labels.Labels{}
-							s := newMemSeries(lbls, chunks.HeadSeriesRef(k)*101, lbls.Hash(), c.mmappedChunkT, 0, 0, 1, 0, nil, defaultIsolationDisabled)
+							s := newMemSeries(lbls, chunks.HeadSeriesRef(k)*101, lbls.Hash(), c.mmappedChunkT, 0, 1, 0, nil, defaultIsolationDisabled)
 							s.append(c.mmappedChunkT, 42, 0, chunkDiskMapper)
 							s.mmapCurrentHeadChunk(chunkDiskMapper)
 						}
@@ -733,7 +733,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	}
 
 	lbls := labels.FromStrings("a", "b")
-	s := newMemSeries(lbls, 1, lbls.Hash(), 2000, 0, 0, 1, 0, &memChunkPool, defaultIsolationDisabled)
+	s := newMemSeries(lbls, 1, lbls.Hash(), 2000, 0, 1, 0, &memChunkPool, defaultIsolationDisabled)
 
 	for i := 0; i < 4000; i += 5 {
 		_, ok, _ := s.append(int64(i), float64(i), 0, chunkDiskMapper)
@@ -1269,7 +1269,7 @@ func TestMemSeries_append(t *testing.T) {
 	}()
 
 	lbls := labels.Labels{}
-	s := newMemSeries(lbls, 1, lbls.Hash(), 500, 0, 0, 1, 0, nil, defaultIsolationDisabled)
+	s := newMemSeries(lbls, 1, lbls.Hash(), 500, 0, 1, 0, nil, defaultIsolationDisabled)
 
 	// Add first two samples at the very end of a chunk range and the next two
 	// on and after it.
@@ -1324,7 +1324,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	})
 
 	lbls := labels.Labels{}
-	s := newMemSeries(lbls, 1, lbls.Hash(), DefaultBlockDuration, 0, 0, 0, 0, nil, defaultIsolationDisabled)
+	s := newMemSeries(lbls, 1, lbls.Hash(), DefaultBlockDuration, 0, 0, 0, nil, defaultIsolationDisabled)
 
 	// At this slow rate, we will fill the chunk in two block durations.
 	slowRate := (DefaultBlockDuration * 2) / samplesPerChunk
@@ -2561,7 +2561,7 @@ func TestMemSafeIteratorSeekIntoBuffer(t *testing.T) {
 	}()
 
 	lbls := labels.Labels{}
-	s := newMemSeries(lbls, 1, lbls.Hash(), 500, 0, 0, 1, 0, nil, defaultIsolationDisabled)
+	s := newMemSeries(lbls, 1, lbls.Hash(), 500, 0, 1, 0, nil, defaultIsolationDisabled)
 
 	for i := 0; i < 7; i++ {
 		_, ok, _ := s.append(int64(i), float64(i), 0, chunkDiskMapper)
@@ -3249,7 +3249,7 @@ func TestOOOWalReplay(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = dir
-	opts.OOOAllowance = 30 * time.Minute.Milliseconds()
+	opts.OutOfOrderAllowance.Store(30 * time.Minute.Milliseconds())
 
 	h, err := NewHead(nil, nil, wlog, oooWlog, opts, nil)
 	require.NoError(t, err)
@@ -3333,8 +3333,8 @@ func TestOOOMmapReplay(t *testing.T) {
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
 	opts.ChunkDirRoot = dir
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 1000 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMax.Store(30)
+	opts.OutOfOrderAllowance.Store(1000 * time.Minute.Milliseconds())
 
 	h, err := NewHead(nil, nil, wlog, oooWlog, opts, nil)
 	require.NoError(t, err)
@@ -3625,8 +3625,8 @@ func TestOOOAppendWithNoSeries(t *testing.T) {
 
 	opts := DefaultHeadOptions()
 	opts.ChunkDirRoot = dir
-	opts.OOOCapMax = 30
-	opts.OOOAllowance = 120 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMax.Store(30)
+	opts.OutOfOrderAllowance.Store(120 * time.Minute.Milliseconds())
 
 	h, err := NewHead(nil, nil, wlog, oooWlog, opts, nil)
 	require.NoError(t, err)

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -362,9 +362,9 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 // an OOOHeadChunkReader to read chunks from it.
 func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 1
-	opts.OOOCapMax = 5
-	opts.OOOAllowance = 120 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 1
+	opts.OutOfOrderCapMax = 5
+	opts.OutOfOrderAllowance = 120 * time.Minute.Milliseconds()
 
 	s1 := labels.FromStrings("l", "v1")
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
@@ -770,9 +770,9 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 // - A == B
 func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(t *testing.T) {
 	opts := DefaultOptions()
-	opts.OOOCapMin = 1
-	opts.OOOCapMax = 5
-	opts.OOOAllowance = 120 * time.Minute.Milliseconds()
+	opts.OutOfOrderCapMin = 1
+	opts.OutOfOrderCapMax = 5
+	opts.OutOfOrderAllowance = 120 * time.Minute.Milliseconds()
 
 	s1 := labels.FromStrings("l", "v1")
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }


### PR DESCRIPTION
To keep the logic simple, this is how the behaviour is for this feature (copy paste of comments):

```
// SetOutOfOrderAllowance updates the out-of-order allowance for the DB.
// This method must not be called concurrently.
// OOO enabled = oooAllowance > 0. OOO disabled = oooAllowance is 0.
// 1) Before: OOO disabled, Now: OOO enabled =>
//    * A new WBL is created for the head block.
//    * OOO compaction is enabled.
//    * Overlapping queries are enabled.
// 2) Before: OOO enabled, Now: OOO enabled =>
//    * Only the allowance is updated.
// 3) Before: OOO enabled, Now: OOO disabled =>
//    * Allowance set to 0. So no new OOO samples will be allowed.
//    * OOO WBL will stay and follow the usual cleanup until a restart.
//    * OOO Compaction and overlapping queries will remain enabled until a restart.
// 4) Before: OOO disabled, Now: OOO disabled => no-op.
```

I also expanded the "ooo" in the flag and DB/Head options since they are more user facing.