### PR TITLE
Shortcut postings for matchers when empty postings are selected

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -113,7 +113,9 @@ func (h *headIndexReader) Postings(name string, values ...string) (index.Posting
 	default:
 		res := make([]index.Postings, 0, len(values))
 		for _, value := range values {
-			res = append(res, h.head.postings.Get(name, value))
+			if p := h.head.postings.Get(name, value); !index.IsEmptyPostings(p) {
+				res = append(res, p)
+			}
 		}
 		return index.Merge(res...), nil
 	}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -113,7 +113,7 @@ func (h *headIndexReader) Postings(name string, values ...string) (index.Posting
 	default:
 		res := make([]index.Postings, 0, len(values))
 		for _, value := range values {
-			if p := h.head.postings.Get(name, value); !index.IsEmptyPostings(p) {
+			if p := h.head.postings.Get(name, value); !index.IsEmptyPostingsType(p) {
 				res = append(res, p)
 			}
 		}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -428,10 +428,10 @@ func EmptyPostings() Postings {
 	return emptyPostings
 }
 
-// IsEmptyPostings returns true if the postings are an empty postings list.
+// IsEmptyPostingsType returns true if the postings are an empty postings list.
 // When this function returns false, it doesn't mean that the postings isn't empty
 // (it could be an empty intersection of two non-empty postings, for example).
-func IsEmptyPostings(p Postings) bool {
+func IsEmptyPostingsType(p Postings) bool {
 	return p == emptyPostings
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -428,6 +428,13 @@ func EmptyPostings() Postings {
 	return emptyPostings
 }
 
+// IsEmptyPostings returns true if the postings are an empty postings list.
+// When this function returns false, it doesn't mean that the postings isn't empty
+// (it could be an empty intersection of two non-empty postings, for example).
+func IsEmptyPostings(p Postings) bool {
+	return p == emptyPostings
+}
+
 // ErrPostings returns new postings that immediately error.
 func ErrPostings(err error) Postings {
 	return errPostings{err}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -215,7 +215,7 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 				if err != nil {
 					return nil, err
 				}
-				if index.IsEmptyPostings(it) {
+				if index.IsEmptyPostingsType(it) {
 					return index.EmptyPostings(), nil
 				}
 				its = append(its, it)
@@ -225,7 +225,7 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 				if err != nil {
 					return nil, err
 				}
-				if index.IsEmptyPostings(it) {
+				if index.IsEmptyPostingsType(it) {
 					return index.EmptyPostings(), nil
 				}
 				its = append(its, it)

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -215,12 +215,18 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 				if err != nil {
 					return nil, err
 				}
+				if index.IsEmptyPostings(it) {
+					return index.EmptyPostings(), nil
+				}
 				its = append(its, it)
 			} else { // l="a"
 				// Non-Not matcher, use normal postingsForMatcher.
 				it, err := postingsForMatcher(ix, m)
 				if err != nil {
 					return nil, err
+				}
+				if index.IsEmptyPostings(it) {
+					return index.EmptyPostings(), nil
 				}
 				its = append(its, it)
 			}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -93,6 +93,7 @@ func BenchmarkQuerier(b *testing.B) {
 
 func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	nX := labels.MustNewMatcher(labels.MatchNotEqual, "n", "X"+postingsBenchSuffix)
 
 	jFoo := labels.MustNewMatcher(labels.MatchEqual, "j", "foo")
 	jNotFoo := labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")
@@ -109,35 +110,50 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iNot2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^2.*$")
 	iNotStar2Star := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*2.*$")
 	jFooBar := labels.MustNewMatcher(labels.MatchRegexp, "j", "foo|bar")
+	jXXXYYY := labels.MustNewMatcher(labels.MatchRegexp, "j", "XXX|YYY")
+	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
 	iCharSet := labels.MustNewMatcher(labels.MatchRegexp, "i", "1[0-9]")
 	iAlternate := labels.MustNewMatcher(labels.MatchRegexp, "i", "(1|2|3|4|5|6|20|55)")
+	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
 	cases := []struct {
 		name     string
 		matchers []*labels.Matcher
 	}{
 		{`n="1"`, []*labels.Matcher{n1}},
+		{`n="X"`, []*labels.Matcher{nX}},
 		{`n="1",j="foo"`, []*labels.Matcher{n1, jFoo}},
+		{`n="X",j="foo"`, []*labels.Matcher{nX, jFoo}},
 		{`j="foo",n="1"`, []*labels.Matcher{jFoo, n1}},
 		{`n="1",j!="foo"`, []*labels.Matcher{n1, jNotFoo}},
+		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}},
 		{`i=~"1[0-9]",j=~"foo|bar"`, []*labels.Matcher{iCharSet, jFooBar}},
 		{`j=~"foo|bar"`, []*labels.Matcher{jFooBar}},
+		{`j=~"XXX|YYY"`, []*labels.Matcher{jXXXYYY}},
+		{`j=~"X.+"`, []*labels.Matcher{jXplus}},
 		{`i=~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iAlternate}},
+		{`i=~"X|Y|Z"`, []*labels.Matcher{iXYZ}},
 		{`i=~".*"`, []*labels.Matcher{iStar}},
 		{`i=~"1.*"`, []*labels.Matcher{i1Star}},
 		{`i=~".*1"`, []*labels.Matcher{iStar1}},
 		{`i=~".+"`, []*labels.Matcher{iPlus}},
+		{`i=~".+",j=~"X.+"`, []*labels.Matcher{iPlus, jXplus}},
 		{`i=~""`, []*labels.Matcher{iEmptyRe}},
 		{`i!=""`, []*labels.Matcher{iNotEmpty}},
 		{`n="1",i=~".*",j="foo"`, []*labels.Matcher{n1, iStar, jFoo}},
+		{`n="X",i=~".*",j="foo"`, []*labels.Matcher{nX, iStar, jFoo}},
 		{`n="1",i=~".*",i!="2",j="foo"`, []*labels.Matcher{n1, iStar, iNot2, jFoo}},
 		{`n="1",i!=""`, []*labels.Matcher{n1, iNotEmpty}},
 		{`n="1",i!="",j="foo"`, []*labels.Matcher{n1, iNotEmpty, jFoo}},
+		{`n="1",i!="",j=~"X.+"`, []*labels.Matcher{n1, iNotEmpty, jXplus}},
+		{`n="1",i!="",j=~"XXX|YYY"`, []*labels.Matcher{n1, iNotEmpty, jXXXYYY}},
+		{`n="1",i=~"X|Y|Z",j="foo"`, []*labels.Matcher{n1, iXYZ, jFoo}},
 		{`n="1",i=~".+",j="foo"`, []*labels.Matcher{n1, iPlus, jFoo}},
 		{`n="1",i=~"1.+",j="foo"`, []*labels.Matcher{n1, i1Plus, jFoo}},
 		{`n="1",i=~".*1.*",j="foo"`, []*labels.Matcher{n1, iStar1Star, jFoo}},
 		{`n="1",i=~".+",i!="2",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2, jFoo}},
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}},
 		{`n="1",i=~".+",i!~".*2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNotStar2Star, jFoo}},
+		{`n="X",i=~".+",i!~".*2.*",j="foo"`, []*labels.Matcher{nX, iPlus, iNotStar2Star, jFoo}},
 	}
 
 	for _, c := range cases {
@@ -154,7 +170,10 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 	i1 := labels.MustNewMatcher(labels.MatchEqual, "i", "1")
 	iStar := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")
 	jNotFoo := labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")
+	jXXXYYY := labels.MustNewMatcher(labels.MatchRegexp, "j", "XXX|YYY")
+	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	nX := labels.MustNewMatcher(labels.MatchNotEqual, "n", "X"+postingsBenchSuffix)
 	nPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")
 
 	cases := []struct {
@@ -166,6 +185,9 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 		{`i with n="1"`, "i", []*labels.Matcher{n1}},
 		{`i with n="^.+$"`, "i", []*labels.Matcher{nPlus}},
 		{`i with n="1",j!="foo"`, "i", []*labels.Matcher{n1, jNotFoo}},
+		{`i with n="1",j=~"X.+"`, "i", []*labels.Matcher{n1, jXplus}},
+		{`i with n="1",j=~"XXX|YYY"`, "i", []*labels.Matcher{n1, jXXXYYY}},
+		{`i with n="X",j!="foo"`, "i", []*labels.Matcher{nX, jNotFoo}},
 		{`i with n="1",i=~"^.*$",j!="foo"`, "i", []*labels.Matcher{n1, iStar, jNotFoo}},
 		// n has 10 values.
 		{`n with j!="foo"`, "n", []*labels.Matcher{jNotFoo}},


### PR DESCRIPTION
Sometimes we receive a matcher for a label that doesn't match any postings. In that case, if it's an AND (_its_) matcher, we can stop the evaluation an return empty postings.

In order to do that properly, we should also return the empty postings everywhere properly.

I also considered adding an optional `Length()` or `IsEmpty()` method to some `Postings` implementation, but it seemed to be an overkill now (it might be useful in the future if we start sorting matchers by postings lengths though).

Benchmark results:

```
name                                                                      old time/op  new time/op  delta
Querier/Head/PostingsForMatchers/n="1"-16                                  321ns ± 1%   320ns ± 1%     ~     (p=0.266 n=8+8)
Querier/Head/PostingsForMatchers/n="X"-16                                  943ns ± 1%   930ns ± 1%   -1.39%  (p=0.000 n=8+10)
Querier/Head/PostingsForMatchers/n="1",j="foo"-16                          483ns ± 3%   480ns ± 1%     ~     (p=0.795 n=9+10)
Querier/Head/PostingsForMatchers/n="X",j="foo"-16                         1.00µs ± 4%  0.96µs ± 1%   -3.70%  (p=0.002 n=10+9)
Querier/Head/PostingsForMatchers/j="foo",n="1"-16                          481ns ± 0%   482ns ± 1%     ~     (p=0.137 n=8+8)
Querier/Head/PostingsForMatchers/n="1",j!="foo"-16                         582ns ± 2%   589ns ± 0%   +1.20%  (p=0.008 n=10+9)
Querier/Head/PostingsForMatchers/n="X",j!="foo"-16                        1.27µs ± 1%  1.22µs ± 0%   -3.86%  (p=0.000 n=8+7)
Querier/Head/PostingsForMatchers/i=~"1[0-9]",j=~"foo|bar"-16              1.32µs ± 0%  0.85µs ± 2%  -35.60%  (p=0.000 n=8+10)
Querier/Head/PostingsForMatchers/j=~"foo|bar"-16                           485ns ± 1%   483ns ± 1%   -0.56%  (p=0.002 n=8+9)
Querier/Head/PostingsForMatchers/j=~"XXX|YYY"-16                           474ns ± 0%   418ns ± 1%  -11.84%  (p=0.000 n=8+10)
Querier/Head/PostingsForMatchers/j=~"X.+"-16                               392ns ± 1%   387ns ± 0%   -1.08%  (p=0.001 n=10+8)
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-16               840ns ± 2%   753ns ± 2%  -10.37%  (p=0.000 n=10+10)
Querier/Head/PostingsForMatchers/i=~"X|Y|Z"-16                             537ns ± 2%   481ns ± 0%  -10.40%  (p=0.000 n=10+8)
Querier/Head/PostingsForMatchers/i=~".*"-16                               5.09ms ± 2%  4.76ms ± 1%   -6.48%  (p=0.000 n=10+9)
Querier/Head/PostingsForMatchers/i=~"1.*"-16                              6.27ms ± 1%  6.07ms ± 2%   -3.14%  (p=0.000 n=9+10)
Querier/Head/PostingsForMatchers/i=~".*1"-16                              4.04ms ± 1%  3.85ms ± 2%   -4.71%  (p=0.000 n=10+10)
Querier/Head/PostingsForMatchers/i=~".+"-16                               37.2ms ± 2%  37.5ms ± 2%     ~     (p=0.052 n=10+10)
Querier/Head/PostingsForMatchers/i=~".+",j=~"X.+"-16                      37.1ms ± 1%  37.5ms ± 1%   +1.04%  (p=0.011 n=10+10)
Querier/Head/PostingsForMatchers/i=~""-16                                 32.9ms ± 1%  33.1ms ± 1%     ~     (p=0.143 n=10+10)
Querier/Head/PostingsForMatchers/i!=""-16                                 32.7ms ± 1%  33.0ms ± 1%   +1.02%  (p=0.009 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~".*",j="foo"-16                 4.98ms ± 1%  4.91ms ± 1%   -1.45%  (p=0.009 n=10+10)
Querier/Head/PostingsForMatchers/n="X",i=~".*",j="foo"-16                 4.98ms ± 1%  4.90ms ± 2%   -1.65%  (p=0.001 n=9+10)
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-16          6.42ms ± 1%  6.25ms ± 1%   -2.77%  (p=0.000 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i!=""-16                           32.7ms ± 1%  33.0ms ± 2%     ~     (p=0.123 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i!="",j="foo"-16                   32.7ms ± 1%  32.9ms ± 1%     ~     (p=0.053 n=9+10)
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"X.+"-16                  32.8ms ± 1%  33.3ms ± 1%   +1.42%  (p=0.000 n=9+8)
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"XXX|YYY"-16              32.8ms ± 2%  33.2ms ± 3%   +1.22%  (p=0.029 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~"X|Y|Z",j="foo"-16               852ns ± 0%   624ns ± 0%  -26.81%  (p=0.000 n=7+9)
Querier/Head/PostingsForMatchers/n="1",i=~".+",j="foo"-16                 37.3ms ± 1%  37.8ms ± 1%   +1.39%  (p=0.004 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~"1.+",j="foo"-16                6.22ms ± 2%  6.21ms ± 1%     ~     (p=0.739 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~".*1.*",j="foo"-16              18.7ms ± 0%  19.0ms ± 1%   +1.78%  (p=0.000 n=9+9)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!="2",j="foo"-16          37.2ms ± 2%  37.6ms ± 1%   +1.19%  (p=0.029 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-16        43.5ms ± 1%  44.1ms ± 1%   +1.52%  (p=0.001 n=10+10)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-16      55.6ms ± 1%  56.6ms ± 1%   +1.75%  (p=0.000 n=10+10)
Querier/Head/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-16      55.6ms ± 1%  56.6ms ± 1%   +1.89%  (p=0.000 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="1"-16                      97.8ms ± 2%  97.4ms ± 3%     ~     (p=0.393 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-16                    117ms ± 2%   116ms ± 2%     ~     (p=0.075 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-16              114ms ± 2%   113ms ± 2%     ~     (p=0.481 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-16             21.6ms ± 1%  21.6ms ± 1%     ~     (p=0.481 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-16         21.6ms ± 1%  21.6ms ± 1%     ~     (p=0.315 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-16             73.6ms ± 2%  73.8ms ± 2%     ~     (p=0.529 n=10+10)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-16    119ms ± 1%   118ms ± 2%     ~     (p=0.123 n=10+10)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-16                    131ms ± 2%   132ms ± 0%     ~     (p=0.173 n=10+8)
Querier/Head/labelValuesWithMatchers/n_with_i="1"-16                      4.76µs ± 1%  4.74µs ± 1%   -0.55%  (p=0.012 n=9+10)
Querier/Block/PostingsForMatchers/n="1"-16                                24.1µs ± 2%  24.3µs ± 2%     ~     (p=0.075 n=10+10)
Querier/Block/PostingsForMatchers/n="X"-16                                 897µs ± 2%   865µs ± 2%   -3.55%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/n="1",j="foo"-16                         255µs ± 2%   256µs ± 3%     ~     (p=0.436 n=10+10)
Querier/Block/PostingsForMatchers/n="X",j="foo"-16                         230µs ± 2%   231µs ± 2%     ~     (p=0.481 n=10+10)
Querier/Block/PostingsForMatchers/j="foo",n="1"-16                         259µs ± 0%   257µs ± 2%     ~     (p=0.475 n=7+10)
Querier/Block/PostingsForMatchers/n="1",j!="foo"-16                        257µs ± 2%   258µs ± 2%     ~     (p=0.353 n=10+10)
Querier/Block/PostingsForMatchers/n="X",j!="foo"-16                       1.38ms ± 5%  1.32ms ± 2%   -4.08%  (p=0.000 n=10+9)
Querier/Block/PostingsForMatchers/i=~"1[0-9]",j=~"foo|bar"-16              886µs ± 2%     4µs ± 0%  -99.59%  (p=0.000 n=10+8)
Querier/Block/PostingsForMatchers/j=~"foo|bar"-16                          880µs ± 1%   861µs ± 2%   -2.13%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/j=~"XXX|YYY"-16                          357ns ± 2%   347ns ± 1%   -2.78%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/j=~"X.+"-16                              628ns ± 0%   613ns ± 1%   -2.42%  (p=0.000 n=7+10)
Querier/Block/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-16             2.50µs ± 0%  2.49µs ± 1%     ~     (p=0.794 n=9+10)
Querier/Block/PostingsForMatchers/i=~"X|Y|Z"-16                            410ns ± 1%   404ns ± 0%   -1.53%  (p=0.000 n=10+8)
Querier/Block/PostingsForMatchers/i=~".*"-16                              3.08ms ± 1%  2.98ms ± 1%   -3.27%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/i=~"1.*"-16                             2.96ms ± 1%  2.86ms ± 1%   -3.30%  (p=0.000 n=10+9)
Querier/Block/PostingsForMatchers/i=~".*1"-16                             1.83ms ± 2%  1.76ms ± 2%   -4.18%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/i=~".+"-16                              13.4ms ± 1%  13.2ms ± 0%   -2.00%  (p=0.000 n=9+9)
Querier/Block/PostingsForMatchers/i=~".+",j=~"X.+"-16                     13.4ms ± 1%  13.2ms ± 1%   -1.63%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/i=~""-16                                14.2ms ± 1%  14.0ms ± 1%   -1.39%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/i!=""-16                                12.7ms ± 1%  12.7ms ± 1%   -0.75%  (p=0.029 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~".*",j="foo"-16                2.41ms ± 1%  2.35ms ± 1%   -2.46%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/n="X",i=~".*",j="foo"-16                2.36ms ± 2%  2.32ms ± 1%   -1.54%  (p=0.000 n=10+9)
Querier/Block/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-16         3.91ms ± 2%  3.81ms ± 1%   -2.43%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i!=""-16                          12.9ms ± 1%  12.7ms ± 1%   -1.18%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/n="1",i!="",j="foo"-16                  13.3ms ± 1%  13.2ms ± 1%   -1.33%  (p=0.000 n=9+10)
Querier/Block/PostingsForMatchers/n="1",i!="",j=~"X.+"-16                 12.9ms ± 1%  12.8ms ± 1%   -0.49%  (p=0.011 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i!="",j=~"XXX|YYY"-16             12.9ms ± 1%  12.8ms ± 1%     ~     (p=0.218 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~"X|Y|Z",j="foo"-16              254µs ± 2%    25µs ± 2%  -90.32%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~".+",j="foo"-16                13.8ms ± 1%  13.7ms ± 1%     ~     (p=0.053 n=9+10)
Querier/Block/PostingsForMatchers/n="1",i=~"1.+",j="foo"-16               3.45ms ± 1%  3.37ms ± 1%   -2.08%  (p=0.000 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~".*1.*",j="foo"-16             8.51ms ± 1%  8.43ms ± 1%   -0.86%  (p=0.005 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~".+",i!="2",j="foo"-16         13.8ms ± 1%  13.8ms ± 1%     ~     (p=0.605 n=9+9)
Querier/Block/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-16       16.9ms ± 1%  16.7ms ± 1%   -1.21%  (p=0.001 n=10+10)
Querier/Block/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-16     22.2ms ± 1%  22.0ms ± 1%   -0.86%  (p=0.007 n=10+10)
Querier/Block/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-16     22.2ms ± 1%  21.9ms ± 1%   -1.17%  (p=0.002 n=10+10)
Querier/Block/labelValuesWithMatchers/i_with_n="1"-16                      108ms ± 0%   108ms ± 1%     ~     (p=0.054 n=7+8)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-16                  97.4ms ± 2%  97.7ms ± 0%     ~     (p=0.549 n=10+9)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-16             113ms ± 2%   114ms ± 1%     ~     (p=0.905 n=10+9)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-16            46.1ms ± 2%  46.4ms ± 1%   +0.72%  (p=0.035 n=10+9)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-16        46.3ms ± 1%  46.3ms ± 0%     ~     (p=0.423 n=9+8)
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-16            79.0ms ± 1%  79.0ms ± 1%     ~     (p=0.912 n=10+10)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-16   115ms ± 3%   116ms ± 0%     ~     (p=0.965 n=10+8)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-16                   150ms ± 1%   148ms ± 1%   -1.35%  (p=0.001 n=9+9)
Querier/Block/labelValuesWithMatchers/n_with_i="1"-16                      937µs ± 1%   886µs ± 1%   -5.48%  (p=0.000 n=10+10)
```