### PR TITLE
Option to align rule group's evaluation time to interval

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -135,12 +135,13 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.
 type RuleGroup struct {
-	Name            string          `yaml:"name"`
-	Interval        model.Duration  `yaml:"interval,omitempty"`
-	EvaluationDelay *model.Duration `yaml:"evaluation_delay,omitempty"`
-	Limit           int             `yaml:"limit,omitempty"`
-	Rules           []RuleNode      `yaml:"rules"`
-	SourceTenants   []string        `yaml:"source_tenants,omitempty"`
+	Name                         string          `yaml:"name"`
+	Interval                     model.Duration  `yaml:"interval,omitempty"`
+	EvaluationDelay              *model.Duration `yaml:"evaluation_delay,omitempty"`
+	Limit                        int             `yaml:"limit,omitempty"`
+	Rules                        []RuleNode      `yaml:"rules"`
+	SourceTenants                []string        `yaml:"source_tenants,omitempty"`
+	AlignExecutionTimeOnInterval bool            `yaml:"align_execution_time_on_interval,omitempty"`
 }
 
 // Rule describes an alerting or recording rule.

--- a/rules/fixtures/rules_with_alignment.yaml
+++ b/rules/fixtures/rules_with_alignment.yaml
@@ -1,0 +1,20 @@
+groups:
+  - name: aligned
+    align_execution_time_on_interval: true
+    interval: 5m
+    rules:
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+
+  - name: unaligned_default
+    interval: 5m
+    rules:
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+
+  - name: unaligned_explicit
+    interval: 5m
+    align_execution_time_on_interval: false
+    rules:
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/fixtures/rules_with_alignment.yaml
+++ b/rules/fixtures/rules_with_alignment.yaml
@@ -6,6 +6,13 @@ groups:
       - record: job:http_requests:rate5m
         expr: sum by (job)(rate(http_requests_total[5m]))
 
+  - name: aligned_with_crazy_interval
+    align_execution_time_on_interval: true
+    interval: 1m27s
+    rules:
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+
   - name: unaligned_default
     interval: 5m
     rules:

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
@@ -919,6 +920,67 @@ func TestUpdateSetsSourceTenants(t *testing.T) {
 	}
 }
 
+func TestAlignEvaluationTimeOnInterval(t *testing.T) {
+	st := teststorage.New(t)
+	defer st.Close()
+
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promql.NewEngine(opts)
+	ruleManager := NewManager(&ManagerOptions{
+		Appendable: st,
+		Queryable:  st,
+		QueryFunc:  EngineQueryFunc(engine, st),
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+	})
+	ruleManager.start()
+	defer ruleManager.Stop()
+
+	rgs, errs := rulefmt.ParseFile("fixtures/rules_with_alignment.yaml")
+	require.Empty(t, errs, "file parsing failures")
+
+	tmpFile, err := os.CreateTemp("", "rules.test.*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	reloadRules(rgs, t, tmpFile, ruleManager, 0)
+
+	// Verify that all groups are loaded, and let's check their evaluation times.
+	loadedGroups := ruleManager.RuleGroups()
+	require.Len(t, loadedGroups, len(rgs.Groups))
+
+	assertGroupEvalTimeAlignedOnIntervalIsHonored := func(groupName string, expectedAligned bool) {
+		g := (*Group)(nil)
+		for _, lg := range loadedGroups {
+			if lg.name == groupName {
+				g = lg
+				break
+			}
+		}
+		require.NotNil(t, g, "group not found: %s", groupName)
+
+		// In very rare cases (when g.hash() % g.interval == 0) alignment cannot be checked, because aligned and unaligned eval timestamps
+		// would be the same. Chance of this happening is tiny.
+		require.NotZero(t, g.hash()%uint64(g.interval), "alignment cannot be checked")
+
+		now := time.Now()
+		ts := g.EvalTimestamp(now.UnixNano())
+
+		aligned := ts.UnixNano()%g.interval.Nanoseconds() == 0
+		assert.Equal(t, expectedAligned, aligned, "group: %s, hash: %d, now: %d", groupName, g.hash(), now.UnixNano())
+	}
+
+	assertGroupEvalTimeAlignedOnIntervalIsHonored("aligned", true)
+	assertGroupEvalTimeAlignedOnIntervalIsHonored("unaligned_default", false)
+	assertGroupEvalTimeAlignedOnIntervalIsHonored("unaligned_explicit", false)
+}
+
 func TestGroupEvaluationContextFuncIsCalledWhenSupplied(t *testing.T) {
 	type testContextKeyType string
 	var testContextKey testContextKeyType = "TestGroupEvaluationContextFuncIsCalledWhenSupplied"
@@ -975,11 +1037,12 @@ type ruleGroupsTest struct {
 
 // ruleGroupTest forms a testing struct for running tests over rules.
 type ruleGroupTest struct {
-	Name          string         `yaml:"name"`
-	Interval      model.Duration `yaml:"interval,omitempty"`
-	Limit         int            `yaml:"limit,omitempty"`
-	Rules         []rulefmt.Rule `yaml:"rules"`
-	SourceTenants []string       `yaml:"source_tenants,omitempty"`
+	Name                         string         `yaml:"name"`
+	Interval                     model.Duration `yaml:"interval,omitempty"`
+	Limit                        int            `yaml:"limit,omitempty"`
+	Rules                        []rulefmt.Rule `yaml:"rules"`
+	SourceTenants                []string       `yaml:"source_tenants,omitempty"`
+	AlignExecutionTimeOnInterval bool           `yaml:"align_execution_time_on_interval,omitempty"`
 }
 
 func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
@@ -998,11 +1061,12 @@ func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
 			})
 		}
 		tmp = append(tmp, ruleGroupTest{
-			Name:          g.Name,
-			Interval:      g.Interval,
-			Limit:         g.Limit,
-			Rules:         rtmp,
-			SourceTenants: g.SourceTenants,
+			Name:                         g.Name,
+			Interval:                     g.Interval,
+			Limit:                        g.Limit,
+			Rules:                        rtmp,
+			SourceTenants:                g.SourceTenants,
+			AlignExecutionTimeOnInterval: g.AlignExecutionTimeOnInterval,
 		})
 	}
 	return ruleGroupsTest{

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
@@ -973,7 +972,7 @@ func TestAlignEvaluationTimeOnInterval(t *testing.T) {
 		ts := g.EvalTimestamp(now.UnixNano())
 
 		aligned := ts.UnixNano()%g.interval.Nanoseconds() == 0
-		assert.Equal(t, expectedAligned, aligned, "group: %s, hash: %d, now: %d", groupName, g.hash(), now.UnixNano())
+		require.Equal(t, expectedAligned, aligned, "group: %s, hash: %d, now: %d", groupName, g.hash(), now.UnixNano())
 	}
 
 	assertGroupEvalTimeAlignedOnIntervalIsHonored("aligned", true)


### PR DESCRIPTION
This PR adds option to rule groups to align their evaluation time on evaluation interval.

This can be useful for example redundancy when two rulers are evaluating same rules -- if they both generate samples with same timestamp, only one sample will be written. But if one of rulers fails, the other one can keep on writing data.

(Our use case is different)