### PR TITLE
Avoid an unnecessary allocation in recording rule evaluation

### DIFF
--- a/rules/recording.go
+++ b/rules/recording.go
@@ -89,7 +89,8 @@ func (rule *RecordingRule) Eval(ctx context.Context, evalDelay time.Duration, ts
 			lb.Set(l.Name, l.Value)
 		}
 
-		sample.Metric = lb.Labels(nil)
+		labelSetSize := len(sample.Metric) + len(rule.labels) + 1 // additional 1 for rule name
+		sample.Metric = lb.Labels(make(labels.Labels, 0, labelSetSize))
 	}
 
 	// Check that the rule does not produce identical metrics after applying

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -155,7 +155,7 @@ func BenchmarkRuleEval(b *testing.B) {
 				result, err := rule.Eval(suite.Context(), 0, ts, EngineQueryFunc(suite.QueryEngine(), suite.Storage()), nil, 0)
 
 				require.NoError(b, err)
-				require.Equal(b, scenario.expected, result)
+				require.ElementsMatch(b, scenario.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
When evaluating a rule, `RecordingRule.Eval()` uses a `labels.Builder` instance to build the label set for the recorded samples.

`Builder.Labels()` assumes that most of the time, the `Builder` is being used to remove or replace labels in the existing label set rather than add to them. 

But in the case of a recording rule, we're likely adding or replacing labels from the rule definition, so `Builder.Labels()` ends up allocating two `Labels` instances (once [here](https://github.com/grafana/mimir-prometheus/blob/98dee9f3843f14ff66e228acb30099822928948c/model/labels/labels.go#L486), and another later on in `append()` [here](https://github.com/grafana/mimir-prometheus/blob/98dee9f3843f14ff66e228acb30099822928948c/model/labels/labels.go#L508)). 

Instead, during rule evaluation, we can calculate the upper bound of the length of the label set and allocate just one `Labels` instance ahead of time.

For one Mimir cluster, we've seen that `Builder.Labels()` is responsible for ~6% of allocations attributable to rule evaluation, so this change should remove ~3% of allocations.

There's a similar improvement to be had in `AlertingRule.Eval()` as well - I will address this in a later commit.

## Benchmark results 

Note that this benchmark includes the cost of evaluating the query used in the benchmark's rule - in Mimir's ruler, the results would be slightly different as we perform a remote query and simply parse the JSON response.

```
name                                                   old time/op    new time/op    delta
RuleEval/no_labels_in_recording_rule-10                  8.18µs ± 0%    8.13µs ± 1%  -0.67%  (p=0.032 n=5+5)
RuleEval/only_new_labels_in_recording_rule-10            8.51µs ± 0%    8.27µs ± 0%  -2.79%  (p=0.008 n=5+5)
RuleEval/some_replacement_labels_in_recording_rule-10    8.26µs ± 0%    8.14µs ± 0%  -1.34%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
RuleEval/no_labels_in_recording_rule-10                  7.37kB ± 0%    7.43kB ± 0%  +0.85%  (p=0.008 n=5+5)
RuleEval/only_new_labels_in_recording_rule-10            7.76kB ± 0%    7.50kB ± 0%  -3.33%  (p=0.008 n=5+5)
RuleEval/some_replacement_labels_in_recording_rule-10    7.37kB ± 0%    7.50kB ± 0%  +1.71%  (p=0.016 n=4+5)

name                                                   old allocs/op  new allocs/op  delta
RuleEval/no_labels_in_recording_rule-10                     135 ± 0%       135 ± 0%    ~     (all equal)
RuleEval/only_new_labels_in_recording_rule-10               137 ± 0%       135 ± 0%  -1.46%  (p=0.008 n=5+5)
RuleEval/some_replacement_labels_in_recording_rule-10       135 ± 0%       135 ± 0%    ~     (all equal)
```