### PR TITLE
Implement fully-featured content negotiation for API requests, and allow overriding the default API codec.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2769,9 +2769,11 @@ func TestRespondSuccess(t *testing.T) {
 		logger: log.NewNopLogger(),
 	}
 
-	api.InstallCodec(&testCodec{contentType: "test/cannot-encode", canEncode: false})
-	api.InstallCodec(&testCodec{contentType: "test/can-encode", canEncode: true})
-	api.InstallCodec(&testCodec{contentType: "test/can-encode-2", canEncode: true})
+	api.ClearCodecs()
+	api.InstallCodec(JSONCodec{})
+	api.InstallCodec(&testCodec{contentType: MIMEType{"test", "cannot-encode"}, canEncode: false})
+	api.InstallCodec(&testCodec{contentType: MIMEType{"test", "can-encode"}, canEncode: true})
+	api.InstallCodec(&testCodec{contentType: MIMEType{"test", "can-encode-2"}, canEncode: true})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		api.respond(w, r, "test", nil)
@@ -3307,11 +3309,11 @@ func TestGetGlobalURL(t *testing.T) {
 }
 
 type testCodec struct {
-	contentType string
+	contentType MIMEType
 	canEncode   bool
 }
 
-func (t *testCodec) ContentType() string {
+func (t *testCodec) ContentType() MIMEType {
 	return t.contentType
 }
 

--- a/web/api/v1/codec.go
+++ b/web/api/v1/codec.go
@@ -13,14 +13,41 @@
 
 package v1
 
+import "github.com/munnerz/goautoneg"
+
 // A Codec performs encoding of API responses.
 type Codec interface {
 	// ContentType returns the MIME time that this Codec emits.
-	ContentType() string
+	ContentType() MIMEType
 
 	// CanEncode determines if this Codec can encode resp.
 	CanEncode(resp *Response) bool
 
 	// Encode encodes resp, ready for transmission to an API consumer.
 	Encode(resp *Response) ([]byte, error)
+}
+
+type MIMEType struct {
+	Type    string
+	SubType string
+}
+
+func (m MIMEType) String() string {
+	return m.Type + "/" + m.SubType
+}
+
+func (m MIMEType) Satisfies(accept goautoneg.Accept) bool {
+	if accept.Type == "*" && accept.SubType == "*" {
+		return true
+	}
+
+	if accept.Type == m.Type && accept.SubType == "*" {
+		return true
+	}
+
+	if accept.Type == m.Type && accept.SubType == m.SubType {
+		return true
+	}
+
+	return false
 }

--- a/web/api/v1/codec_test.go
+++ b/web/api/v1/codec_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/munnerz/goautoneg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMIMEType_String(t *testing.T) {
+	m := MIMEType{Type: "application", SubType: "json"}
+
+	require.Equal(t, "application/json", m.String())
+}
+
+func TestMIMEType_Satisfies(t *testing.T) {
+	m := MIMEType{Type: "application", SubType: "json"}
+
+	scenarios := map[string]struct {
+		accept   goautoneg.Accept
+		expected bool
+	}{
+		"exact match": {
+			accept:   goautoneg.Accept{Type: "application", SubType: "json"},
+			expected: true,
+		},
+		"sub-type wildcard match": {
+			accept:   goautoneg.Accept{Type: "application", SubType: "*"},
+			expected: true,
+		},
+		"full wildcard match": {
+			accept:   goautoneg.Accept{Type: "*", SubType: "*"},
+			expected: true,
+		},
+		"inverted": {
+			accept:   goautoneg.Accept{Type: "json", SubType: "application"},
+			expected: false,
+		},
+		"inverted sub-type wildcard": {
+			accept:   goautoneg.Accept{Type: "json", SubType: "*"},
+			expected: false,
+		},
+		"complete mismatch": {
+			accept:   goautoneg.Accept{Type: "text", SubType: "plain"},
+			expected: false,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			actual := m.Satisfies(scenario.accept)
+			require.Equal(t, scenario.expected, actual)
+		})
+	}
+}

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -34,8 +34,8 @@ func init() {
 // JSONCodec is a Codec that encodes API responses as JSON.
 type JSONCodec struct{}
 
-func (j JSONCodec) ContentType() string {
-	return "application/json"
+func (j JSONCodec) ContentType() MIMEType {
+	return MIMEType{Type: "application", SubType: "json"}
 }
 
 func (j JSONCodec) CanEncode(_ *Response) bool {


### PR DESCRIPTION
This resolves a concern with merging content negotiation to upstream (see https://github.com/prometheus/prometheus/pull/11905). 

It also allows us to override the default codec, which will allow us to use a custom codec that forbids encoding native histograms in the default JSON format between queriers and query frontends.