### PR TITLE
Add missing `InstallCodec` call to benchmark

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3293,6 +3293,7 @@ func BenchmarkRespond(b *testing.B) {
 	}
 	b.ResetTimer()
 	api := API{}
+	api.InstallCodec(JSONCodec{})
 	for n := 0; n < b.N; n++ {
 		api.respond(&testResponseWriter, request, response, nil)
 	}


### PR DESCRIPTION
@bboreham noticed that `BenchmarkRespond` was missing a call to `InstallCodec` in  https://github.com/prometheus/prometheus/pull/11905#discussion_r1251255249.
