### PR TITLE
Correct license header in `web/api/v1/codec_test.go`.

### DIFF
--- a/web/api/v1/codec_test.go
+++ b/web/api/v1/codec_test.go
@@ -1,4 +1,15 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package v1
 


### PR DESCRIPTION
This was incorrectly added as part of #428.
