### PR TITLE
Add option to always restore the state of rules when loading

### DIFF
--- a/rules/fixtures/rules_alerts.yaml
+++ b/rules/fixtures/rules_alerts.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test
+    rules:
+      - alert: test
+        expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/fixtures/rules_alerts2.yaml
+++ b/rules/fixtures/rules_alerts2.yaml
@@ -1,0 +1,5 @@
+groups:
+  - name: test
+    rules:
+      - alert: test_2
+        expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -962,7 +962,7 @@ type ManagerOptions struct {
 	GroupLoader                GroupLoader
 	DefaultEvaluationDelay     func() time.Duration
 
-	// AlwaysRestoreAlertState forces all new groups added via LoadGroups to restore their state.
+	// AlwaysRestoreAlertState forces all new or changed groups in calls to Update to restore.
 	// Useful when you know you will be adding alerting rules after the manager has already started.
 	AlwaysRestoreAlertState bool
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -962,6 +962,10 @@ type ManagerOptions struct {
 	GroupLoader                GroupLoader
 	DefaultEvaluationDelay     func() time.Duration
 
+	// AlwaysRestoreAlertState forces all new groups added via LoadGroups to restore their state.
+	// Useful when you know you will be adding alerting rules after the manager has already started.
+	AlwaysRestoreAlertState bool
+
 	Metrics *Metrics
 }
 
@@ -1116,7 +1120,7 @@ func (m *Manager) LoadGroups(
 ) (map[string]*Group, []error) {
 	groups := make(map[string]*Group)
 
-	shouldRestore := !m.restored
+	shouldRestore := !m.restored || m.opts.AlwaysRestoreAlertState
 
 	for _, fn := range filenames {
 		rgs, errs := m.opts.GroupLoader.Load(fn)
@@ -1146,7 +1150,7 @@ func (m *Manager) LoadGroups(
 						labels.FromMap(r.Annotations),
 						externalLabels,
 						externalURL,
-						m.restored,
+						!shouldRestore,
 						log.With(m.logger, "alert", r.Alert),
 					))
 					continue


### PR DESCRIPTION
When the ruler manager loads alerts while running it doesn't restore their state. For mimir this means that rules that get sharded to a ruler replica while it's running don't get their state restored. This PR adds an option to the ruler manager to always restore alert state when it load new or changed alerts. 

This behaviour does not affect loading groups which are unchanged. But it affects loading groups which have changed - either with new rules or with removed rules - those rules will get their state restored. 

This seems like a small change, so I think if this seems ok to us, I will propose to merge with with upstream.

related to https://github.com/grafana/mimir/issues/2888