### PR TITLE
Remediate PostingsForMatchers race condition with appends

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -187,18 +186,26 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 			labelMustBeSet[m.Name] = true
 		}
 	}
-	isSubtractingMatcher := func(m *labels.Matcher) bool {
-		if !labelMustBeSet[m.Name] {
-			return true
-		}
-		return (m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp) && m.Matches("")
-	}
+
 	someSubtractingMatchers, someIntersectingMatchers := false, false
 	for _, m := range ms {
-		if isSubtractingMatcher(m) {
-			someSubtractingMatchers = true
-		} else {
+		switch {
+		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
 			someIntersectingMatchers = true
+		case labelMustBeSet[m.Name]:
+			// If this matcher must be non-empty, we can be smarter.
+			matchesEmpty := m.Matches("")
+			isNot := m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp
+			switch {
+			case isNot && matchesEmpty: // l!="foo"
+				someSubtractingMatchers = true
+			case isNot && !matchesEmpty: // l!=""
+				someIntersectingMatchers = true
+			default: // l="a"
+				someIntersectingMatchers = true
+			}
+		default: // l=""
+			someSubtractingMatchers = true
 		}
 	}
 
@@ -213,15 +220,6 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 		}
 		its = append(its, allPostings)
 	}
-
-	// Sort matchers to have the intersecting matchers first.
-	// This way the base for subtraction is smaller and
-	// there is no chance that the set we subtract from
-	// contains postings of series that didn't exist when
-	// we constructed the set we subtract by.
-	slices.SortFunc(ms, func(i, j *labels.Matcher) bool {
-		return !isSubtractingMatcher(i) && isSubtractingMatcher(j)
-	})
 
 	for _, m := range ms {
 		switch {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -187,6 +187,40 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 		}
 	}
 
+	someSubtractingMatchers, someIntersectingMatchers := false, false
+	for _, m := range ms {
+		switch {
+		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
+			someIntersectingMatchers = true
+		case labelMustBeSet[m.Name]:
+			// If this matcher must be non-empty, we can be smarter.
+			matchesEmpty := m.Matches("")
+			isNot := m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp
+			switch {
+			case isNot && matchesEmpty: // l!="foo"
+				someSubtractingMatchers = true
+			case isNot && !matchesEmpty: // l!=""
+				someIntersectingMatchers = true
+			default: // l="a"
+				someIntersectingMatchers = true
+			}
+		default: // l=""
+			someSubtractingMatchers = true
+		}
+	}
+
+	if someSubtractingMatchers && !someIntersectingMatchers {
+		// If there's nothing to subtract from, add in everything and remove the notIts later.
+		// We prefer to get AllPostings so that the base of subtraction (i.e. allPostings)
+		// doesn't include series that may be added ot the index reader during this function call.
+		k, v := index.AllPostingsKey()
+		allPostings, err := ix.Postings(k, v)
+		if err != nil {
+			return nil, err
+		}
+		its = append(its, allPostings)
+	}
+
 	for _, m := range ms {
 		switch {
 		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
@@ -252,16 +286,6 @@ func PostingsForMatchers(ix IndexPostingsReader, ms ...*labels.Matcher) (index.P
 			}
 			notIts = append(notIts, it)
 		}
-	}
-
-	// If there's nothing to subtract from, add in everything and remove the notIts later.
-	if len(its) == 0 && len(notIts) != 0 {
-		k, v := index.AllPostingsKey()
-		allPostings, err := ix.Postings(k, v)
-		if err != nil {
-			return nil, err
-		}
-		its = append(its, allPostings)
 	}
 
 	it := index.Intersect(its...)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2223,7 +2223,7 @@ func TestPostingsForMatchersRace(t *testing.T) {
 		{
 			// This fails less often because the race conditions are on the series appended since the start of the PostingsForMatchers call
 			// and in the test case we can only anchor on a single value, i.e. only one test run is succeptable to the race.
-			// For me this fails in one test case when I run with -test.count=500.
+			// For me this fails in one test case when I run with -count=500.
 			matchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchNotEqual, "n", "495"),
 				labels.MustNewMatcher(labels.MatchRegexp, "n", ".+"),

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2202,7 +2202,7 @@ func syncLog(ctx context.Context, l interface{ Log(...any) }, messages chan stri
 }
 
 func TestPostingsForMatchersRace(t *testing.T) {
-	const testRepeats = 10000
+	const testRepeats = 1000
 	chunkDir := t.TempDir()
 	opts := DefaultHeadOptions()
 	opts.ChunkRange = 1000
@@ -2266,7 +2266,7 @@ func appendSeries(ctx context.Context, logs chan string, h *Head, numSeries int)
 			logs <- fmt.Sprintf("appendSeries error: %s", err)
 		}
 		logs <- fmt.Sprintf("appended %d", i)
-		if i%100 == 0 {
+		if i%10 == 0 {
 			// Throttle down the appends to keep the test somewhat nimble.
 			time.Sleep(time.Millisecond)
 		}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2223,7 +2223,11 @@ func TestPostingsForMatchersRace(t *testing.T) {
 		{
 			// This fails less often because the race conditions are on the series appended since the start of the PostingsForMatchers call
 			// and in the test case we can only anchor on a single value, i.e. only one test run is succeptable to the race.
-			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "n", "495")},
+			// For me this fails in one test case when I run with -test.count=500.
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "n", "495"),
+				labels.MustNewMatcher(labels.MatchRegexp, "n", ".+"),
+			},
 		},
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "")},


### PR DESCRIPTION
PostingsForMatchers has a race condition with appending to the TSDB head block.
PostingsForMatchers returns the list of series IDs for some label matchers.

### Bug

This bug can manifest when a new series is appended to the head block while PostingsForMatchers is computing its result. Then the result from PostingsForMatchers can contains series references that do not match the matchers.

This is less likely to affect Prometheus because there most queries request the `__name__` label and it is generally computed first.

### Example

The query is 
```
{datacenter!="dc1", datacenter=~"dc.*"}
```

PostingsForMatchers computes its result like so
* find the series IDs for `datacenter!=dc1`; call this $D1$
* find the series IDs for `datacenter=~dc.*`; call this $D2$
* return $P = D2 - D1$

If there is an append with a new timeseries between computing $D1$ and $D2$, then $P$ can contain more series than is correct.

* find the series IDs for `datacenter!=dc1`; call this $D1$
* __in another request__ append a new timeseries to the TSDB head `{datacenter="dc1"}`
* find the series IDs for `datacenter=~dc.*`; call this $D2$
* return $P = D2 - D1$

There is no synchronisation between the calculation of the different series sets, so now $D2$ contains the new timeseries, but $D1$ doesn't.

### Tests

I added two test cases that exemplify the bug. Without the fix the first one - `n=""` triggers way more often, for the second, `n!="495",n=~".+"` needs a few hundred runs to fail (`go test ... -count=500`).


### Remediation

Always compute the series IDs for intersecting matchers first and for subtracting matchers second. This means that intersected sets of series will not contain new series, so even if the subtracting sets contain new series, then the result is still valid (only slightly outdated).

In typical Prometheus queries `__name__`, which is an intersecting matcher is computed first, therefore this race condition doesn't manifest.

