### PR TITLE
Don't recreate iterator for each series on each timestep when evaluating a query with `timestamp()`

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -186,6 +186,10 @@ func rangeQueryCases() []benchCase {
 			expr:  "count({__name__!=\"\",l=\"\"})",
 			steps: 1,
 		},
+		// timestamp() function
+		{
+			expr: "timestamp(a_X)",
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1806,14 +1806,14 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 		vec := make(Vector, 0, len(vs.Series))
 		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
 		var chkIter chunkenc.Iterator
-		for i, s := range vs.Series {
+		for _, s := range vs.Series {
 			chkIter = s.Iterator(chkIter)
 			it.Reset(chkIter)
 
 			t, f, h, ok := ev.vectorSelectorSingle(it, vs, enh.Ts)
 			if ok {
 				vec = append(vec, Sample{
-					Metric: vs.Series[i].Labels(),
+					Metric: s.Labels(),
 					T:      t,
 					F:      f,
 					H:      h,
@@ -1825,7 +1825,6 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 					ev.error(ErrTooManySamples(env))
 				}
 			}
-
 		}
 		ev.samplesStats.UpdatePeak(ev.currentSamples)
 		return call([]parser.Value{vec}, e.Args, enh), ws

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1796,7 +1796,12 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 	if err != nil {
 		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 	}
-	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
+
+	seriesIterators := make([]*storage.MemoizedSeriesIterator, len(vs.Series))
+	for i, s := range vs.Series {
+		it := s.Iterator(nil)
+		seriesIterators[i] = storage.NewMemoizedIterator(it, durationMilliseconds(ev.lookbackDelta))
+	}
 
 	return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 		if vs.Timestamp != nil {
@@ -1804,12 +1809,10 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 			// needs to be adjusted for every point.
 			vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
 		}
-		vec := make(Vector, 0, len(vs.Series))
-		var chkIter chunkenc.Iterator
-		for _, s := range vs.Series {
-			chkIter = s.Iterator(chkIter)
-			it.Reset(chkIter)
 
+		vec := make(Vector, 0, len(vs.Series))
+		for i, s := range vs.Series {
+			it := seriesIterators[i]
 			t, f, h, ok := ev.vectorSelectorSingle(it, vs, enh.Ts)
 			if ok {
 				vec = append(vec, Sample{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1792,15 +1792,16 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 }
 
 func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSelector, call FunctionCall, e *parser.Call) (parser.Value, storage.Warnings) {
+	ws, err := checkAndExpandSeriesSet(ev.ctx, vs)
+	if err != nil {
+		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
+	}
+
 	return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 		if vs.Timestamp != nil {
 			// This is a special case only for "timestamp" since the offset
 			// needs to be adjusted for every point.
 			vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
-		}
-		ws, err := checkAndExpandSeriesSet(ev.ctx, vs)
-		if err != nil {
-			ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 		}
 		vec := make(Vector, 0, len(vs.Series))
 		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1796,6 +1796,7 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 	if err != nil {
 		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 	}
+	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
 
 	return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
 		if vs.Timestamp != nil {
@@ -1804,7 +1805,6 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 			vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
 		}
 		vec := make(Vector, 0, len(vs.Series))
-		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
 		var chkIter chunkenc.Iterator
 		for _, s := range vs.Series {
 			chkIter = s.Iterator(chkIter)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1798,43 +1798,37 @@ func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSe
 			// needs to be adjusted for every point.
 			vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
 		}
-		val, ws := ev.vectorSelector(vs, enh.Ts)
-		return call([]parser.Value{val}, e.Args, enh), ws
-	})
-}
-
-// vectorSelector evaluates a *parser.VectorSelector expression.
-func (ev *evaluator) vectorSelector(node *parser.VectorSelector, ts int64) (Vector, storage.Warnings) {
-	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
-	if err != nil {
-		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
-	}
-	vec := make(Vector, 0, len(node.Series))
-	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
-	var chkIter chunkenc.Iterator
-	for i, s := range node.Series {
-		chkIter = s.Iterator(chkIter)
-		it.Reset(chkIter)
-
-		t, f, h, ok := ev.vectorSelectorSingle(it, node, ts)
-		if ok {
-			vec = append(vec, Sample{
-				Metric: node.Series[i].Labels(),
-				T:      t,
-				F:      f,
-				H:      h,
-			})
-
-			ev.currentSamples++
-			ev.samplesStats.IncrementSamplesAtTimestamp(ts, 1)
-			if ev.currentSamples > ev.maxSamples {
-				ev.error(ErrTooManySamples(env))
-			}
+		ws, err := checkAndExpandSeriesSet(ev.ctx, vs)
+		if err != nil {
+			ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 		}
+		vec := make(Vector, 0, len(vs.Series))
+		it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
+		var chkIter chunkenc.Iterator
+		for i, s := range vs.Series {
+			chkIter = s.Iterator(chkIter)
+			it.Reset(chkIter)
 
-	}
-	ev.samplesStats.UpdatePeak(ev.currentSamples)
-	return vec, ws
+			t, f, h, ok := ev.vectorSelectorSingle(it, vs, enh.Ts)
+			if ok {
+				vec = append(vec, Sample{
+					Metric: vs.Series[i].Labels(),
+					T:      t,
+					F:      f,
+					H:      h,
+				})
+
+				ev.currentSamples++
+				ev.samplesStats.IncrementSamplesAtTimestamp(enh.Ts, 1)
+				if ev.currentSamples > ev.maxSamples {
+					ev.error(ErrTooManySamples(env))
+				}
+			}
+
+		}
+		ev.samplesStats.UpdatePeak(ev.currentSamples)
+		return call([]parser.Value{vec}, e.Args, enh), ws
+	})
 }
 
 // vectorSelectorSingle evaluates an instant vector for the iterator of one time series.

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1976,6 +1976,100 @@ func TestSubquerySelector(t *testing.T) {
 	}
 }
 
+func TestTimestampFunction_StepsMoreOftenThanSamples(t *testing.T) {
+	test, err := NewTest(t, `
+load 1m
+  metric 0+1x1000
+`)
+	require.NoError(t, err)
+	defer test.Close()
+
+	err = test.Run()
+	require.NoError(t, err)
+
+	query := "timestamp(metric)"
+	start := time.Unix(0, 0)
+	end := time.Unix(61, 0)
+	interval := time.Second
+
+	expectedResult := Matrix{
+		Series{
+			Floats: []FPoint{
+				{F: 0, T: 0},
+				{F: 0, T: 1_000},
+				{F: 0, T: 2_000},
+				{F: 0, T: 3_000},
+				{F: 0, T: 4_000},
+				{F: 0, T: 5_000},
+				{F: 0, T: 6_000},
+				{F: 0, T: 7_000},
+				{F: 0, T: 8_000},
+				{F: 0, T: 9_000},
+				{F: 0, T: 10_000},
+				{F: 0, T: 11_000},
+				{F: 0, T: 12_000},
+				{F: 0, T: 13_000},
+				{F: 0, T: 14_000},
+				{F: 0, T: 15_000},
+				{F: 0, T: 16_000},
+				{F: 0, T: 17_000},
+				{F: 0, T: 18_000},
+				{F: 0, T: 19_000},
+				{F: 0, T: 20_000},
+				{F: 0, T: 21_000},
+				{F: 0, T: 22_000},
+				{F: 0, T: 23_000},
+				{F: 0, T: 24_000},
+				{F: 0, T: 25_000},
+				{F: 0, T: 26_000},
+				{F: 0, T: 27_000},
+				{F: 0, T: 28_000},
+				{F: 0, T: 29_000},
+				{F: 0, T: 30_000},
+				{F: 0, T: 31_000},
+				{F: 0, T: 32_000},
+				{F: 0, T: 33_000},
+				{F: 0, T: 34_000},
+				{F: 0, T: 35_000},
+				{F: 0, T: 36_000},
+				{F: 0, T: 37_000},
+				{F: 0, T: 38_000},
+				{F: 0, T: 39_000},
+				{F: 0, T: 40_000},
+				{F: 0, T: 41_000},
+				{F: 0, T: 42_000},
+				{F: 0, T: 43_000},
+				{F: 0, T: 44_000},
+				{F: 0, T: 45_000},
+				{F: 0, T: 46_000},
+				{F: 0, T: 47_000},
+				{F: 0, T: 48_000},
+				{F: 0, T: 49_000},
+				{F: 0, T: 50_000},
+				{F: 0, T: 51_000},
+				{F: 0, T: 52_000},
+				{F: 0, T: 53_000},
+				{F: 0, T: 54_000},
+				{F: 0, T: 55_000},
+				{F: 0, T: 56_000},
+				{F: 0, T: 57_000},
+				{F: 0, T: 58_000},
+				{F: 0, T: 59_000},
+				{F: 60, T: 60_000},
+				{F: 60, T: 61_000},
+			},
+			Metric: labels.EmptyLabels(),
+		},
+	}
+
+	qry, err := test.QueryEngine().NewRangeQuery(test.context, test.Queryable(), nil, query, start, end, interval)
+	require.NoError(t, err)
+
+	res := qry.Exec(test.Context())
+	require.NoError(t, res.Err)
+	require.Equal(t, expectedResult, res.Value)
+}
+
 type FakeQueryLogger struct {
 	closed bool
 	logs   []interface{}


### PR DESCRIPTION
While investigating an issue with queries that use the `timestamp()` function with Mimir's chunks streaming (https://github.com/grafana/mimir/pull/5370), we discovered that the current special case handling for this function creates a new series iterator for each series for each time step in the query, as well as a new `MemoizedSeriesIterator` for each time step.

Not only does this break Mimir's chunks streaming (because creating a second iterator for a series requires reading chunks that we've already read past), it also turns out to be quite inefficient. Changing the special case for `timestamp()` to create and retain one iterator per series for the whole query has the following impact on the benchmark added in this PR:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                   │  before.txt  │              after.txt              │
                                                   │    sec/op    │    sec/op     vs base               │
RangeQuery/expr=timestamp(a_one),steps=1-10           10.74µ ± 1%   11.84µ ±  7%  +10.19% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=10-10          25.56µ ± 1%   12.54µ ±  7%  -50.95% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=100-10        271.63µ ± 1%   36.07µ ±  6%  -86.72% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=1000-10       8798.2µ ± 1%   221.0µ ± 11%  -97.49% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1-10           48.00µ ± 1%   36.20µ ±  9%  -24.58% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=10-10         187.21µ ± 1%   56.89µ ± 10%  -69.61% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=100-10        2600.1µ ± 1%   290.3µ ±  8%  -88.84% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1000-10       89.292m ± 2%   2.562m ±  7%  -97.13% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-10       416.8µ ± 1%   322.0µ ± 20%  -22.74% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=10-10     1816.6µ ± 1%   562.5µ ±  7%  -69.04% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-10    26.112m ± 1%   2.542m ± 20%  -90.26% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-10   896.10m ± 1%   22.67m ±  1%  -97.47% (p=0.002 n=6)
geomean                                               1.304m        227.2µ        -82.58%

                                                   │  before.txt   │              after.txt              │
                                                   │     B/op      │     B/op      vs base               │
RangeQuery/expr=timestamp(a_one),steps=1-10           7.506Ki ± 0%   7.013Ki ± 0%   -6.57% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=10-10         12.782Ki ± 0%   7.787Ki ± 0%  -39.08% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=100-10         68.79Ki ± 0%   15.76Ki ± 0%  -77.09% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=1000-10       994.03Ki ± 0%   96.04Ki ± 0%  -90.34% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1-10           21.54Ki ± 0%   22.25Ki ± 0%   +3.26% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=10-10          47.25Ki ± 0%   28.25Ki ± 0%  -40.21% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=100-10        339.33Ki ± 0%   89.54Ki ± 0%  -73.61% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1000-10       6996.4Ki ± 0%   703.0Ki ± 0%  -89.95% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-10       169.1Ki ± 0%   181.8Ki ± 0%   +7.57% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=10-10      398.3Ki ± 0%   239.4Ki ± 0%  -39.90% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-10    3044.3Ki ± 0%   826.3Ki ± 0%  -72.86% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-10   65.363Mi ± 0%   6.540Mi ± 0%  -89.99% (p=0.002 n=6)
geomean                                               278.5Ki        98.03Ki       -64.80%

                                                   │  before.txt   │             after.txt              │
                                                   │   allocs/op   │  allocs/op   vs base               │
RangeQuery/expr=timestamp(a_one),steps=1-10             152.0 ± 0%    147.0 ± 0%   -3.29% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=10-10            233.0 ± 0%    174.0 ± 0%  -25.32% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=100-10          1192.0 ± 0%    447.0 ± 0%  -62.50% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_one),steps=1000-10        19.886k ± 0%   3.167k ± 0%  -84.07% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1-10             290.0 ± 0%    285.0 ± 0%   -1.72% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=10-10            624.0 ± 0%    322.0 ± 0%  -48.40% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=100-10          5686.0 ± 0%    710.0 ± 0%  -87.51% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_ten),steps=1000-10       153.082k ± 0%   4.561k ± 0%  -97.02% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1-10        1.584k ± 0%   1.579k ± 0%   -0.32% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=10-10       4.404k ± 0%   1.672k ± 0%  -62.03% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-10     50.081k ± 0%   2.801k ± 0%  -94.41% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-10   1480.41k ± 0%   13.78k ± 0%  -99.07% (p=0.002 n=6)
geomean                                                4.497k        1.008k       -77.59%

```

One drawback of this approach is that all chunks for all series will be held in memory while evaluating the query, including when using Mimir's chunks streaming. However, this is no worse than the current non-streaming situation. Modifying the PromQL engine to operate per-series in this case would require more complex changes to the PromQL engine code, so I'd like to test how things fare with this change in place, and then come back and revisit this if it proves to be problematic.

Note to reviewers: I'd suggest reviewing each commit separately, as they incrementally build up the changes required.

I'll submit this to `prometheus/prometheus` once I've tested this in a Mimir test environment.