### PR TITLE
Simplify how OutOfOrderTimeWindow works

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -314,12 +314,6 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.wal-compression", "Compress the tsdb WAL.").
 		Hidden().Default("true").BoolVar(&cfg.tsdb.WALCompression)
 
-	serverOnlyFlag(a, "storage.tsdb.out-of-order-cap-min", "Minimum capacity for out of order chunks (in samples. between 0 and 255.)").
-		Hidden().Default("4").IntVar(&cfg.tsdb.OutOfOrderCapMin)
-
-	serverOnlyFlag(a, "storage.tsdb.out-of-order-cap-max", "Maximum capacity for out of order chunks (in samples. between 1 and 255.)").
-		Hidden().Default("32").IntVar(&cfg.tsdb.OutOfOrderCapMax)
-
 	serverOnlyFlag(a, "storage.tsdb.head-chunks-write-queue-size", "Size of the queue through which head chunks are written to the disk to be m-mapped, 0 disables the queue completely. Experimental.").
 		Default("0").IntVar(&cfg.tsdb.HeadChunksWriteQueueSize)
 
@@ -1536,8 +1530,6 @@ type tsdbOptions struct {
 	MinBlockDuration               model.Duration
 	MaxBlockDuration               model.Duration
 	OutOfOrderTimeWindow           int64
-	OutOfOrderCapMin               int
-	OutOfOrderCapMax               int
 	EnableExemplarStorage          bool
 	MaxExemplars                   int64
 	EnableMemorySnapshotOnShutdown bool
@@ -1561,8 +1553,6 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		MaxExemplars:                   opts.MaxExemplars,
 		EnableMemorySnapshotOnShutdown: opts.EnableMemorySnapshotOnShutdown,
 		OutOfOrderTimeWindow:           opts.OutOfOrderTimeWindow,
-		OutOfOrderCapMin:               int64(opts.OutOfOrderCapMin),
-		OutOfOrderCapMax:               int64(opts.OutOfOrderCapMax),
 	}
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -671,6 +671,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.OutOfOrderCapMax <= 0 {
 		opts.OutOfOrderCapMax = DefaultOutOfOrderCapMax
 	}
+	if opts.OutOfOrderCapMin > opts.OutOfOrderCapMax {
+		opts.OutOfOrderCapMax = opts.OutOfOrderCapMin
+	}
 	if opts.OutOfOrderTimeWindow < 0 {
 		opts.OutOfOrderTimeWindow = 0
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4261,8 +4261,18 @@ func TestOOOAppendAndQuery(t *testing.T) {
 
 	// At the edge of time window, also it would be "out of bound" without the ooo support.
 	addSample(s1, 60, 65, false)
-	addSample(s2, 50, 55, false)
-	verifyOOOMinMaxTimes(50, 265)
+	verifyOOOMinMaxTimes(60, 265)
+	testQuery()
+
+	// This sample is not within the time window w.r.t. the head's maxt, but it is within the window
+	// w.r.t. the series' maxt. But we consider only head's maxt.
+	addSample(s2, 59, 59, true)
+	verifyOOOMinMaxTimes(60, 265)
+	testQuery()
+
+	// Now the sample is within time window w.r.t. the head's maxt.
+	addSample(s2, 60, 65, false)
+	verifyOOOMinMaxTimes(60, 265)
 	testQuery()
 
 	// Out of time window again.
@@ -4276,7 +4286,7 @@ func TestOOOAppendAndQuery(t *testing.T) {
 	require.Equal(t, float64(4), prom_testutil.ToFloat64(db.head.metrics.chunksCreated))
 	addSample(s1, 180, 249, false)
 	require.Equal(t, float64(6), prom_testutil.ToFloat64(db.head.metrics.chunksCreated))
-	verifyOOOMinMaxTimes(50, 265)
+	verifyOOOMinMaxTimes(60, 265)
 	testQuery()
 }
 


### PR DESCRIPTION
This PR tries to simplify the logic around working of the `OutOfOrderTimeWindow`.

Current logic: If there is a series, time window is w.r.t. series' maxt. If the series does not exist, then it is w.r.t. the head's maxt. Problems with this is described in more detail in https://github.com/grafana/mimir-prometheus/issues/284

New solution: out of order time window now will always be taken w.r.t. the head's maxt. Making the logic as "if the sample cannot go in as in-order sample, then it should be within OutOfOrderTimeWindow from TSDB's maxt to inside out-of-order chunk".

This simple of logic of pinning it to a single time (i.e. head's maxt) will also make work with caches easier.


(This PR also removes 2 flags that are not required at Prometheus level)