### PR TITLE
Hackathon: raw_increase

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -219,20 +219,36 @@ func funcRawIncrease(vals []parser.Value, args parser.Expressions, enh *EvalNode
 	)
 
 	// Make sure that the requested window is smaller than the matrix selector range.
-	if ms := args[0].(*parser.MatrixSelector); window > ms.Range.Milliseconds() {
+	ms := args[0].(*parser.MatrixSelector)
+	if window > ms.Range.Milliseconds() {
 		panic(fmt.Sprintf("invalid window for raw_increase, can't be bigger than matrix selector range: window=%dms > range=%dms", window, ms.Range.Milliseconds()))
 	}
 
-	// No sense in trying to compute a rate without at least two points. Drop this Vector element.
-	if len(samples.Points) < 2 {
+	// No samples for zero samples in the range.
+	// Or zero increase for one sample in the range.
+	if len(samples.Points) == 0 {
 		return enh.Out
+	} else if len(samples.Points) == 1 {
+		// TODO: should this be a raw increase of sample's value?
+		// TODO: if Prometheus just lost a bunch of scrapes, we can't say this is an increase.
+		return append(enh.Out, Sample{
+			Point: Point{V: 0},
+		})
+	}
+
+	// No increase if all samples are outside of the window, but we still generate the 0 sample (as there are samples in the range).
+	fromTs := enh.Ts - ms.VectorSelector.(*parser.VectorSelector).Offset.Milliseconds() - window
+	if samples.Points[len(samples.Points)-1].T < fromTs {
+		return append(enh.Out, Sample{
+			Point: Point{V: 0},
+		})
 	}
 
 	if samples.Points[0].H != nil {
 		// TODO (oleg): implement raw increase for histograms.
 		return nil
 	} else {
-		fromTs := samples.Points[len(samples.Points)-1].T - window
+		// Start with two points (last two), and keep adding more points to the evaluation window while they're in the window (T >= fromTs).
 		startIdx := len(samples.Points) - 2
 		for startIdx > 0 && samples.Points[startIdx-1].T >= fromTs {
 			startIdx--

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -218,7 +218,7 @@ func funcRawIncrease(vals []parser.Value, args parser.Expressions, enh *EvalNode
 		resultValue float64
 	)
 
-	// Make sure that the requested
+	// Make sure that the requested window is smaller than the matrix selector range.
 	if ms := args[0].(*parser.MatrixSelector); window > ms.Range.Milliseconds() {
 		panic(fmt.Sprintf("invalid window for raw_increase, can't be bigger than matrix selector range: window=%dms > range=%dms", window, ms.Range.Milliseconds()))
 	}

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -292,6 +292,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"raw_increase": {
+		Name:       "raw_increase",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+	},
 	"resets": {
 		Name:       "resets",
 		ArgTypes:   []ValueType{ValueTypeMatrix},

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -1037,31 +1037,3 @@ eval instant at 5m log10(exp_root_log - 20)
 	{l="y"} -Inf
 
 clear
-
-# Testing raw_increase().
-load 30s
-	http_requests{path="/foo"}	0+10x6 10 20 30 40
-	http_requests{path="/bar"}	0+10x6 10 20 30 10
-	http_requests{path="/baz"}	0+10x6 10 20  _ 10
-	http_requests{path="/boo"}	0+10x6  _  _  _ 10
-
-
-# Tests for raw_increase().
-eval instant at 5m raw_increase(http_requests[1m], 30e3)
-	{path="/foo"} 10
-	{path="/bar"} 10
-	{path="/baz"} 10
-
-eval instant at 5m raw_increase(http_requests[2m], 30e3)
-	{path="/foo"} 10
-	{path="/bar"} 10
-	{path="/baz"} 10
-	{path="/boo"} 10
-
-eval instant at 5m raw_increase(http_requests[2m], 60e3)
-	{path="/foo"} 20
-	{path="/bar"} 20
-	{path="/baz"} 10
-	{path="/boo"} 10
-
-clear

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -1037,3 +1037,31 @@ eval instant at 5m log10(exp_root_log - 20)
 	{l="y"} -Inf
 
 clear
+
+# Testing raw_increase().
+load 30s
+	http_requests{path="/foo"}	0+10x6 10 20 30 40
+	http_requests{path="/bar"}	0+10x6 10 20 30 10
+	http_requests{path="/baz"}	0+10x6 10 20  _ 10
+	http_requests{path="/boo"}	0+10x6  _  _  _ 10
+
+
+# Tests for raw_increase().
+eval instant at 5m raw_increase(http_requests[1m], 30e3)
+	{path="/foo"} 10
+	{path="/bar"} 10
+	{path="/baz"} 10
+
+eval instant at 5m raw_increase(http_requests[2m], 30e3)
+	{path="/foo"} 10
+	{path="/bar"} 10
+	{path="/baz"} 10
+	{path="/boo"} 10
+
+eval instant at 5m raw_increase(http_requests[2m], 60e3)
+	{path="/foo"} 20
+	{path="/bar"} 20
+	{path="/baz"} 10
+	{path="/boo"} 10
+
+clear

--- a/promql/testdata/raw_increase.test
+++ b/promql/testdata/raw_increase.test
@@ -1,0 +1,30 @@
+# Testing raw_increase().
+load 30s
+	http_requests{path="/foo"}	0+10x5 10 20 30 40 50
+	http_requests{path="/bar"}	0+10x5 10 20 30 40 10
+	http_requests{path="/baz"}	0+10x5 10 20 30 _  10
+	http_requests{path="/boo"}	0+10x5  _  _  _ _  10
+	http_requests{path="/faf"}	0+10x5  _ 10  _  _  _
+
+# Tests for raw_increase().
+eval instant at 5m raw_increase(http_requests[1m], 30e3)
+	{path="/foo"} 10
+	{path="/bar"} 10
+	{path="/baz"} 10
+	{path="/boo"}  0
+
+eval instant at 5m raw_increase(http_requests[2m], 30e3)
+	{path="/foo"} 10
+	{path="/bar"} 10
+	{path="/baz"} 10
+	{path="/boo"}  0
+	{path="/faf"}  0
+
+eval instant at 5m raw_increase(http_requests[2m], 60e3)
+	{path="/foo"} 20
+	{path="/bar"} 20
+	{path="/baz"} 10
+	{path="/boo"}  0
+	{path="/faf"}  0
+
+clear


### PR DESCRIPTION
Introduces a new function `raw_increase(matrix, scalar millis)` that calculates the raw incrase ("raw" as opposed to the extrapolated increase that `increase()` and `rate()` calculate) in the window provided by the scalar millis param. It can make use of a bigger matrix range if there are not enough values in the window, to find the previous
value.

It accounts for the counter resets.

If there are at least 2 samples in the window, it doesn't look back past the window.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
