### PR TITLE
Remove redundant CI Lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,6 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Lint
-        uses: golangci/golangci-lint-action@v2
-
   test:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This repository has a custom `test.yml` github workflow https://github.com/grafana/mimir-prometheus/blob/628f66d19afcef69b38fb6fc7b259e60a0ad1c31/.github/workflows/test.yml#L1 that has a redundant lint stage since there is a job from upstream that already does this https://github.com/grafana/mimir-prometheus/blob/d713e39865be0bd950404d1d0bb90a60ab4804e7/.github/workflows/golangci-lint.yml#L27-L30

So this PR is getting rid of the obsolete and redudant Lint job in test.yml