### PR TITLE
Do not warn on finding overlapping blocks, debug instead

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1341,7 +1341,7 @@ func (db *DB) reloadBlocks() (err error) {
 		blockMetas = append(blockMetas, b.Meta())
 	}
 	if overlaps := OverlappingBlocks(blockMetas); len(overlaps) > 0 {
-		level.Warn(db.logger).Log("msg", "Overlapping blocks found during reloadBlocks", "detail", overlaps.String())
+		level.Debug(db.logger).Log("msg", "Overlapping blocks found during reloadBlocks", "detail", overlaps.String())
 	}
 
 	// Append blocks to old, deletable blocks, so we can close them.


### PR DESCRIPTION
It is a lot of noise now that we expect overlapping blocks everytime there is out of order enabled.