### PR TITLE
Do not optimize regexps with begin/end text anchors inside

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -325,6 +325,14 @@ func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
 	clearCapture(re)
 
 	switch re.Op {
+	case syntax.OpBeginText:
+		// Correctly handling the begin text operator inside a regex is tricky,
+		// so in this case we fallback to the regex engine.
+		return nil
+	case syntax.OpEndText:
+		// Correctly handling the end text operator inside a regex is tricky,
+		// so in this case we fallback to the regex engine.
+		return nil
 	case syntax.OpPlus, syntax.OpStar:
 		if re.Sub[0].Op != syntax.OpAnyChar && re.Sub[0].Op != syntax.OpAnyCharNotNL {
 			return nil

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -49,7 +49,7 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 	if parsed.Op == syntax.OpConcat {
 		m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
 	}
-	if matches, caseSensitive := findSetMatches(parsed, ""); caseSensitive {
+	if matches, caseSensitive := findSetMatches(parsed); caseSensitive {
 		m.setMatches = matches
 	}
 	m.stringMatcher = stringMatcherFromRegexp(parsed)
@@ -60,10 +60,22 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 // findSetMatches extract equality matches from a regexp.
 // Returns nil if we can't replace the regexp by only equality matchers or the regexp contains
 // a mix of case sensitive and case insensitive matchers.
-func findSetMatches(re *syntax.Regexp, base string) (matches []string, caseSensitive bool) {
+func findSetMatches(re *syntax.Regexp) (matches []string, caseSensitive bool) {
 	clearBeginEndText(re)
 
+	return findSetMatchesInternal(re, "")
+}
+
+func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, caseSensitive bool) {
 	switch re.Op {
+	case syntax.OpBeginText:
+		// Correctly handling the begin text operator inside a regex is tricky,
+		// so in this case we fallback to the regex engine.
+		return nil, false
+	case syntax.OpEndText:
+		// Correctly handling the end text operator inside a regex is tricky,
+		// so in this case we fallback to the regex engine.
+		return nil, false
 	case syntax.OpLiteral:
 		return []string{base + string(re.Rune)}, isCaseSensitive(re)
 	case syntax.OpEmptyMatch:
@@ -74,7 +86,7 @@ func findSetMatches(re *syntax.Regexp, base string) (matches []string, caseSensi
 		return findSetMatchesFromAlternate(re, base)
 	case syntax.OpCapture:
 		clearCapture(re)
-		return findSetMatches(re, base)
+		return findSetMatchesInternal(re, base)
 	case syntax.OpConcat:
 		return findSetMatchesFromConcat(re, base)
 	case syntax.OpCharClass:
@@ -116,7 +128,7 @@ func findSetMatchesFromConcat(re *syntax.Regexp, base string) (matches []string,
 	for i := 0; i < len(re.Sub); i++ {
 		var newMatches []string
 		for j, b := range matches {
-			m, caseSensitive := findSetMatches(re.Sub[i], b)
+			m, caseSensitive := findSetMatchesInternal(re.Sub[i], b)
 			if m == nil {
 				return nil, false
 			}
@@ -144,7 +156,7 @@ func findSetMatchesFromConcat(re *syntax.Regexp, base string) (matches []string,
 
 func findSetMatchesFromAlternate(re *syntax.Regexp, base string) (matches []string, matchesCaseSensitive bool) {
 	for i, sub := range re.Sub {
-		found, caseSensitive := findSetMatches(sub, base)
+		found, caseSensitive := findSetMatchesInternal(sub, base)
 		if found == nil {
 			return nil, false
 		}
@@ -179,6 +191,12 @@ func clearCapture(regs ...*syntax.Regexp) {
 
 // clearBeginEndText removes the begin and end text from the regexp. Prometheus regexp are anchored to the beginning and end of the string.
 func clearBeginEndText(re *syntax.Regexp) {
+	// Do not clear begin/end text from an alternate operator because it could
+	// change the actual regexp properties.
+	if re.Op == syntax.OpAlternate {
+		return
+	}
+
 	if len(re.Sub) == 0 {
 		return
 	}
@@ -298,8 +316,13 @@ type StringMatcher interface {
 // It returns nil if the regexp is not supported.
 // For examples, it will replace `.*foo` with `foo.*` and `.*foo.*` with `(?i)foo`.
 func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
-	clearCapture(re)
 	clearBeginEndText(re)
+
+	return stringMatcherFromRegexpInternal(re)
+}
+
+func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
+	clearCapture(re)
 
 	switch re.Op {
 	case syntax.OpPlus, syntax.OpStar:
@@ -321,7 +344,7 @@ func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
 	case syntax.OpAlternate:
 		or := make([]StringMatcher, 0, len(re.Sub))
 		for _, sub := range re.Sub {
-			m := stringMatcherFromRegexp(sub)
+			m := stringMatcherFromRegexpInternal(sub)
 			if m == nil {
 				return nil
 			}
@@ -334,26 +357,26 @@ func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
 			return emptyStringMatcher{}
 		}
 		if len(re.Sub) == 1 {
-			return stringMatcherFromRegexp(re.Sub[0])
+			return stringMatcherFromRegexpInternal(re.Sub[0])
 		}
 		var left, right StringMatcher
 		// Let's try to find if there's a first and last any matchers.
 		if re.Sub[0].Op == syntax.OpPlus || re.Sub[0].Op == syntax.OpStar {
-			left = stringMatcherFromRegexp(re.Sub[0])
+			left = stringMatcherFromRegexpInternal(re.Sub[0])
 			if left == nil {
 				return nil
 			}
 			re.Sub = re.Sub[1:]
 		}
 		if re.Sub[len(re.Sub)-1].Op == syntax.OpPlus || re.Sub[len(re.Sub)-1].Op == syntax.OpStar {
-			right = stringMatcherFromRegexp(re.Sub[len(re.Sub)-1])
+			right = stringMatcherFromRegexpInternal(re.Sub[len(re.Sub)-1])
 			if right == nil {
 				return nil
 			}
 			re.Sub = re.Sub[:len(re.Sub)-1]
 		}
 
-		matches, matchesCaseSensitive := findSetMatches(re, "")
+		matches, matchesCaseSensitive := findSetMatchesInternal(re, "")
 		if len(matches) == 0 {
 			return nil
 		}

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -129,6 +129,9 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		{regex: "(?i).*(?-i:abc)def", prefix: "", suffix: "", contains: "abc"},
 		{regex: ".*(?msU:abc).*", prefix: "", suffix: "", contains: "abc"},
 		{regex: "[aA]bc.*", prefix: "", suffix: "", contains: "bc"},
+		{regex: "^5..$", prefix: "5", suffix: "", contains: ""},
+		{regex: "^release.*", prefix: "release", suffix: "", contains: ""},
+		{regex: "^env-[0-9]+laio[1]?[^0-9].*", prefix: "env-", suffix: "", contains: "laio"},
 	}
 
 	for _, c := range cases {
@@ -164,8 +167,11 @@ func TestFindSetMatches(t *testing.T) {
 		{"bar|b|buzz", []string{"bar", "b", "buzz"}, true},
 		// Skip outer anchors (it's enforced anyway at the root).
 		{"^(bar|b|buzz)$", []string{"bar", "b", "buzz"}, true},
+		{"^(?:prod|production)$", []string{"prod", "production"}, true},
 		// Do not optimize regexp with inner anchors.
 		{"(bar|b|b^uz$z)", nil, false},
+		// Do not optimize regexp with empty string matcher.
+		{"^$|Running", nil, false},
 		// Simple sets containing escaped characters.
 		{"fo\\.o|bar\\?|\\^baz", []string{"fo.o", "bar?", "^baz"}, true},
 		// using charclass


### PR DESCRIPTION
I've added another fuzz test and found several issues related to how we optimize regexps when they contain the being/end text anchors inside. In the `main` version, we always remove being/end text anchors and we treat the regexp like if there were no anchors because of the assumption that any regex is anchored in Prometheus (which is true).

However, removing the begin/end text anchors from inside is not always safe. For example, if we remove the anchor from `^|x`, the resulting optimization is different because the empty string in one case is valid, while in the other case it's not.

After some experimentation, I found very difficult to correctly handle all begin/end text anchors, so in this PR I propose to not optimize a regexp if it contains them, unless they're really at tbe begin/end of the whole regexp.

I'm a bit sad with this PR because we may stop optimizing some regexps which were already correctly handled. Alternative, may be keep leaving with the bug in `main`, assuming customers don't run regexps like the absurd ones written by the fuzzy test.

I've run both fuzzy tests for few minutes and, with the changes in this PR, they don't report any more issue. However, it's also true that with the changes in this PR, a bunch of regexps generated by the fuzzy test are not optimized anymore.