### PR TITLE
Improve fast regexp matcher cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.22
+	github.com/DmitriyVTitov/size v1.5.0
 	github.com/alecthomas/kingpin/v2 v2.3.2
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.44.217
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dennwc/varint v1.0.0
+	github.com/dgraph-io/ristretto v0.1.1
 	github.com/digitalocean/godo v1.98.0
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/edsrzf/mmap-go v1.1.0
@@ -28,7 +30,6 @@ require (
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/consul/api v1.20.0
-	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hashicorp/nomad/api v0.0.0-20230308192510-48e7d70fcd4b
 	github.com/hetznercloud/hcloud-go v1.41.0
 	github.com/ionos-cloud/sdk-go/v6 v6.1.5
@@ -84,6 +85,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DmitriyVTitov/size v1.5.0 h1:/PzqxYrOyOUX1BXj6J9OuVRVGe+66VL4D9FlUaW515g=
+github.com/DmitriyVTitov/size v1.5.0/go.mod h1:le6rNI4CoLQV1b9gzp1+3d7hMAD/uu2QcJ+aYbNgiU0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
@@ -148,7 +150,11 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
+github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
+github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/digitalocean/godo v1.98.0 h1:potyC1eD0N9n5/P4/WmJuKgg+OGYZOBWEW+/aKTX6QQ=
 github.com/digitalocean/godo v1.98.0/go.mod h1:NRpFznZFvhHjBoqZAaOD3khVzsJ3EibzKqFL4R60dmA=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -162,6 +168,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -444,8 +452,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
-github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
@@ -1001,6 +1007,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DmitriyVTitov/size"
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
 	"github.com/stretchr/testify/require"
@@ -96,6 +97,66 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		}
 
 	}
+}
+
+func TestNewFastRegexMatcher_CacheSizeLimit(t *testing.T) {
+	// Start with an empty cache.
+	fastRegexMatcherCache.Clear()
+
+	// Init the random seed with a constant, so that it doesn't change between runs.
+	randGenerator := rand.New(rand.NewSource(1))
+
+	// Generate a very expensive regex.
+	alternates := make([]string, 1000)
+	for i := 0; i < len(alternates); i++ {
+		alternates[i] = randString(randGenerator, 100) + fmt.Sprintf(".%d", i)
+	}
+	expensiveRegexp := strings.Join(alternates, "|")
+
+	// Utility function to get a unique expensive regexp.
+	getExpensiveRegexp := func(id int) string {
+		return expensiveRegexp + fmt.Sprintf("%d", id)
+	}
+
+	// Estimate the size of the matcher with the expensive regexp.
+	m, err := newFastRegexMatcherWithoutCache(expensiveRegexp)
+	require.NoError(t, err)
+	expensiveRegexpSizeBytes := size.Of(m)
+	t.Logf("expensive regexp estimated size (bytes): %d", expensiveRegexpSizeBytes)
+
+	// Estimate the max number of items in the cache.
+	estimatedMaxItemsInCache := fastRegexMatcherCacheMaxSizeBytes / expensiveRegexpSizeBytes
+
+	// Fill the cache.
+	for i := 0; i < estimatedMaxItemsInCache; i++ {
+		_, err := NewFastRegexMatcher(getExpensiveRegexp(i))
+		require.NoError(t, err)
+	}
+
+	// Ensure all regexp matchers are still in the cache.
+	fastRegexMatcherCache.Wait()
+
+	for i := 0; i < estimatedMaxItemsInCache; i++ {
+		_, ok := fastRegexMatcherCache.Get(getExpensiveRegexp(i))
+		require.True(t, ok, "checking if regexp matcher #%d is still in the cache", i)
+	}
+
+	// Add one more regexp matcher to the cache.
+	_, err = NewFastRegexMatcher(getExpensiveRegexp(estimatedMaxItemsInCache + 1))
+	require.NoError(t, err)
+
+	// Ensure one item has been evicted from the cache to make room for the new entry.
+	fastRegexMatcherCache.Wait()
+
+	numEvicted := 0
+	for i := 0; i < estimatedMaxItemsInCache; i++ {
+		if _, ok := fastRegexMatcherCache.Get(getExpensiveRegexp(i)); !ok {
+			t.Logf("the regexp matcher #%d has been evicted from the cache", i)
+			numEvicted++
+		}
+	}
+
+	require.Equal(t, 1, numEvicted)
 }
 
 func BenchmarkNewFastRegexMatcher(b *testing.B) {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -130,7 +130,7 @@ func BenchmarkNewFastRegexMatcher_CacheMisses(b *testing.B) {
 	for testName, regexpPrefix := range tests {
 		b.Run(testName, func(b *testing.B) {
 			// Ensure the cache is empty.
-			fastRegexMatcherCache.Purge()
+			fastRegexMatcherCache.Clear()
 
 			b.ResetTimer()
 


### PR DESCRIPTION
In #465 I've introduced an in-memory cache for `FastRegexMatcher`. Unfortunately we learned the hard way that a cache size limit based on the number of entries may practically cause unbounded memory utilization, based on the actual complexity of the cached regexps. Moreover, since there's no TTL, if a tenant runs many queries with complex regexps and then doesn't use regexps anymore (or they're used at a low rate), these cached entries will be never removed from the cache.

To solve these problems, in this PR I propose to:
1. Limit the cache size by bytes (1GB limit)
2. Add a 5m TTL to cached entries (we mostly care about hitting the cache for queries with recurring regexp matchers in a short time span)

To do it, I've introduced two more dependencies:
1. `github.com/DmitriyVTitov/size` to compute the actual size of `FastRegexMatcher`
2. `github.com/dgraph-io/ristretto` for the cache (instead of `github.com/hashicorp/golang-lru/v2`). I've picked ristretto because we already use such cache in GEM, so we have some experience with it

## Benchmark

Ristretto is more complex (and so expensive) than the lightweight LRU I was using before, so the % CPU increase showed in the benchmark looks huge, but if you look at the actual time spent (ns) I think it's still acceptable.

```
name                                                                   old time/op    new time/op    delta
NewFastRegexMatcher/with_cache/#00-12                                    30.2ns ± 2%   147.8ns ± 1%  +390.05%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/foo-12                                    30.6ns ± 0%   196.1ns ± 1%  +540.53%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/^foo-12                                   31.6ns ± 0%   197.1ns ± 1%  +524.02%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(foo|bar)-12                              31.6ns ± 0%   192.3ns ± 1%  +508.33%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/foo.*-12                                  32.4ns ± 1%   198.1ns ± 4%  +510.50%  (p=0.001 n=3+3)
NewFastRegexMatcher/with_cache/.*foo-12                                  35.6ns ± 1%   197.9ns ± 2%  +456.01%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/^.*foo$-12                                33.3ns ± 1%   198.1ns ± 2%  +495.73%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/^.+foo$-12                                36.2ns ± 0%   198.5ns ± 1%  +447.54%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/.*-12                                     36.5ns ± 4%   210.2ns ± 7%  +475.19%  (p=0.002 n=3+3)
NewFastRegexMatcher/with_cache/.+-12                                     36.1ns ± 0%   221.5ns ± 9%  +513.10%  (p=0.004 n=3+3)
NewFastRegexMatcher/with_cache/foo.+-12                                  35.1ns ± 1%   200.1ns ± 3%  +470.94%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/.+foo-12                                  37.6ns ± 4%   204.1ns ± 5%  +443.02%  (p=0.001 n=3+3)
NewFastRegexMatcher/with_cache/foo_.+-12                                 35.2ns ± 1%   197.5ns ± 1%  +460.44%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/foo_.*-12                                 35.2ns ± 2%   205.4ns ± 2%  +484.23%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/.*foo.*-12                                35.6ns ± 0%   206.6ns ± 1%  +480.72%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/.+foo.+-12                                34.4ns ± 1%   204.7ns ± 2%  +494.83%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?s:.*)-12                                35.3ns ± 1%   199.8ns ± 2%  +465.38%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?s:.+)-12                                35.9ns ± 2%   200.6ns ± 2%  +459.65%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?s:^.*foo$)-12                           36.4ns ± 1%   200.8ns ± 2%  +452.26%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?i:foo)-12                               35.2ns ± 2%   198.2ns ± 1%  +462.27%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?i:(foo|bar))-12                         36.0ns ± 5%   203.9ns ± 0%  +466.70%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|bar))-12                   35.6ns ± 1%   206.8ns ± 1%  +480.39%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/^(?i:foo|oo)|(bar)$-12                    35.5ns ± 1%   203.7ns ± 1%  +474.00%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12       39.9ns ± 2%   217.1ns ± 1%  +444.35%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/((.*)(bar|b|buzz)(.+)|foo)$-12            36.8ns ± 1%   203.0ns ± 2%  +451.54%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/^$-12                                     36.2ns ± 2%   200.4ns ± 1%  +453.43%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/(prometheus|api_prom)_api_v1_.+-12        35.4ns ± 1%   202.3ns ± 0%  +471.46%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/10\.0\.(1|2)\.+-12                        35.7ns ± 1%   210.1ns ± 2%  +487.80%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/10\.0\.(1|2).+-12                         35.4ns ± 1%   206.0ns ± 1%  +481.65%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/((fo(bar))|.+foo)-12                      37.8ns ± 8%   207.8ns ± 1%  +449.31%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12       59.2ns ± 2%   314.8ns ± 1%  +432.15%  (p=0.000 n=3+3)
NewFastRegexMatcher/with_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12       1.18µs ± 1%    3.92µs ± 5%  +233.75%  (p=0.001 n=3+3)
NewFastRegexMatcher/with_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12       59.9ns ± 0%   316.2ns ± 1%  +427.79%  (p=0.000 n=3+3)
NewFastRegexMatcher/without_cache/#00-12                                 77.9ns ± 1%    85.7ns ± 1%   +10.01%  (p=0.001 n=3+3)
NewFastRegexMatcher/without_cache/foo-12                                  119ns ± 1%     122ns ± 0%    +3.06%  (p=0.003 n=3+3)
NewFastRegexMatcher/without_cache/^foo-12                                4.14µs ± 1%    4.19µs ± 0%      ~     (p=0.069 n=3+3)
NewFastRegexMatcher/without_cache/(foo|bar)-12                           6.54µs ± 1%    6.69µs ± 2%      ~     (p=0.096 n=3+3)
NewFastRegexMatcher/without_cache/foo.*-12                               5.08µs ± 1%    5.21µs ± 2%      ~     (p=0.178 n=3+3)
NewFastRegexMatcher/without_cache/.*foo-12                               4.70µs ± 1%    4.83µs ± 0%    +2.61%  (p=0.028 n=3+3)
NewFastRegexMatcher/without_cache/^.*foo$-12                             5.37µs ± 1%    5.53µs ± 0%      ~     (p=0.053 n=3+3)
NewFastRegexMatcher/without_cache/^.+foo$-12                             5.44µs ± 1%    5.61µs ± 0%    +3.09%  (p=0.007 n=3+3)
NewFastRegexMatcher/without_cache/.*-12                                  3.26µs ± 2%    3.29µs ± 1%      ~     (p=0.508 n=3+3)
NewFastRegexMatcher/without_cache/.+-12                                  3.08µs ± 0%    3.14µs ± 0%    +1.93%  (p=0.007 n=3+3)
NewFastRegexMatcher/without_cache/foo.+-12                               5.05µs ± 0%    5.16µs ± 0%    +2.23%  (p=0.001 n=3+3)
NewFastRegexMatcher/without_cache/.+foo-12                               4.89µs ± 2%    4.92µs ± 1%      ~     (p=0.728 n=3+3)
NewFastRegexMatcher/without_cache/foo_.+-12                              5.35µs ± 0%    5.46µs ± 0%    +2.08%  (p=0.004 n=3+3)
NewFastRegexMatcher/without_cache/foo_.*-12                              5.32µs ± 0%    5.43µs ± 0%    +2.22%  (p=0.000 n=3+3)
NewFastRegexMatcher/without_cache/.*foo.*-12                             5.49µs ± 1%    5.60µs ± 0%    +1.91%  (p=0.006 n=3+3)
NewFastRegexMatcher/without_cache/.+foo.+-12                             5.57µs ± 0%    5.79µs ± 3%      ~     (p=0.153 n=3+3)
NewFastRegexMatcher/without_cache/(?s:.*)-12                             3.42µs ± 1%    3.44µs ± 0%      ~     (p=0.484 n=3+3)
NewFastRegexMatcher/without_cache/(?s:.+)-12                             3.30µs ± 0%    3.32µs ± 0%      ~     (p=0.077 n=3+3)
NewFastRegexMatcher/without_cache/(?s:^.*foo$)-12                        5.56µs ± 0%    5.81µs ± 1%    +4.57%  (p=0.018 n=3+3)
NewFastRegexMatcher/without_cache/(?i:foo)-12                            4.23µs ± 0%    4.34µs ± 1%      ~     (p=0.077 n=3+3)
NewFastRegexMatcher/without_cache/(?i:(foo|bar))-12                      7.89µs ± 2%    8.01µs ± 0%      ~     (p=0.227 n=3+3)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|bar))-12                10.1µs ± 1%    10.3µs ± 0%    +1.65%  (p=0.039 n=3+3)
NewFastRegexMatcher/without_cache/^(?i:foo|oo)|(bar)$-12                 10.6µs ± 1%    11.0µs ± 1%    +3.49%  (p=0.004 n=3+3)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12    44.0µs ± 2%    45.1µs ± 0%      ~     (p=0.116 n=3+3)
NewFastRegexMatcher/without_cache/((.*)(bar|b|buzz)(.+)|foo)$-12         13.9µs ± 2%    14.1µs ± 0%      ~     (p=0.379 n=3+3)
NewFastRegexMatcher/without_cache/^$-12                                  3.26µs ± 1%    3.34µs ± 0%    +2.38%  (p=0.010 n=3+3)
NewFastRegexMatcher/without_cache/(prometheus|api_prom)_api_v1_.+-12     14.7µs ± 0%    15.1µs ± 1%    +3.23%  (p=0.050 n=3+3)
NewFastRegexMatcher/without_cache/10\.0\.(1|2)\.+-12                     7.77µs ± 3%    7.51µs ± 0%      ~     (p=0.168 n=3+3)
NewFastRegexMatcher/without_cache/10\.0\.(1|2).+-12                      8.10µs ± 1%    8.16µs ± 0%      ~     (p=0.159 n=3+3)
NewFastRegexMatcher/without_cache/((fo(bar))|.+foo)-12                   9.65µs ± 0%    9.95µs ± 0%    +3.07%  (p=0.001 n=3+3)
NewFastRegexMatcher/without_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12    6.97µs ± 1%    6.88µs ± 1%      ~     (p=0.066 n=3+3)
NewFastRegexMatcher/without_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12     147µs ± 2%     147µs ± 1%      ~     (p=0.880 n=3+3)
NewFastRegexMatcher/without_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12     254µs ± 0%     268µs ± 1%    +5.41%  (p=0.001 n=3+3)
NewFastRegexMatcher_CacheMisses/simple_regexp-12                          522ns ± 1%    1522ns ± 7%  +191.83%  (p=0.003 n=3+3)
NewFastRegexMatcher_CacheMisses/complex_regexp-12                        7.97µs ± 2%   33.93µs ± 1%  +325.52%  (p=0.000 n=3+3)

name                                                                   old alloc/op   new alloc/op   delta
NewFastRegexMatcher/with_cache/#00-12                                     0.00B          7.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo-12                                     0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^foo-12                                    0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(foo|bar)-12                               0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo.*-12                                   0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*foo-12                                   0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^.*foo$-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^.+foo$-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*-12                                      0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+-12                                      0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo.+-12                                   0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+foo-12                                   0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo_.+-12                                  0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo_.*-12                                  0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*foo.*-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+foo.+-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:.*)-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:.+)-12                                 0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:^.*foo$)-12                            0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:foo)-12                                0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo|bar))-12                          0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|bar))-12                    0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^(?i:foo|oo)|(bar)$-12                     0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12        0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/((.*)(bar|b|buzz)(.+)|foo)$-12             0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^$-12                                      0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(prometheus|api_prom)_api_v1_.+-12         0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/10\.0\.(1|2)\.+-12                         0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/10\.0\.(1|2).+-12                          0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/((fo(bar))|.+foo)-12                       0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12        0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12        0.00B         24.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12        0.00B         23.00B ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/#00-12                                   152B ± 0%      152B ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo-12                                   176B ± 0%      176B ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^foo-12                                3.89kB ± 0%    3.89kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(foo|bar)-12                           6.02kB ± 0%    6.02kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo.*-12                               5.06kB ± 0%    5.06kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*foo-12                               5.10kB ± 0%    5.10kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^.*foo$-12                             5.84kB ± 0%    5.84kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^.+foo$-12                             5.89kB ± 0%    5.89kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*-12                                  3.21kB ± 0%    3.21kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+-12                                  3.18kB ± 0%    3.18kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo.+-12                               5.06kB ± 0%    5.06kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+foo-12                               5.14kB ± 0%    5.14kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo_.+-12                              5.15kB ± 0%    5.15kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo_.*-12                              5.15kB ± 0%    5.15kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*foo.*-12                             5.89kB ± 0%    5.89kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+foo.+-12                             5.90kB ± 0%    5.90kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:.*)-12                             3.30kB ± 0%    3.30kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:.+)-12                             3.29kB ± 0%    3.29kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:^.*foo$)-12                        6.00kB ± 0%    6.00kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:foo)-12                            3.76kB ± 0%    3.76kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo|bar))-12                      6.80kB ± 0%    6.80kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|bar))-12                7.82kB ± 0%    7.82kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^(?i:foo|oo)|(bar)$-12                 10.6kB ± 0%    10.6kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12    42.9kB ± 0%    42.9kB ± 0%      ~     (p=0.519 n=3+3)
NewFastRegexMatcher/without_cache/((.*)(bar|b|buzz)(.+)|foo)$-12         14.2kB ± 0%    14.2kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^$-12                                  3.46kB ± 0%    3.46kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(prometheus|api_prom)_api_v1_.+-12     14.7kB ± 0%    14.7kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/10\.0\.(1|2)\.+-12                     6.42kB ± 0%    6.42kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/10\.0\.(1|2).+-12                      6.80kB ± 0%    6.80kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/((fo(bar))|.+foo)-12                   10.0kB ± 0%    10.0kB ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12    4.85kB ± 0%    4.85kB ± 0%      ~     (p=0.184 n=3+3)
NewFastRegexMatcher/without_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12    82.2kB ± 0%    82.2kB ± 0%      ~     (p=0.442 n=3+3)
NewFastRegexMatcher/without_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12     276kB ± 0%     276kB ± 0%      ~     (p=0.113 n=3+3)
NewFastRegexMatcher_CacheMisses/simple_regexp-12                           255B ± 0%      696B ±18%  +173.30%  (p=0.021 n=3+3)
NewFastRegexMatcher_CacheMisses/complex_regexp-12                        6.06kB ± 0%   14.17kB ± 0%  +134.00%  (p=0.000 n=3+3)

name                                                                   old allocs/op  new allocs/op  delta
NewFastRegexMatcher/with_cache/#00-12                                      0.00           0.00           ~     (zero variance)
NewFastRegexMatcher/with_cache/foo-12                                      0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^foo-12                                     0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(foo|bar)-12                                0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo.*-12                                    0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*foo-12                                    0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^.*foo$-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^.+foo$-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*-12                                       0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+-12                                       0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo.+-12                                    0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+foo-12                                    0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo_.+-12                                   0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/foo_.*-12                                   0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.*foo.*-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/.+foo.+-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:.*)-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:.+)-12                                  0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?s:^.*foo$)-12                             0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:foo)-12                                 0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo|bar))-12                           0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|bar))-12                     0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^(?i:foo|oo)|(bar)$-12                      0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12         0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/((.*)(bar|b|buzz)(.+)|foo)$-12              0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/^$-12                                       0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(prometheus|api_prom)_api_v1_.+-12          0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/10\.0\.(1|2)\.+-12                          0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/10\.0\.(1|2).+-12                           0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/((fo(bar))|.+foo)-12                        0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12         0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12         0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/with_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12         0.00           1.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/#00-12                                   2.00 ± 0%      2.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo-12                                   3.00 ± 0%      3.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^foo-12                                  66.0 ± 0%      66.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(foo|bar)-12                             91.0 ± 0%      91.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo.*-12                                 76.0 ± 0%      76.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*foo-12                                 67.0 ± 0%      67.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^.*foo$-12                               74.0 ± 0%      74.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^.+foo$-12                               77.0 ± 0%      77.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*-12                                    50.0 ± 0%      50.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+-12                                    47.0 ± 0%      47.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo.+-12                                 77.0 ± 0%      77.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+foo-12                                 69.0 ± 0%      69.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo_.+-12                                79.0 ± 0%      79.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/foo_.*-12                                78.0 ± 0%      78.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.*foo.*-12                               74.0 ± 0%      74.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/.+foo.+-12                               77.0 ± 0%      77.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:.*)-12                               50.0 ± 0%      50.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:.+)-12                               48.0 ± 0%      48.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?s:^.*foo$)-12                          75.0 ± 0%      75.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:foo)-12                              63.0 ± 0%      63.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo|bar))-12                         109 ± 0%       109 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|bar))-12                   139 ± 0%       139 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^(?i:foo|oo)|(bar)$-12                    137 ± 0%       137 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12       433 ± 0%       433 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/((.*)(bar|b|buzz)(.+)|foo)$-12            151 ± 0%       151 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/^$-12                                    49.0 ± 0%      49.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(prometheus|api_prom)_api_v1_.+-12        182 ± 0%       182 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/10\.0\.(1|2)\.+-12                       98.0 ± 0%      98.0 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/10\.0\.(1|2).+-12                         111 ± 0%       111 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/((fo(bar))|.+foo)-12                      116 ± 0%       116 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12      7.00 ± 0%      7.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/jyyfj00j0061|jyyfj00j0062|jyyfj9-12      6.00 ± 0%      6.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher/without_cache/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12     1.50k ± 0%     1.50k ± 0%      ~     (zero variance)
NewFastRegexMatcher_CacheMisses/simple_regexp-12                           6.00 ± 0%      9.00 ± 0%      ~     (zero variance)
NewFastRegexMatcher_CacheMisses/complex_regexp-12                          10.0 ± 0%     133.0 ± 0%      ~     (zero variance)
```