### PR TITLE
Optimized very long case insensitive alternations

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -20,7 +20,14 @@ import (
 	"github.com/grafana/regexp/syntax"
 )
 
-const maxSetMatches = 256
+const (
+	maxSetMatches = 256
+
+	// The minimum number of alternate values a regex should have to trigger
+	// the optimization done by optimizeEqualStringMatchers(). This value has
+	// been computed running BenchmarkOptimizeEqualStringMatchers.
+	optimizeEqualStringMatchersThreshold = 16
+)
 
 type FastRegexMatcher struct {
 	re *regexp.Regexp
@@ -326,7 +333,10 @@ type StringMatcher interface {
 func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
 	clearBeginEndText(re)
 
-	return stringMatcherFromRegexpInternal(re)
+	m := stringMatcherFromRegexpInternal(re)
+	m = optimizeEqualStringMatchers(m, optimizeEqualStringMatchersThreshold)
+
+	return m
 }
 
 func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
@@ -503,6 +513,24 @@ func (m *equalStringMatcher) Matches(s string) bool {
 	return strings.EqualFold(m.s, s)
 }
 
+// equalMultiStringMatcher matches a string exactly against a set of valid values.
+type equalMultiStringMatcher struct {
+	// values to match a string against. If the matching is case insensitive,
+	// the values here must be lowercase.
+	values map[string]struct{}
+
+	caseSensitive bool
+}
+
+func (m *equalMultiStringMatcher) Matches(s string) bool {
+	if !m.caseSensitive {
+		s = strings.ToLower(s)
+	}
+
+	_, ok := m.values[s]
+	return ok
+}
+
 // anyStringMatcher is a matcher that matches any string.
 // It is used for the + and * operator. matchNL tells if it should matches newlines or not.
 type anyStringMatcher struct {
@@ -518,4 +546,80 @@ func (m *anyStringMatcher) Matches(s string) bool {
 		return false
 	}
 	return true
+}
+
+// optimizeEqualStringMatchers optimize a specific case where all matchers are made by an
+// alternation (orStringMatcher) of strings checked for equality (equalStringMatcher). In
+// this specific case, when we have many strings to match against we can use a map instead
+// of iterating over the list of strings.
+func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatcher {
+	values, caseSensitive := findEqualStringMatchers(input)
+	if values == nil {
+		return input
+	}
+
+	if len(values) < threshold {
+		return input
+	}
+
+	return &equalMultiStringMatcher{
+		values:        values,
+		caseSensitive: caseSensitive,
+	}
+}
+
+// findEqualStringMatchers analyze the input StringMatcher and return a map with all
+// equalStringMatcher values if and only if the input StringMatcher is composed by an
+// alternation of equalStringMatcher with the same case sensitivity.
+func findEqualStringMatchers(input StringMatcher) (values map[string]struct{}, caseSensitive bool) {
+	orInput, ok := input.(orStringMatcher)
+	if !ok {
+		return nil, false
+	}
+
+	values = map[string]struct{}{}
+
+	for _, m := range orInput {
+		switch casted := m.(type) {
+		case orStringMatcher:
+			subValues, subCaseSensitive := findEqualStringMatchers(m)
+			if subValues == nil {
+				return nil, false
+			}
+
+			// Ensure we don't have mixed case sensitivity.
+			if len(values) > 0 && caseSensitive != subCaseSensitive {
+				return nil, false
+			} else if len(values) == 0 {
+				caseSensitive = subCaseSensitive
+			}
+
+			// Merge the values with our owns.
+			for v := range subValues {
+				values[v] = struct{}{}
+			}
+
+		case *equalStringMatcher:
+			// Ensure we don't have mixed case sensitivity.
+			if len(values) > 0 && caseSensitive != casted.caseSensitive {
+				return nil, false
+			} else if len(values) == 0 {
+				caseSensitive = casted.caseSensitive
+			}
+
+			// Store the value (lower case if matcher is case insensitive).
+			if caseSensitive {
+				values[casted.s] = struct{}{}
+			} else {
+				values[strings.ToLower(casted.s)] = struct{}{}
+			}
+
+		default:
+			// It's not an equal string matcher, so we have to stop searching
+			// cause this optimization can't be applied.
+			return nil, false
+		}
+	}
+
+	return
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -169,9 +169,9 @@ func TestFindSetMatches(t *testing.T) {
 		// Skip outer anchors (it's enforced anyway at the root).
 		{"^(bar|b|buzz)$", []string{"bar", "b", "buzz"}, true},
 		{"^(?:prod|production)$", []string{"prod", "production"}, true},
-		// Do not optimizeEqualStringMatchers regexp with inner anchors.
+		// Do not optimize regexp with inner anchors.
 		{"(bar|b|b^uz$z)", nil, false},
-		// Do not optimizeEqualStringMatchers regexp with empty string matcher.
+		// Do not optimize regexp with empty string matcher.
 		{"^$|Running", nil, false},
 		// Simple sets containing escaped characters.
 		{"fo\\.o|bar\\?|\\^baz", []string{"fo.o", "bar?", "^baz"}, true},

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -93,27 +93,15 @@ func TestNewFastRegexMatcher(t *testing.T) {
 }
 
 func BenchmarkNewFastRegexMatcher(b *testing.B) {
-	benchValues := values
-	for _, v := range values {
-		for i := 5; i < 50; i = i + 5 {
-			benchValues = append(benchValues, v+randString(i))
-			benchValues = append(benchValues, randString(i)+v+randString(i))
-			benchValues = append(benchValues, randString(i)+v)
-		}
-	}
 	for _, r := range regexes {
-		r := r
-		b.Run(r, func(b *testing.B) {
-			m, err := NewFastRegexMatcher(r)
-			require.NoError(b, err)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				for _, v := range benchValues {
-					_ = m.MatchString(v)
+		b.Run(getTestNameFromRegexp(r), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_, err := NewFastRegexMatcher(r)
+				if err != nil {
+					b.Fatal(err)
 				}
 			}
 		})
-
 	}
 }
 
@@ -243,12 +231,7 @@ func BenchmarkFastRegexMatcher(b *testing.B) {
 		z = x + "foo"
 	)
 	for _, r := range regexes {
-		testName := r
-		if len(testName) > 32 {
-			testName = testName[:32]
-		}
-
-		b.Run(testName, func(b *testing.B) {
+		b.Run(getTestNameFromRegexp(r), func(b *testing.B) {
 			m, err := NewFastRegexMatcher(r)
 			require.NoError(b, err)
 			b.ResetTimer()
@@ -576,4 +559,11 @@ func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
 			})
 		}
 	}
+}
+
+func getTestNameFromRegexp(re string) string {
+	if len(re) > 32 {
+		return re[:32]
+	}
+	return re
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -489,7 +489,7 @@ func TestOptimizeEqualStringMatchers(t *testing.T) {
 			},
 			expectedValues: nil,
 		},
-		"should return lowercase values case insensitive matchers": {
+		"should return lowercase values on case insensitive matchers": {
 			input: orStringMatcher{
 				&equalStringMatcher{s: "FOO", caseSensitive: false},
 				orStringMatcher{

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -15,6 +15,7 @@ package labels
 
 import (
 	"bufio"
+	"fmt"
 	"math/rand"
 	"os"
 	"strings"
@@ -86,9 +87,9 @@ func BenchmarkNewFastRegexMatcher(b *testing.B) {
 	benchValues := values
 	for _, v := range values {
 		for i := 5; i < 50; i = i + 5 {
-			benchValues = append(benchValues, v+RandStringRunes(i))
-			benchValues = append(benchValues, RandStringRunes(i)+v+RandStringRunes(i))
-			benchValues = append(benchValues, RandStringRunes(i)+v)
+			benchValues = append(benchValues, v+randString(i))
+			benchValues = append(benchValues, randString(i)+v+randString(i))
+			benchValues = append(benchValues, randString(i)+v)
 		}
 	}
 	for _, r := range regexes {
@@ -171,9 +172,9 @@ func TestFindSetMatches(t *testing.T) {
 		// Skip outer anchors (it's enforced anyway at the root).
 		{"^(bar|b|buzz)$", []string{"bar", "b", "buzz"}, true},
 		{"^(?:prod|production)$", []string{"prod", "production"}, true},
-		// Do not optimize regexp with inner anchors.
+		// Do not optimizeEqualStringMatchers regexp with inner anchors.
 		{"(bar|b|b^uz$z)", nil, false},
-		// Do not optimize regexp with empty string matcher.
+		// Do not optimizeEqualStringMatchers regexp with empty string matcher.
 		{"^$|Running", nil, false},
 		// Simple sets containing escaped characters.
 		{"fo\\.o|bar\\?|\\^baz", []string{"fo.o", "bar?", "^baz"}, true},
@@ -251,10 +252,18 @@ func BenchmarkFastRegexMatcher(b *testing.B) {
 		"(?i:(foo1|foo2|aaa|bbb|ccc|ddd|eee|fff|ggg|hhh|iii|lll|mmm|nnn|ooo|ppp|qqq|rrr|sss|ttt|uuu|vvv|www|xxx|yyy|zzz))",
 		"(prometheus|api_prom)_api_v1_.+",
 		"((fo(bar))|.+foo)",
+		// A long case sensitive alternation.
+		"zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb",
+		// A long case insensitive alternation.
+		"(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb))",
 	}
 	for _, r := range regexes {
-		r := r
-		b.Run(r, func(b *testing.B) {
+		testName := r
+		if len(testName) > 32 {
+			testName = testName[:32]
+		}
+
+		b.Run(testName, func(b *testing.B) {
 			m, err := NewFastRegexMatcher(r)
 			require.NoError(b, err)
 			b.ResetTimer()
@@ -331,12 +340,20 @@ func Test_OptimizeRegex(t *testing.T) {
 	}
 }
 
-func RandStringRunes(n int) string {
-	b := make([]rune, n)
+func randString(length int) string {
+	b := make([]rune, length)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func randStrings(many, length int) []string {
+	out := make([]string, 0, many)
+	for i := 0; i < many; i++ {
+		out = append(out, randString(length))
+	}
+	return out
 }
 
 func FuzzFastRegexMatcher_WithStaticallyDefinedRegularExpressions(f *testing.F) {
@@ -427,4 +444,151 @@ func TestAnalyzeRealQueries(t *testing.T) {
 	}
 
 	t.Logf("Found %d (%.2f%%) optimized matchers out of %d", numOptimized, (float64(numOptimized)/float64(numChecked))*100, numChecked)
+}
+
+func TestFindEqualStringMatchers(t *testing.T) {
+	tests := map[string]struct {
+		input                 StringMatcher
+		expectedValues        map[string]struct{}
+		expectedCaseSensitive bool
+	}{
+		"should return nil values on orStringMatcher with containsStringMatcher": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				&containsStringMatcher{substrings: []string{"a", "b", "c"}},
+			},
+			expectedValues: nil,
+		},
+		"should return values on orStringMatcher with equalStringMatcher and same case sensitivity": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				&equalStringMatcher{s: "bar", caseSensitive: true},
+				&equalStringMatcher{s: "baz", caseSensitive: true},
+			},
+			expectedValues: map[string]struct{}{
+				"FOO": {},
+				"bar": {},
+				"baz": {},
+			},
+			expectedCaseSensitive: true,
+		},
+		"should return nil values on orStringMatcher with equalStringMatcher but different case sensitivity": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				&equalStringMatcher{s: "bar", caseSensitive: false},
+				&equalStringMatcher{s: "baz", caseSensitive: true},
+			},
+			expectedValues: nil,
+		},
+		"should return values on orStringMatcher with nested orStringMatcher and equalStringMatcher, and same case sensitivity": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				orStringMatcher{
+					&equalStringMatcher{s: "bar", caseSensitive: true},
+					&equalStringMatcher{s: "xxx", caseSensitive: true},
+				},
+				&equalStringMatcher{s: "baz", caseSensitive: true},
+			},
+			expectedValues: map[string]struct{}{
+				"FOO": {},
+				"bar": {},
+				"xxx": {},
+				"baz": {},
+			},
+			expectedCaseSensitive: true,
+		},
+		"should return nil values on orStringMatcher with nested orStringMatcher and equalStringMatcher, but different case sensitivity": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				orStringMatcher{
+					// Case sensitivity is different within items at the same level.
+					&equalStringMatcher{s: "bar", caseSensitive: true},
+					&equalStringMatcher{s: "xxx", caseSensitive: false},
+				},
+				&equalStringMatcher{s: "baz", caseSensitive: true},
+			},
+			expectedValues: nil,
+		},
+		"should return nil values on orStringMatcher with nested orStringMatcher and equalStringMatcher, but different case sensitivity in the nested one": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: true},
+				// Case sensitivity is different between the parent and child.
+				orStringMatcher{
+					&equalStringMatcher{s: "bar", caseSensitive: false},
+					&equalStringMatcher{s: "xxx", caseSensitive: false},
+				},
+				&equalStringMatcher{s: "baz", caseSensitive: true},
+			},
+			expectedValues: nil,
+		},
+		"should return lowercase values case insensitive matchers": {
+			input: orStringMatcher{
+				&equalStringMatcher{s: "FOO", caseSensitive: false},
+				orStringMatcher{
+					&equalStringMatcher{s: "bAr", caseSensitive: false},
+				},
+				&equalStringMatcher{s: "baZ", caseSensitive: false},
+			},
+			expectedValues: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+				"baz": {},
+			},
+			expectedCaseSensitive: false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualValues, actualCaseSensitive := findEqualStringMatchers(testData.input)
+			require.Equal(t, testData.expectedValues, actualValues)
+			require.Equal(t, testData.expectedCaseSensitive, actualCaseSensitive)
+		})
+	}
+}
+
+// This benchmark is used to find a good threshold to use to apply the optimization
+// done by optimizeEqualStringMatchers()
+func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
+	// Generate variable lengths random texts to match against.
+	texts := append([]string{}, randStrings(10, 10)...)
+	texts = append(texts, randStrings(5, 30)...)
+	texts = append(texts, randStrings(1, 100)...)
+
+	for numAlternations := 2; numAlternations <= 256; numAlternations *= 2 {
+		for _, caseSensitive := range []bool{true, false} {
+			b.Run(fmt.Sprintf("alternations: %d case sensitive: %t", numAlternations, caseSensitive), func(b *testing.B) {
+				// Generate a regex with the expected number of alternations.
+				re := strings.Join(randStrings(numAlternations, 10), "|")
+				if !caseSensitive {
+					re = "(?i:(" + re + "))"
+				}
+
+				parsed, err := syntax.Parse(re, syntax.Perl)
+				require.NoError(b, err)
+
+				unoptimized := stringMatcherFromRegexpInternal(parsed)
+				require.IsType(b, orStringMatcher{}, unoptimized)
+
+				optimized := optimizeEqualStringMatchers(unoptimized, 0)
+				require.IsType(b, &equalMultiStringMatcher{}, optimized)
+
+				b.Run("without optimizeEqualStringMatchers()", func(b *testing.B) {
+					for n := 0; n < b.N; n++ {
+						for _, t := range texts {
+							unoptimized.Matches(t)
+						}
+					}
+				})
+
+				b.Run("with optimizeEqualStringMatchers()", func(b *testing.B) {
+					for n := 0; n < b.N; n++ {
+						for _, t := range texts {
+							optimized.Matches(t)
+						}
+					}
+				})
+			})
+		}
+	}
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -34,6 +34,8 @@ func init() {
 var (
 	letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	regexes     = []string{
+		"foo",
+		"^foo",
 		"(foo|bar)",
 		"foo.*",
 		".*foo",
@@ -47,17 +49,24 @@ var (
 		"foo\n.*",
 		".*foo.*",
 		".+foo.+",
-		"",
 		"(?s:.*)",
 		"(?s:.+)",
 		"(?s:^.*foo$)",
+		"(?i:foo)",
+		"(?i:(foo|bar))",
+		"(?i:(foo1|foo2|bar))",
 		"^(?i:foo|oo)|(bar)$",
+		"(?i:(foo1|foo2|aaa|bbb|ccc|ddd|eee|fff|ggg|hhh|iii|lll|mmm|nnn|ooo|ppp|qqq|rrr|sss|ttt|uuu|vvv|www|xxx|yyy|zzz))",
 		"((.*)(bar|b|buzz)(.+)|foo)$",
 		"^$",
 		"(prometheus|api_prom)_api_v1_.+",
 		"10\\.0\\.(1|2)\\.+",
 		"10\\.0\\.(1|2).+",
 		"((fo(bar))|.+foo)",
+		// A long case sensitive alternation.
+		"zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb",
+		// A long case insensitive alternation.
+		"(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb))",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
@@ -233,30 +242,6 @@ func BenchmarkFastRegexMatcher(b *testing.B) {
 		y = "foo" + x
 		z = x + "foo"
 	)
-	regexes := []string{
-		"foo",
-		"^foo",
-		"(foo|bar)",
-		"foo.*",
-		".*foo",
-		"^.*foo$",
-		"^.+foo$",
-		".*",
-		".+",
-		"foo.+",
-		".+foo",
-		".*foo.*",
-		"(?i:foo)",
-		"(?i:(foo|bar))",
-		"(?i:(foo1|foo2|bar))",
-		"(?i:(foo1|foo2|aaa|bbb|ccc|ddd|eee|fff|ggg|hhh|iii|lll|mmm|nnn|ooo|ppp|qqq|rrr|sss|ttt|uuu|vvv|www|xxx|yyy|zzz))",
-		"(prometheus|api_prom)_api_v1_.+",
-		"((fo(bar))|.+foo)",
-		// A long case sensitive alternation.
-		"zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb",
-		// A long case insensitive alternation.
-		"(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb))",
-	}
 	for _, r := range regexes {
 		testName := r
 		if len(testName) > 32 {


### PR DESCRIPTION
When a regex matcher contains a long list of case insensitive alternations, the `FastRegexMatcher` optimise the matching using the `StringMatcher` returned by `stringMatcherFromRegexp()`. In particular, we will be in the case there are 1 or more nested `orStringMatcher` each one with multiple `equalStringMatcher`. All the `equalStringMatcher` are evaluated sequentially, so it's like iterating over a list of string values and compare each of them against the input.

In this specific case, when there are many alternations, it may be faster to put all values in a map and then lookup the values in the map to find if there's anyone of them matching. This is what this PR does.

To do it, I've introduced the function `optimizeEqualStringMatchers()` which optimise the output of `stringMatcherFromRegexp()` exactly for the case described above. The reason why it's difficult to optimise directly `stringMatcherFromRegexp()` is because an alternate regex could be unrolled as a set of alternate + concat, so we have to first unroll it and then check if we can apply the optimization.

I've introduced a couple of new cases to the benchmark. This optimization is valuable when the regex contains a long list of case insensitive alternations (which is the specific case I'm trying to optimise):

```
name                                                  old time/op    new time/op    delta
FastRegexMatcher/foo-12                                 7.05ns ± 2%    7.29ns ± 1%     ~     (p=0.063 n=3+3)
FastRegexMatcher/^foo-12                                7.82ns ± 7%    7.19ns ± 0%     ~     (p=0.166 n=3+3)
FastRegexMatcher/(foo|bar)-12                           9.15ns ±11%    9.58ns ± 4%     ~     (p=0.484 n=3+3)
FastRegexMatcher/foo.*-12                               32.1ns ±10%    29.2ns ± 3%     ~     (p=0.252 n=3+3)
FastRegexMatcher/.*foo-12                               32.3ns ± 1%    30.7ns ± 2%   -4.85%  (p=0.013 n=3+3)
FastRegexMatcher/^.*foo$-12                             35.8ns ±10%    31.1ns ± 2%     ~     (p=0.110 n=3+3)
FastRegexMatcher/^.+foo$-12                             32.8ns ± 2%    31.1ns ± 2%   -5.26%  (p=0.012 n=3+3)
FastRegexMatcher/.*-12                                  28.8ns ± 7%    27.1ns ± 2%     ~     (p=0.218 n=3+3)
FastRegexMatcher/.+-12                                  31.3ns ± 5%    27.9ns ± 1%  -10.90%  (p=0.048 n=3+3)
FastRegexMatcher/foo.+-12                               29.9ns ± 1%    29.2ns ± 2%     ~     (p=0.100 n=3+3)
FastRegexMatcher/.+foo-12                               33.8ns ± 5%    31.8ns ± 4%     ~     (p=0.134 n=3+3)
FastRegexMatcher/.*foo.*-12                             86.4ns ± 5%    81.2ns ± 2%     ~     (p=0.144 n=3+3)
FastRegexMatcher/(?i:foo)-12                            22.9ns ± 9%    22.8ns ± 2%     ~     (p=0.929 n=3+3)
FastRegexMatcher/(?i:(foo|bar))-12                      47.1ns ± 6%    43.6ns ± 3%     ~     (p=0.122 n=3+3)
FastRegexMatcher/(?i:(foo1|foo2|bar))-12                66.8ns ± 1%    67.1ns ± 3%     ~     (p=0.839 n=3+3)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12     439ns ±10%     229ns ± 7%  -47.90%  (p=0.007 n=3+3)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-12     46.7ns ± 3%    43.8ns ± 3%     ~     (p=0.051 n=3+3)
FastRegexMatcher/((fo(bar))|.+foo)-12                   66.4ns ±13%    61.2ns ± 2%     ~     (p=0.347 n=3+3)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12     159ns ± 9%     168ns ± 3%     ~     (p=0.315 n=3+3)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12    1.53µs ± 1%    0.23µs ± 4%  -85.23%  (p=0.000 n=3+3)

name                                                  old alloc/op   new alloc/op   delta
FastRegexMatcher/foo-12                                  0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/^foo-12                                 0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(foo|bar)-12                            0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/foo.*-12                                0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/.*foo-12                                0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/^.*foo$-12                              0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/^.+foo$-12                              0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/.*-12                                   0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/.+-12                                   0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/foo.+-12                                0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/.+foo-12                                0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/.*foo.*-12                              0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(?i:foo)-12                             0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(?i:(foo|bar))-12                       0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(?i:(foo1|foo2|bar))-12                 0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12     0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-12      0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/((fo(bar))|.+foo)-12                    0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12     0.00B          0.00B          ~     (zero variance)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12     0.00B          0.00B          ~     (zero variance)

name                                                  old allocs/op  new allocs/op  delta
FastRegexMatcher/foo-12                                   0.00           0.00          ~     (zero variance)
FastRegexMatcher/^foo-12                                  0.00           0.00          ~     (zero variance)
FastRegexMatcher/(foo|bar)-12                             0.00           0.00          ~     (zero variance)
FastRegexMatcher/foo.*-12                                 0.00           0.00          ~     (zero variance)
FastRegexMatcher/.*foo-12                                 0.00           0.00          ~     (zero variance)
FastRegexMatcher/^.*foo$-12                               0.00           0.00          ~     (zero variance)
FastRegexMatcher/^.+foo$-12                               0.00           0.00          ~     (zero variance)
FastRegexMatcher/.*-12                                    0.00           0.00          ~     (zero variance)
FastRegexMatcher/.+-12                                    0.00           0.00          ~     (zero variance)
FastRegexMatcher/foo.+-12                                 0.00           0.00          ~     (zero variance)
FastRegexMatcher/.+foo-12                                 0.00           0.00          ~     (zero variance)
FastRegexMatcher/.*foo.*-12                               0.00           0.00          ~     (zero variance)
FastRegexMatcher/(?i:foo)-12                              0.00           0.00          ~     (zero variance)
FastRegexMatcher/(?i:(foo|bar))-12                        0.00           0.00          ~     (zero variance)
FastRegexMatcher/(?i:(foo1|foo2|bar))-12                  0.00           0.00          ~     (zero variance)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12      0.00           0.00          ~     (zero variance)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-12       0.00           0.00          ~     (zero variance)
FastRegexMatcher/((fo(bar))|.+foo)-12                     0.00           0.00          ~     (zero variance)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12      0.00           0.00          ~     (zero variance)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12      0.00           0.00          ~     (zero variance)
```


I've also re-run the fuzz tests for few minutes (they don't run in CI) and they reported no failures.