### PR TITLE
Remove the hack in config for OutOfOrderAllowance

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1535,7 +1535,7 @@ type tsdbOptions struct {
 	StripeSize                     int
 	MinBlockDuration               model.Duration
 	MaxBlockDuration               model.Duration
-	OutOfOrderAllowance            model.Duration
+	OutOfOrderAllowance            int64
 	OutOfOrderCapMin               int
 	OutOfOrderCapMax               int
 	EnableExemplarStorage          bool
@@ -1560,7 +1560,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableExemplarStorage:          opts.EnableExemplarStorage,
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
-		OutOfOrderAllowance:            int64(time.Duration(opts.OutOfOrderAllowance) / time.Millisecond),
+		OutOfOrderAllowance:            opts.OutOfOrderAllowance,
 		OutOfOrderCapMin:               int64(opts.OutOfOrderCapMin),
 		OutOfOrderCapMax:               int64(opts.OutOfOrderCapMax),
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -969,16 +969,8 @@ func (db *DB) Appender(ctx context.Context) storage.Appender {
 func (db *DB) ApplyConfig(conf *config.Config) error {
 	oooAllowance := int64(0)
 	if conf.StorageConfig.TSDBConfig != nil {
-		// OutOfOrderAllowance is a Duration only for convenience. TSDB will use OutOfOrderAllowance.Milliseconds()
-		// as the final value for the allowance. If you use milliseconds as the unit of time, then you can use
-		// the duration as an actual duration. But if you use some other unit for time, then you have to choose
-		// the duration whose .Milliseconds() will give you the desired value.
-		// For example, if your unit was in milliseconds, then setting this to '1s' does mean 1 second allowance.
-		// But if your time unit was in seconds, then setting this to '1s' means 1000 seconds allowance. So to get 1s
-		// allowance you will have to set it to '1ms' in this case.
-		oooAllowance = time.Duration(conf.StorageConfig.TSDBConfig.OutOfOrderAllowance).Milliseconds()
+		oooAllowance = conf.StorageConfig.TSDBConfig.OutOfOrderAllowance
 	}
-
 	if oooAllowance < 0 {
 		oooAllowance = 0
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -4938,7 +4937,7 @@ func TestOutOfOrderRuntimeConfig(t *testing.T) {
 		return &config.Config{
 			StorageConfig: config.StorageConfig{
 				TSDBConfig: &config.TSDBConfig{
-					OutOfOrderAllowance: model.Duration(time.Duration(oooAllowanceMins) * time.Minute),
+					OutOfOrderAllowance: int64(oooAllowanceMins) * time.Minute.Milliseconds(),
 				},
 			},
 		}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -884,14 +884,7 @@ func (h *Head) removeCorruptedMmappedChunks(err error) (map[chunks.HeadSeriesRef
 func (h *Head) ApplyConfig(cfg *config.Config, wbl *wal.WAL) {
 	oooAllowance := int64(0)
 	if cfg.StorageConfig.TSDBConfig != nil {
-		// OutOfOrderAllowance is a Duration only for convenience. TSDB will use OutOfOrderAllowance.Milliseconds()
-		// as the final value for the allowance. If you use milliseconds as the unit of time, then you can use
-		// the duration as an actual duration. But if you use some other unit for time, then you have to choose
-		// the duration whose .Milliseconds() will give you the desired value.
-		// For example, if your unit was in milliseconds, then setting this to '1s' does mean 1 second allowance.
-		// But if your time unit was in seconds, then setting this to '1s' means 1000 seconds allowance. So to get 1s
-		// allowance you will have to set it to '1ms' in this case.
-		oooAllowance = time.Duration(cfg.StorageConfig.TSDBConfig.OutOfOrderAllowance).Milliseconds()
+		oooAllowance = cfg.StorageConfig.TSDBConfig.OutOfOrderAllowance
 	}
 	if oooAllowance < 0 {
 		oooAllowance = 0


### PR DESCRIPTION
Removes the confusion over how the .Milliseconds() in the TSDB is used for OutOfOrderAllowance