### PR TITLE
Add TestAnalyzeRealQueries

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -59,6 +59,8 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 
 // isOptimized returns true if any fast-path optimization is applied to the
 // regex matcher.
+//
+//nolint:unused
 func (m *FastRegexMatcher) isOptimized() bool {
 	return len(m.setMatches) > 0 || m.stringMatcher != nil || m.prefix != "" || m.suffix != "" || m.contains != ""
 }

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -57,6 +57,12 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 	return m, nil
 }
 
+// isOptimized returns true if any fast-path optimization is applied to the
+// regex matcher.
+func (m *FastRegexMatcher) isOptimized() bool {
+	return len(m.setMatches) > 0 || m.stringMatcher != nil || m.prefix != "" || m.suffix != "" || m.contains != ""
+}
+
 // findSetMatches extract equality matches from a regexp.
 // Returns nil if we can't replace the regexp by only equality matchers or the regexp contains
 // a mix of case sensitive and case insensitive matchers.


### PR DESCRIPTION
The change introduced in https://github.com/grafana/mimir-prometheus/pull/433 made me wonder if we're skipping the optimization for a significative % of queries that we were optimizing before that PR. I've extracted 300k of queries with regexp matchers from production and computed the % of optimized matchers before/after PR #443.  The good news is that among the 300k queries analyzed, the PR #433 reduces the % of optimized queries by very few (from 96.06% to 95.95%). The other good news is that https://github.com/grafana/mimir-prometheus/pull/430 actually increased the optimized queries by about a +3%.

In this PR I would like to upstream the code to run the analysis as a skipped test, so that it's ready if we want to re-run it in the future.