### PR TITLE
Prevent panic with ApplyConfig

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -980,7 +980,10 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 	// Create WBL if it was not present and if OOO is enabled with WAL enabled.
 	var wblog *wal.WAL
 	var err error
-	if !db.oooWasEnabled.Load() && oooTimeWindow > 0 && db.opts.WALSegmentSize >= 0 {
+	if db.head.wbl != nil {
+		// The existing WBL from the disk might have been replayed while OOO was disabled.
+		wblog = db.head.wbl
+	} else if !db.oooWasEnabled.Load() && oooTimeWindow > 0 && db.opts.WALSegmentSize >= 0 {
 		segmentSize := wal.DefaultSegmentSize
 		// Wal is set to a custom size.
 		if db.opts.WALSegmentSize > 0 {


### PR DESCRIPTION
We now replay WBL even if OOO is disabled, in which case WBL might be already initialised. This was not accounted for in ApplyConfig.