### PR TITLE
stop-unfinished-writers-in-populateBlock

### DIFF
--- a/tsdb/async_block_writer.go
+++ b/tsdb/async_block_writer.go
@@ -16,6 +16,7 @@ import (
 var errAsyncBlockWriterNotRunning = errors.New("asyncBlockWriter doesn't run anymore")
 
 // asyncBlockWriter runs a background goroutine that writes series and chunks to the block asynchronously.
+// All calls on asyncBlockWriter must be done from single goroutine, it is not safe for concurrent usage from multiple goroutines.
 type asyncBlockWriter struct {
 	chunkPool chunkenc.Pool // Where to return chunks after writing.
 

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -2285,6 +2285,7 @@ func TestAsyncBlockWriterSuccess(t *testing.T) {
 	const series = 100
 	// prepare index, add all symbols
 	iw, err := index.NewWriter(context.Background(), filepath.Join(t.TempDir(), indexFilename))
+	require.NoError(t, err)
 
 	require.NoError(t, iw.AddSymbol("__name__"))
 	for ix := 0; ix < series; ix++ {
@@ -2330,6 +2331,7 @@ func TestAsyncBlockWriterFailure(t *testing.T) {
 
 	// We don't write symbols to this index writer, so adding series next will fail.
 	iw, err := index.NewWriter(context.Background(), filepath.Join(t.TempDir(), indexFilename))
+	require.NoError(t, err)
 
 	// async block writer expects index writer ready to receive series.
 	abw := newAsyncBlockWriter(chunkenc.NewPool(), cw, iw, semaphore.NewWeighted(int64(1)))

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -2275,4 +2276,96 @@ func TestLeveledCompactor_plan_overlapping_disabled(t *testing.T) {
 			return
 		}
 	}
+}
+
+func TestAsyncBlockWriterSuccess(t *testing.T) {
+	cw, err := chunks.NewWriter(t.TempDir())
+	require.NoError(t, err)
+
+	const series = 100
+	// prepare index, add all symbols
+	iw, err := index.NewWriter(context.Background(), filepath.Join(t.TempDir(), indexFilename))
+
+	require.NoError(t, iw.AddSymbol("__name__"))
+	for ix := 0; ix < series; ix++ {
+		s := fmt.Sprintf("s_%3d", ix)
+		require.NoError(t, iw.AddSymbol(s))
+	}
+
+	// async block writer expects index writer ready to receive series.
+	abw := newAsyncBlockWriter(chunkenc.NewPool(), cw, iw, semaphore.NewWeighted(int64(1)))
+
+	for ix := 0; ix < series; ix++ {
+		s := fmt.Sprintf("s_%3d", ix)
+		require.NoError(t, abw.addSeries(labels.FromStrings("__name__", s), []chunks.Meta{{Chunk: randomChunk(t), MinTime: 0, MaxTime: math.MaxInt64}}))
+	}
+
+	// signal that no more series are coming
+	abw.closeAsync()
+
+	// We can do this repeatedly.
+	abw.closeAsync()
+	abw.closeAsync()
+
+	// wait for result
+	stats, err := abw.waitFinished()
+	require.NoError(t, err)
+	require.Equal(t, uint64(series), stats.NumSeries)
+	require.Equal(t, uint64(series), stats.NumChunks)
+
+	// We get the same result on subsequent calls to waitFinished.
+	for i := 0; i < 5; i++ {
+		newstats, err := abw.waitFinished()
+		require.NoError(t, err)
+		require.Equal(t, stats, newstats)
+
+		// We can call close async again, as long as it's on the same goroutine.
+		abw.closeAsync()
+	}
+}
+
+func TestAsyncBlockWriterFailure(t *testing.T) {
+	cw, err := chunks.NewWriter(t.TempDir())
+	require.NoError(t, err)
+
+	// We don't write symbols to this index writer, so adding series next will fail.
+	iw, err := index.NewWriter(context.Background(), filepath.Join(t.TempDir(), indexFilename))
+
+	// async block writer expects index writer ready to receive series.
+	abw := newAsyncBlockWriter(chunkenc.NewPool(), cw, iw, semaphore.NewWeighted(int64(1)))
+
+	// Adding single series doesn't fail, as it just puts it onto the queue.
+	require.NoError(t, abw.addSeries(labels.FromStrings("__name__", "test"), []chunks.Meta{{Chunk: randomChunk(t), MinTime: 0, MaxTime: math.MaxInt64}}))
+
+	// Signal that no more series are coming.
+	abw.closeAsync()
+
+	// We can do this repeatedly.
+	abw.closeAsync()
+	abw.closeAsync()
+
+	// Wait for result, this time we get error due to missing symbols.
+	_, err = abw.waitFinished()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown symbol")
+
+	// We get the same error on each repeated call to waitFinished.
+	for i := 0; i < 5; i++ {
+		_, nerr := abw.waitFinished()
+		require.Equal(t, err, nerr)
+
+		// We can call close async again, as long as it's on the same goroutine.
+		abw.closeAsync()
+	}
+}
+
+func randomChunk(t *testing.T) chunkenc.Chunk {
+	chunk := chunkenc.NewXORChunk()
+	l := rand.Int() % 120
+	app, err := chunk.Appender()
+	require.NoError(t, err)
+	for i := 0; i < l; i++ {
+		app.Append(rand.Int63(), rand.Float64())
+	}
+	return chunk
 }


### PR DESCRIPTION
This PR fixes bug in `populateBlock` method. When `populateBlock` encountered error, it  could return with some async block writer were still running. This could then cause panic when closing index writer:

```
fatal error: concurrent map iteration and map write
goroutine 1155011084 [running]:
github.com/prometheus/prometheus/tsdb/index.(*Writer).writePostingsToTmpFiles(0xc108b21ce0)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/index/index.go:821 +0xe8
github.com/prometheus/prometheus/tsdb/index.(*Writer).ensureStage(0xc108b21ce0, 0x3)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/index/index.go:380 +0xba
github.com/prometheus/prometheus/tsdb/index.(*Writer).Close(0xc108b21ce0)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/index/index.go:1028 +0x27
github.com/prometheus/prometheus/tsdb.(*preventDoubleCloseIndexWriter).Close(0x24fa400?)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/async_block_writer.go:155 +0x38
github.com/prometheus/prometheus/tsdb/errors.CloseAll({0xc10ca604c0?, 0x2, 0x7f223419f2b0?})
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/errors/errors.go:86 +0x102
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).write.func1({0xc09bee3410?, 0x40dfc7?, 0x4266420?})
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/compact.go:743 +0x93
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).write(0xc0003fbe00, {0xc000572560, 0x10}, {0xc09bee3868?, 0x1, 0x1}, {0xc09bee3838, 0x1, 0x1})
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/compact.go:818 +0xa6c
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).Write(0xc0003fbe00, {0xc000572560, 0x10}, {0x2f523c0, 0xc0f849e5a0}, 0x18582a92000, 0x1858316fd00, 0x0)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/compact.go:694 +0x275
github.com/prometheus/prometheus/tsdb.(*DB).compactOOO(0xc00031bc20, {0xc000572560, 0x10}, 0xc11e9b60f0)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/db.go:1214 +0x34a
github.com/prometheus/prometheus/tsdb.(*DB).compactOOOHead(0xc00031bc20)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/db.go:1170 +0x7a
github.com/prometheus/prometheus/tsdb.(*DB).Compact(0xc00031bc20)
	/backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/db.go:1130 +0x627
github.com/grafana/mimir/pkg/ingester.(*userTSDB).Compact(...)
	/backend-enterprise/vendor/github.com/grafana/mimir/pkg/ingester/user_tsdb.go:128
github.com/grafana/mimir/pkg/ingester.(*Ingester).compactBlocks.func1({0xc0c9260521?, 0xc0bc9d3dc8?}, {0xc000572318, 0x5})
	/backend-enterprise/vendor/github.com/grafana/mimir/pkg/ingester/ingester.go:1994 +0x3e5
github.com/grafana/dskit/concurrency.ForEachUser.func1()
	/backend-enterprise/vendor/github.com/grafana/dskit/concurrency/runner.go:45 +0x14d
created by github.com/grafana/dskit/concurrency.ForEachUser
	/backend-enterprise/vendor/github.com/grafana/dskit/concurrency/runner.go:36 +0x12b
```

This PR makes sure that `populateBlock` not only calls `(*asyncBlockWriter).closeAsync`, but also `(*asyncBlockWriter).waitFinished` for each started async block writer in `defer` statement.

