### PR TITLE
Avoid crash in compactOOOHead if wbl is nil

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1166,6 +1166,12 @@ func (db *DB) compactOOOHead() error {
 	if !db.oooWasEnabled.Load() {
 		return nil
 	}
+	// If this is nil then calling NewOOOCompactionHead will crash.
+	// Don't really understand why this happens, but let's not crash.
+	if db.head.wbl == nil {
+		level.Warn(db.logger).Log("msg", "compact ooo head with nil wbl")
+		return nil
+	}
 	oooHead, err := NewOOOCompactionHead(db.head)
 	if err != nil {
 		return errors.Wrap(err, "get ooo compaction head")


### PR DESCRIPTION
Trying to avoid this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10dc1bd]

goroutine 82338 [running]:
github.com/prometheus/prometheus/tsdb/wlog.(*WL).NextSegmentSync(0x0)
        /backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/wlog/wlog.go:478 +0x3d
github.com/prometheus/prometheus/tsdb.NewOOOCompactionHead(0xc014a1d400)
        /backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_read.go:285 +0x3a
github.com/prometheus/prometheus/tsdb.(*DB).compactOOOHead(0xc001125d10)
        /backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/db.go:1165 +0x4f
github.com/prometheus/prometheus/tsdb.(*DB).CompactOOOHead(0xc001125d10?)
        /backend-enterprise/vendor/github.com/prometheus/prometheus/tsdb/db.go:1158 +0x96
github.com/grafana/mimir/pkg/ingester.(*userTSDB).compactHead(0xc00f371440, 0x6ddd00)
        /backend-enterprise/vendor/github.com/grafana/mimir/pkg/ingester/user_tsdb.go:201 +0x378
github.com/grafana/mimir/pkg/ingester.(*Ingester).compactBlocks.func1({0xc0064bc120?, 0xc008fdef28?}, {0xc001ce10d3, 0x6})
        /backend-enterprise/vendor/github.com/grafana/mimir/pkg/ingester/ingester.go:2111 +0x3c5
github.com/grafana/dskit/concurrency.ForEachUser.func1()
        /backend-enterprise/vendor/github.com/grafana/dskit/concurrency/runner.go:45 +0x14d
created by github.com/grafana/dskit/concurrency.ForEachUser
        /backend-enterprise/vendor/github.com/grafana/dskit/concurrency/runner.go:36 +0x125
```