### PR TITLE
Fixup labels usage

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3114,17 +3114,11 @@ func TestRangeQuery(t *testing.T) {
 			Result: Matrix{
 				Series{
 					Points: []Point{{V: 1, T: 0}, {V: 3, T: 60000}, {V: 5, T: 120000}},
-					Metric: labels.Labels{
-						labels.Label{Name: "__name__", Value: "bar"},
-						labels.Label{Name: "job", Value: "2"},
-					},
+					Metric: labels.FromStrings("__name__", "bar", "job", "2"),
 				},
 				Series{
 					Points: []Point{{V: 3, T: 60000}, {V: 5, T: 120000}},
-					Metric: labels.Labels{
-						labels.Label{Name: "__name__", Value: "foo"},
-						labels.Label{Name: "job", Value: "1"},
-					},
+					Metric: labels.FromStrings("__name__", "foo", "job", "1"),
 				},
 			},
 			Start:    time.Unix(0, 0),

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -828,7 +828,7 @@ func TestUpdate_AlwaysRestore(t *testing.T) {
 	ruleManager.start()
 	defer ruleManager.Stop()
 
-	err := ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts.yaml"}, nil, "", nil)
+	err := ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts.yaml"}, labels.EmptyLabels(), "", nil)
 	require.NoError(t, err)
 
 	for _, g := range ruleManager.groups {
@@ -837,7 +837,7 @@ func TestUpdate_AlwaysRestore(t *testing.T) {
 	}
 
 	// Use different file, so groups haven't changed, therefore, we expect state restoration
-	err = ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts2.yaml"}, nil, "", nil)
+	err = ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts2.yaml"}, labels.EmptyLabels(), "", nil)
 	for _, g := range ruleManager.groups {
 		require.True(t, g.shouldRestore)
 	}
@@ -860,7 +860,7 @@ func TestUpdate_AlwaysRestoreDoesntAffectUnchangedGroups(t *testing.T) {
 	ruleManager.start()
 	defer ruleManager.Stop()
 
-	err := ruleManager.Update(10*time.Second, files, nil, "", nil)
+	err := ruleManager.Update(10*time.Second, files, labels.EmptyLabels(), "", nil)
 	require.NoError(t, err)
 
 	for _, g := range ruleManager.groups {
@@ -869,7 +869,7 @@ func TestUpdate_AlwaysRestoreDoesntAffectUnchangedGroups(t *testing.T) {
 	}
 
 	// Use the same file, so groups haven't changed, therefore, we don't expect state restoration
-	err = ruleManager.Update(10*time.Second, files, nil, "", nil)
+	err = ruleManager.Update(10*time.Second, files, labels.EmptyLabels(), "", nil)
 	for _, g := range ruleManager.groups {
 		require.False(t, g.shouldRestore)
 	}
@@ -1087,7 +1087,7 @@ func reloadRules(rgs *rulefmt.RuleGroups, t *testing.T, tmpFile *os.File, ruleMa
 	_, _ = tmpFile.Seek(0, 0)
 	_, err = tmpFile.Write(bs)
 	require.NoError(t, err)
-	err = ruleManager.Update(interval, []string{tmpFile.Name()}, nil, "", nil)
+	err = ruleManager.Update(interval, []string{tmpFile.Name()}, labels.EmptyLabels(), "", nil)
 	require.NoError(t, err)
 }
 
@@ -1683,7 +1683,7 @@ groups:
 		},
 	})
 	m.start()
-	err = m.Update(time.Second, []string{fname}, nil, "", nil)
+	err = m.Update(time.Second, []string{fname}, labels.EmptyLabels(), "", nil)
 	require.NoError(t, err)
 
 	rgs := m.RuleGroups()

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -1178,13 +1178,17 @@ func (c *LeveledCompactor) populateSymbols(sets []storage.ChunkSeriesSet, outBlo
 			obIx = c.shardFunc(s.Labels()) % uint64(len(outBlocks))
 		}
 
-		for _, l := range s.Labels() {
+		err := s.Labels().Validate(func(l labels.Label) error {
 			if err := batchers[obIx].addSymbol(l.Name); err != nil {
 				return errors.Wrap(err, "addSymbol to batcher")
 			}
 			if err := batchers[obIx].addSymbol(l.Value); err != nil {
 				return errors.Wrap(err, "addSymbol to batcher")
 			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -600,10 +600,10 @@ func TestCompaction_CompactWithSplitting(t *testing.T) {
 						require.Equal(t, uint64(shardIndex), lbls.Labels().Hash()%shardCount)
 
 						// Collect all symbols used by series.
-						for _, l := range lbls.Labels() {
+						lbls.Labels().Range(func(l labels.Label) {
 							seriesSymbols[l.Name] = struct{}{}
 							seriesSymbols[l.Value] = struct{}{}
-						}
+						})
 					}
 					require.NoError(t, p.Err())
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2443,10 +2443,7 @@ func TestHeadShardedPostings(t *testing.T) {
 	// Append some series.
 	app := head.Appender(context.Background())
 	for i := 0; i < 100; i++ {
-		_, err := app.Append(0, labels.Labels{
-			{Name: "unique", Value: fmt.Sprintf("value%d", i)},
-			{Name: "const", Value: "1"},
-		}, 100, 0)
+		_, err := app.Append(0, labels.FromStrings("unique", fmt.Sprintf("value%d", i), "const", "1"), 100, 0)
 		require.NoError(t, err)
 	}
 	require.NoError(t, app.Commit())

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -630,10 +630,8 @@ func BenchmarkReader_ShardedPostings(b *testing.B) {
 	require.NoError(b, iw.AddSymbol("unique"))
 
 	for i := 1; i <= numSeries; i++ {
-		require.NoError(b, iw.AddSeries(storage.SeriesRef(i), labels.Labels{
-			{Name: "const", Value: fmt.Sprintf("%10d", 1)},
-			{Name: "unique", Value: fmt.Sprintf("%10d", i)},
-		}))
+		require.NoError(b, iw.AddSeries(storage.SeriesRef(i),
+			labels.FromStrings("const", fmt.Sprintf("%10d", 1), "unique", fmt.Sprintf("%10d", i))))
 	}
 
 	require.NoError(b, iw.Close())


### PR DESCRIPTION
Code should not be assuming `labels.Labels` is a slice, because at some point that could change.
