### PR TITLE
Add NumNativeHistogramChunks to tsdb.BlockStats

### DIFF
--- a/tsdb/async_block_writer.go
+++ b/tsdb/async_block_writer.go
@@ -78,6 +78,9 @@ func (bw *asyncBlockWriter) loop() (res asyncBlockWriterResult) {
 		stats.NumSeries++
 		for _, chk := range sw.chks {
 			stats.NumSamples += uint64(chk.Chunk.NumSamples())
+			if enc := chk.Chunk.Encoding(); enc == chunkenc.EncHistogram || enc == chunkenc.EncFloatHistogram {
+				stats.NumNativeHistogramChunks++
+			}
 		}
 
 		for _, chk := range sw.chks {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -176,10 +176,11 @@ type BlockMeta struct {
 
 // BlockStats contains stats about contents of a block.
 type BlockStats struct {
-	NumSamples    uint64 `json:"numSamples,omitempty"`
-	NumSeries     uint64 `json:"numSeries,omitempty"`
-	NumChunks     uint64 `json:"numChunks,omitempty"`
-	NumTombstones uint64 `json:"numTombstones,omitempty"`
+	NumSamples               uint64 `json:"numSamples,omitempty"`
+	NumSeries                uint64 `json:"numSeries,omitempty"`
+	NumChunks                uint64 `json:"numChunks,omitempty"`
+	NumTombstones            uint64 `json:"numTombstones,omitempty"`
+	NumNativeHistogramChunks uint64 `json:"numNativeHistogramChunks,omitempty"`
 }
 
 // BlockDesc describes a block by ULID and time range.


### PR DESCRIPTION
This PR adds a new `NumNativeHistogramChunks` property to `tsdb.BlockStats` that tracks the number of native histogram chunks within the block.

This can be useful in cases where blocks containing native histograms may need to undergo special treatment such as in https://github.com/grafana/mimir/issues/3971.

Signed-off-by: Justin Lei <justin.lei@grafana.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
