### PR TITLE
Test StableHash and implement it for stringlabels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,27 @@ jobs:
 
       - name: Run Tests
         run: GO=/usr/local/go/bin/go make common-test
+
+  test-stringlabels:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Upgrade golang
+        run: |
+          cd /tmp
+          wget https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz
+          tar -zxvf go1.20.3.linux-amd64.tar.gz
+          sudo rm -fr /usr/local/go
+          sudo mv /tmp/go /usr/local/go
+          cd -
+          ls -l /usr/bin/go
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      # This file would normally be created by `make assets`, here we just
+      #  mock it because the file is required for the tests to pass.
+      - name: Mock building of necessary react file
+        run: mkdir web/ui/static/react && touch web/ui/static/react/index.html
+
+      - name: Run Tests -tags=stringlabels
+        run: GO=/usr/local/go/bin/go GOOPTS=-tags=stringlabels make common-test

--- a/model/labels/sharding.go
+++ b/model/labels/sharding.go
@@ -1,3 +1,5 @@
+//go:build !stringlabels
+
 package labels
 
 import (

--- a/model/labels/sharding_stringlabels.go
+++ b/model/labels/sharding_stringlabels.go
@@ -1,0 +1,22 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build stringlabels
+
+package labels
+
+// StableHash is a labels hashing implementation which is guaranteed to not change over time.
+// This function should be used whenever labels hashing backward compatibility must be guaranteed.
+func StableHash(ls Labels) uint64 {
+	return ls.Hash()
+}

--- a/model/labels/sharding_test.go
+++ b/model/labels/sharding_test.go
@@ -1,0 +1,19 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStableHash tests that StableHash is stable.
+// The hashes this test asserts should not be changed.
+func TestStableHash(t *testing.T) {
+	for expectedHash, lbls := range map[uint64]Labels{
+		0xef46db3751d8e999: EmptyLabels(),
+		0x347c8ee7a9e29708: FromStrings("hello", "world"),
+		0xcbab40540f26097d: FromStrings(MetricName, "metric", "label", "value"),
+	} {
+		require.Equal(t, expectedHash, StableHash(lbls))
+	}
+}


### PR DESCRIPTION
We need a test that checks that `StableHash` is really stable. I think checking three hashes should be ok.

Also implemented this function for the `stringlabels` build tag.

Finally, added a CI piepline to ensure that this doesn't break anymore.