### PR TITLE
Run OOO compaction after restart if there is OOO data from WBL

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -859,6 +859,11 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 	}
 
+	if db.head.MinOOOTime() != int64(math.MaxInt64) {
+		// Some OOO data was replayed from the disk that needs compaction and cleanup.
+		db.oooWasEnabled.Store(true)
+	}
+
 	go db.run()
 
 	return db, nil


### PR DESCRIPTION
If there was some OOO data on disk (in WBL or mmap chunks) that got replayed while OOO being disabled during a restart, we were not compacting that data. Hence never cleaning up the chunks_head directory of old files because those OOO mmap chunks share the chunks_head. This caused the disk to fill up after disabling OOO.

This PR fixes it by setting `db.oooWasEnabled` to true if some OOO data was replayed. `db.oooWasEnabled` is a way to signal that compaction needs to run on OOO data. 