### PR TITLE
Faster JSON serialising of labels

### DIFF
--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -70,12 +70,7 @@ func marshalSeriesJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	s := *((*promql.Series)(ptr))
 	stream.WriteObjectStart()
 	stream.WriteObjectField(`metric`)
-	m, err := s.Metric.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), m...))
+	marshalLabelsJSON(s.Metric, stream)
 
 	for i, p := range s.Floats {
 		stream.WriteMore()
@@ -131,12 +126,7 @@ func marshalSampleJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	s := *((*promql.Sample)(ptr))
 	stream.WriteObjectStart()
 	stream.WriteObjectField(`metric`)
-	m, err := s.Metric.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), m...))
+	marshalLabelsJSON(s.Metric, stream)
 	stream.WriteMore()
 	if s.H == nil {
 		stream.WriteObjectField(`value`)
@@ -196,12 +186,7 @@ func marshalExemplarJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 
 	// "labels" key.
 	stream.WriteObjectField(`labels`)
-	lbls, err := p.Labels.MarshalJSON()
-	if err != nil {
-		stream.Error = err
-		return
-	}
-	stream.SetBuffer(append(stream.Buffer(), lbls...))
+	marshalLabelsJSON(p.Labels, stream)
 
 	// "value" key.
 	stream.WriteMore()


### PR DESCRIPTION
Inspired by https://github.com/prometheus/prometheus/pull/12249, but adding in the idea I had at https://github.com/prometheus/prometheus/pull/12249#pullrequestreview-1507699841

I did this in mimir-prometheus not upstream because the implementation has moved around here.

Note: Mimir should remove [its encodeLabels function](https://github.com/grafana/mimir/blob/bae4a0c903f3119afcdf08fa11f3a8b97b934487/pkg/storage/chunk/json_helpers.go#L39) if this is merged.

```
name                              old time/op    new time/op    delta
Respond/10000_points_no_labels-8     479µs ± 1%     483µs ± 1%   +0.99%  (p=0.017 n=5+6)
Respond/1000_labels-8                633µs ± 1%      70µs ± 0%  -89.00%  (p=0.004 n=6+5)
Respond/1000_series_10_points-8     1.17ms ± 0%    0.56ms ± 0%  -51.75%  (p=0.002 n=6+6)

name                              old alloc/op   new alloc/op   delta
Respond/10000_points_no_labels-8     214kB ± 0%     214kB ± 0%     ~     (p=0.126 n=6+6)
Respond/1000_labels-8                913kB ± 0%      74kB ± 0%  -91.89%  (p=0.002 n=6+6)
Respond/1000_series_10_points-8     1.10MB ± 0%    0.26MB ± 0%  -76.15%  (p=0.002 n=6+6)

name                              old allocs/op  new allocs/op  delta
Respond/10000_points_no_labels-8      10.0 ± 0%       7.0 ± 0%  -30.00%  (p=0.002 n=6+6)
Respond/1000_labels-8                13.0k ± 0%      0.0k ± 0%  -99.95%  (p=0.002 n=6+6)
Respond/1000_series_10_points-8      13.0k ± 0%      0.0k ± 0%  -99.95%  (p=0.002 n=6+6)
```