### PR TITLE
Fix name of align_execution_time_on_interval option.

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -135,13 +135,13 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.
 type RuleGroup struct {
-	Name                         string          `yaml:"name"`
-	Interval                     model.Duration  `yaml:"interval,omitempty"`
-	EvaluationDelay              *model.Duration `yaml:"evaluation_delay,omitempty"`
-	Limit                        int             `yaml:"limit,omitempty"`
-	Rules                        []RuleNode      `yaml:"rules"`
-	SourceTenants                []string        `yaml:"source_tenants,omitempty"`
-	AlignExecutionTimeOnInterval bool            `yaml:"align_execution_time_on_interval,omitempty"`
+	Name                          string          `yaml:"name"`
+	Interval                      model.Duration  `yaml:"interval,omitempty"`
+	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty"`
+	Limit                         int             `yaml:"limit,omitempty"`
+	Rules                         []RuleNode      `yaml:"rules"`
+	SourceTenants                 []string        `yaml:"source_tenants,omitempty"`
+	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty"`
 }
 
 // Rule describes an alerting or recording rule.

--- a/rules/fixtures/rules_with_alignment.yaml
+++ b/rules/fixtures/rules_with_alignment.yaml
@@ -1,13 +1,13 @@
 groups:
   - name: aligned
-    align_execution_time_on_interval: true
+    align_evaluation_time_on_interval: true
     interval: 5m
     rules:
       - record: job:http_requests:rate5m
         expr: sum by (job)(rate(http_requests_total[5m]))
 
   - name: aligned_with_crazy_interval
-    align_execution_time_on_interval: true
+    align_evaluation_time_on_interval: true
     interval: 1m27s
     rules:
       - record: job:http_requests:rate5m
@@ -21,7 +21,7 @@ groups:
 
   - name: unaligned_explicit
     interval: 5m
-    align_execution_time_on_interval: false
+    align_evaluation_time_on_interval: false
     rules:
       - record: job:http_requests:rate5m
         expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -270,8 +270,8 @@ type Group struct {
 
 	metrics *Metrics
 
-	ruleGroupPostProcessFunc     RuleGroupPostProcessFunc
-	alignExecutionTimeOnInterval bool
+	ruleGroupPostProcessFunc      RuleGroupPostProcessFunc
+	alignEvaluationTimeOnInterval bool
 }
 
 // This function will be used before each rule group evaluation if not nil.
@@ -279,17 +279,17 @@ type Group struct {
 type RuleGroupPostProcessFunc func(g *Group, lastEvalTimestamp time.Time, log log.Logger) error
 
 type GroupOptions struct {
-	Name, File                   string
-	Interval                     time.Duration
-	Limit                        int
-	Rules                        []Rule
-	SourceTenants                []string
-	ShouldRestore                bool
-	Opts                         *ManagerOptions
-	EvaluationDelay              *time.Duration
-	done                         chan struct{}
-	RuleGroupPostProcessFunc     RuleGroupPostProcessFunc
-	AlignExecutionTimeOnInterval bool
+	Name, File                    string
+	Interval                      time.Duration
+	Limit                         int
+	Rules                         []Rule
+	SourceTenants                 []string
+	ShouldRestore                 bool
+	Opts                          *ManagerOptions
+	EvaluationDelay               *time.Duration
+	done                          chan struct{}
+	RuleGroupPostProcessFunc      RuleGroupPostProcessFunc
+	AlignEvaluationTimeOnInterval bool
 }
 
 // NewGroup makes a new Group with the given name, options, and rules.
@@ -311,23 +311,23 @@ func NewGroup(o GroupOptions) *Group {
 	metrics.GroupInterval.WithLabelValues(key).Set(o.Interval.Seconds())
 
 	return &Group{
-		name:                         o.Name,
-		file:                         o.File,
-		interval:                     o.Interval,
-		evaluationDelay:              o.EvaluationDelay,
-		limit:                        o.Limit,
-		rules:                        o.Rules,
-		shouldRestore:                o.ShouldRestore,
-		opts:                         o.Opts,
-		sourceTenants:                o.SourceTenants,
-		seriesInPreviousEval:         make([]map[string]labels.Labels, len(o.Rules)),
-		done:                         make(chan struct{}),
-		managerDone:                  o.done,
-		terminated:                   make(chan struct{}),
-		logger:                       log.With(o.Opts.Logger, "file", o.File, "group", o.Name),
-		metrics:                      metrics,
-		ruleGroupPostProcessFunc:     o.RuleGroupPostProcessFunc,
-		alignExecutionTimeOnInterval: o.AlignExecutionTimeOnInterval,
+		name:                          o.Name,
+		file:                          o.File,
+		interval:                      o.Interval,
+		evaluationDelay:               o.EvaluationDelay,
+		limit:                         o.Limit,
+		rules:                         o.Rules,
+		shouldRestore:                 o.ShouldRestore,
+		opts:                          o.Opts,
+		sourceTenants:                 o.SourceTenants,
+		seriesInPreviousEval:          make([]map[string]labels.Labels, len(o.Rules)),
+		done:                          make(chan struct{}),
+		managerDone:                   o.done,
+		terminated:                    make(chan struct{}),
+		logger:                        log.With(o.Opts.Logger, "file", o.File, "group", o.Name),
+		metrics:                       metrics,
+		ruleGroupPostProcessFunc:      o.RuleGroupPostProcessFunc,
+		alignEvaluationTimeOnInterval: o.AlignEvaluationTimeOnInterval,
 	}
 }
 
@@ -551,7 +551,7 @@ func (g *Group) setLastEvaluation(ts time.Time) {
 // EvalTimestamp returns the immediately preceding consistently slotted evaluation time.
 func (g *Group) EvalTimestamp(startTime int64) time.Time {
 	var offset int64
-	if !g.alignExecutionTimeOnInterval {
+	if !g.alignEvaluationTimeOnInterval {
 		offset = int64(g.hash() % uint64(g.interval))
 	}
 
@@ -933,7 +933,7 @@ func (g *Group) Equals(ng *Group) bool {
 		return false
 	}
 
-	if g.alignExecutionTimeOnInterval != ng.alignExecutionTimeOnInterval {
+	if g.alignEvaluationTimeOnInterval != ng.alignEvaluationTimeOnInterval {
 		return false
 	}
 
@@ -1205,18 +1205,18 @@ func (m *Manager) LoadGroups(
 			}
 
 			groups[GroupKey(fn, rg.Name)] = NewGroup(GroupOptions{
-				Name:                         rg.Name,
-				File:                         fn,
-				Interval:                     itv,
-				Limit:                        rg.Limit,
-				Rules:                        rules,
-				SourceTenants:                rg.SourceTenants,
-				ShouldRestore:                shouldRestore,
-				Opts:                         m.opts,
-				EvaluationDelay:              (*time.Duration)(rg.EvaluationDelay),
-				done:                         m.done,
-				RuleGroupPostProcessFunc:     ruleGroupPostProcessFunc,
-				AlignExecutionTimeOnInterval: rg.AlignExecutionTimeOnInterval,
+				Name:                          rg.Name,
+				File:                          fn,
+				Interval:                      itv,
+				Limit:                         rg.Limit,
+				Rules:                         rules,
+				SourceTenants:                 rg.SourceTenants,
+				ShouldRestore:                 shouldRestore,
+				Opts:                          m.opts,
+				EvaluationDelay:               (*time.Duration)(rg.EvaluationDelay),
+				done:                          m.done,
+				RuleGroupPostProcessFunc:      ruleGroupPostProcessFunc,
+				AlignEvaluationTimeOnInterval: rg.AlignEvaluationTimeOnInterval,
 			})
 		}
 	}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1040,12 +1040,12 @@ type ruleGroupsTest struct {
 
 // ruleGroupTest forms a testing struct for running tests over rules.
 type ruleGroupTest struct {
-	Name                         string         `yaml:"name"`
-	Interval                     model.Duration `yaml:"interval,omitempty"`
-	Limit                        int            `yaml:"limit,omitempty"`
-	Rules                        []rulefmt.Rule `yaml:"rules"`
-	SourceTenants                []string       `yaml:"source_tenants,omitempty"`
-	AlignExecutionTimeOnInterval bool           `yaml:"align_execution_time_on_interval,omitempty"`
+	Name                          string         `yaml:"name"`
+	Interval                      model.Duration `yaml:"interval,omitempty"`
+	Limit                         int            `yaml:"limit,omitempty"`
+	Rules                         []rulefmt.Rule `yaml:"rules"`
+	SourceTenants                 []string       `yaml:"source_tenants,omitempty"`
+	AlignEvaluationTimeOnInterval bool           `yaml:"align_evaluation_time_on_interval,omitempty"`
 }
 
 func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
@@ -1064,12 +1064,12 @@ func formatRules(r *rulefmt.RuleGroups) ruleGroupsTest {
 			})
 		}
 		tmp = append(tmp, ruleGroupTest{
-			Name:                         g.Name,
-			Interval:                     g.Interval,
-			Limit:                        g.Limit,
-			Rules:                        rtmp,
-			SourceTenants:                g.SourceTenants,
-			AlignExecutionTimeOnInterval: g.AlignExecutionTimeOnInterval,
+			Name:                          g.Name,
+			Interval:                      g.Interval,
+			Limit:                         g.Limit,
+			Rules:                         rtmp,
+			SourceTenants:                 g.SourceTenants,
+			AlignEvaluationTimeOnInterval: g.AlignEvaluationTimeOnInterval,
 		})
 	}
 	return ruleGroupsTest{


### PR DESCRIPTION
This PR renames newly introduced align_execution_time_on_interval to use "evaluation" instead of "execution"