### PR TITLE
Fix OOO Head LabelValues and PostingsForMatchers

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4196,7 +4196,7 @@ func TestOOOAppendAndQuery(t *testing.T) {
 	s2 := labels.FromStrings("foo", "bar2")
 
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
-	expSamples := make(map[string][]tsdbutil.Sample)
+	appendedSamples := make(map[string][]tsdbutil.Sample)
 	totalSamples := 0
 	addSample := func(lbls labels.Labels, fromMins, toMins int64, faceError bool) {
 		app := db.Appender(context.Background())
@@ -4209,7 +4209,7 @@ func TestOOOAppendAndQuery(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				expSamples[key] = append(expSamples[key], sample{t: min, v: val})
+				appendedSamples[key] = append(appendedSamples[key], sample{t: min, v: val})
 				totalSamples++
 			}
 		}
@@ -4220,17 +4220,30 @@ func TestOOOAppendAndQuery(t *testing.T) {
 		}
 	}
 
-	testQuery := func() {
-		querier, err := db.Querier(context.TODO(), math.MinInt64, math.MaxInt64)
+	testQuery := func(from, to int64) {
+		querier, err := db.Querier(context.TODO(), from, to)
 		require.NoError(t, err)
 
 		seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar."))
 
-		for k, v := range expSamples {
+		for k, v := range appendedSamples {
 			sort.Slice(v, func(i, j int) bool {
 				return v[i].T() < v[j].T()
 			})
-			expSamples[k] = v
+			appendedSamples[k] = v
+		}
+
+		expSamples := make(map[string][]tsdbutil.Sample)
+		for k, samples := range appendedSamples {
+			for _, s := range samples {
+				if s.T() < from {
+					continue
+				}
+				if s.T() > to {
+					continue
+				}
+				expSamples[k] = append(expSamples[k], s)
+			}
 		}
 		require.Equal(t, expSamples, seriesSet)
 		require.Equal(t, float64(totalSamples-2), prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamplesAppended), "number of ooo appended samples mismatch")
@@ -4245,40 +4258,43 @@ func TestOOOAppendAndQuery(t *testing.T) {
 	addSample(s1, 300, 300, false)
 	addSample(s2, 290, 290, false)
 	require.Equal(t, float64(2), prom_testutil.ToFloat64(db.head.metrics.chunksCreated))
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// Some ooo samples.
 	addSample(s1, 250, 260, false)
 	addSample(s2, 255, 265, false)
 	verifyOOOMinMaxTimes(250, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
+	testQuery(minutes(250), minutes(265)) // Test querying ono data time range
+	testQuery(minutes(290), minutes(300)) // Test querying in-order data time range
+	testQuery(minutes(250), minutes(300)) // Test querying the entire range
 
 	// Out of time window.
 	addSample(s1, 59, 59, true)
 	addSample(s2, 49, 49, true)
 	verifyOOOMinMaxTimes(250, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// At the edge of time window, also it would be "out of bound" without the ooo support.
 	addSample(s1, 60, 65, false)
 	verifyOOOMinMaxTimes(60, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// This sample is not within the time window w.r.t. the head's maxt, but it is within the window
 	// w.r.t. the series' maxt. But we consider only head's maxt.
 	addSample(s2, 59, 59, true)
 	verifyOOOMinMaxTimes(60, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// Now the sample is within time window w.r.t. the head's maxt.
 	addSample(s2, 60, 65, false)
 	verifyOOOMinMaxTimes(60, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// Out of time window again.
 	addSample(s1, 59, 59, true)
 	addSample(s2, 49, 49, true)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 
 	// Generating some m-map chunks. The m-map chunks here are in such a way
 	// that when sorted w.r.t. mint, the last chunk's maxt is not the overall maxt
@@ -4287,7 +4303,7 @@ func TestOOOAppendAndQuery(t *testing.T) {
 	addSample(s1, 180, 249, false)
 	require.Equal(t, float64(6), prom_testutil.ToFloat64(db.head.metrics.chunksCreated))
 	verifyOOOMinMaxTimes(60, 265)
-	testQuery()
+	testQuery(math.MinInt64, math.MaxInt64)
 }
 
 func TestOOODisabled(t *testing.T) {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -367,41 +367,88 @@ func TestOOOHeadChunkReader_LabelValues(t *testing.T) {
 
 	// Add in-order samples
 	_, err := app.Append(0, labels.Labels{
-		{Name: "foo", Value: fmt.Sprintf("bar1")},
+		{Name: "foo", Value: "bar1"},
 	}, 100, 1)
 	require.NoError(t, err)
 	_, err = app.Append(0, labels.Labels{
-		{Name: "foo", Value: fmt.Sprintf("bar2")},
+		{Name: "foo", Value: "bar2"},
 	}, 100, 2)
 	require.NoError(t, err)
 
 	// Add ooo samples for those series
 	_, err = app.Append(0, labels.Labels{
-		{Name: "foo", Value: fmt.Sprintf("bar1")},
+		{Name: "foo", Value: "bar1"},
 	}, 90, 1)
 	require.NoError(t, err)
 	_, err = app.Append(0, labels.Labels{
-		{Name: "foo", Value: fmt.Sprintf("bar2")},
+		{Name: "foo", Value: "bar2"},
 	}, 90, 2)
 	require.NoError(t, err)
 
 	require.NoError(t, app.Commit())
 
-	oh := NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64)
-	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar1")}
-	values, err := oh.LabelValues("foo", matchers...)
-	require.NoError(t, err)
-	require.Equal(t, []string{"bar1"}, values)
+	cases := []struct {
+		name       string
+		queryMinT  int64
+		queryMaxT  int64
+		expValues1 []string
+		expValues2 []string
+		expValues3 []string
+		expValues4 []string
+	}{
+		{
+			name:       "LabelValues calls when ooo head has max query range",
+			queryMinT:  math.MinInt64,
+			queryMaxT:  math.MaxInt64,
+			expValues1: []string{"bar1"},
+			expValues2: []string{},
+			expValues3: []string{"bar1", "bar2"},
+			expValues4: []string{"bar1", "bar2"},
+		},
+		{
+			name:       "LabelValues calls with ooo head query range not overlapping in-order data",
+			queryMinT:  90,
+			queryMaxT:  90,
+			expValues1: []string{"bar1"},
+			expValues2: []string{},
+			expValues3: []string{"bar1", "bar2"},
+			expValues4: []string{"bar1", "bar2"},
+		},
+		{
+			name:       "LabelValues calls with ooo head query range not overlapping out-of-order data",
+			queryMinT:  100,
+			queryMaxT:  100,
+			expValues1: []string{},
+			expValues2: []string{},
+			expValues3: []string{},
+			expValues4: []string{},
+		},
+	}
 
-	matchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "foo", "^bar.")}
-	values, err = oh.LabelValues("foo", matchers...)
-	require.NoError(t, err)
-	require.Equal(t, []string{}, values)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// We first want to test using a head index reader that covers the biggest query interval
+			oh := NewOOOHeadIndexReader(head, tc.queryMinT, tc.queryMaxT)
+			matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar1")}
+			values, err := oh.LabelValues("foo", matchers...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expValues1, values)
 
-	matchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.")}
-	values, err = oh.LabelValues("foo", matchers...)
-	require.NoError(t, err)
-	require.Equal(t, []string{"bar1", "bar2"}, values)
+			matchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotRegexp, "foo", "^bar.")}
+			values, err = oh.LabelValues("foo", matchers...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expValues2, values)
+
+			matchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.")}
+			values, err = oh.LabelValues("foo", matchers...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expValues3, values)
+
+			values, err = oh.LabelValues("foo")
+			require.NoError(t, err)
+			require.Equal(t, tc.expValues4, values)
+		})
+	}
 }
 
 // TestOOOHeadChunkReader_Chunk tests that the Chunk method works as expected.


### PR DESCRIPTION
OOOHeadIndexReader was using the headIndexReader PostingsForMatchers()
and LabelValues() implementation which lead to a very subtle bug that
led to wrong query results.

headIndexReader LabelValues() implementation checks if the query
timerange overlaps with the head maxt and mint and if it doesnt it
returns an empty list of values. Since this code was also used by the
ooo head it led to wrong results that we were not able to see in tests
because our queries where always from MinInt64 to MaxInt64. This commit
also adds a new test that performs multiple time range queries to make
sure this never happens again.