### PR TITLE
Disable PRs from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-# Disable version updates; we will get them when we update from upstream Prometheus.
+    # Disable version updates; we will get them when we update from upstream Prometheus.
     open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/documentation/examples/remote_storage"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+# Disable version updates; we will get them when we update from upstream Prometheus.
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/documentation/examples/remote_storage"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "npm"
     directory: "/web/ui"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This repo should be be as far as possible identical to upstream Prometheus, so we don't want these PRs.

This is what I found when I looked for instructions to disable [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).