### PR TITLE
Optimize `labelValuesWithMatchers` to fetch label values from selected series

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -386,18 +386,12 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 		// Add space for one extra posting when checking if we expanded all postings.
 		expanded := make([]storage.SeriesRef, 0, maxExpandedPostings+1)
 
-		for len(expanded) < maxExpandedPostings && p.Next() {
+		// Call p.Next() even if len(expanded) == maxExpandedPostings. This tells us if there are more postings or not.
+		for len(expanded) <= maxExpandedPostings && p.Next() {
 			expanded = append(expanded, p.At())
 		}
 
-		// Did we reach the end of postings?
-		reachedEnd := true
-		if len(expanded) == maxExpandedPostings && p.Next() {
-			reachedEnd = false
-			expanded = append(expanded, p.At())
-		}
-
-		if reachedEnd {
+		if len(expanded) <= maxExpandedPostings {
 			// When we're here, p.Next() must have returned false, so we need to check for errors.
 			if err := p.Err(); err != nil {
 				return nil, errors.Wrap(err, "expanding postings for matchers")

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -390,7 +390,7 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 			expanded = append(expanded, p.At())
 		}
 
-		// Did we reach end of postings?
+		// Did we reach the end of postings?
 		reachedEnd := true
 		if len(expanded) == maxExpandedPostings && p.Next() {
 			reachedEnd = false
@@ -398,6 +398,11 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 		}
 
 		if reachedEnd {
+			// When we're here, p.Next() must have returned false, so we need to check for errors.
+			if err := p.Err(); err != nil {
+				return nil, errors.Wrap(err, "expanding postings for matchers")
+			}
+
 			// We have expanded all the postings -- all returned label values will be from these series only.
 			return labelValuesFromSeries(r, name, expanded)
 		}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -398,7 +398,7 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 			}
 
 			// We have expanded all the postings -- all returned label values will be from these series only.
-			// (We supply allValues[:0] as a buffer for storing results. It should be big enough already, since it holds all possible label values.)
+			// (We supply allValues as a buffer for storing results. It should be big enough already, since it holds all possible label values.)
 			return labelValuesFromSeries(r, name, expanded, allValues)
 		}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -346,6 +346,11 @@ func inversePostingsForMatcher(ix IndexPostingsReader, m *labels.Matcher) (index
 	return ix.Postings(m.Name, res...)
 }
 
+const (
+	minSeriesForPostingsLabelValues = 1000 // Minimum number of label values when we try to use labels from series instead.
+	maxExpandedFactor               = 100  // Division factor for maximum number of matched series.
+)
+
 func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
 	p, err := PostingsForMatchers(r, matchers...)
 	if err != nil {
@@ -355,6 +360,36 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 	allValues, err := r.LabelValues(name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching values of label %s", name)
+	}
+
+	// If there are many values, let's see if expanded postings for matchers have smaller cardinality.
+	if len(allValues) >= minSeriesForPostingsLabelValues {
+		// We will only expand this number of postings.
+		maxPostings := len(allValues) / maxExpandedFactor
+		// Add space for one extra posting when checking if we expanded all.
+		expanded := make([]storage.SeriesRef, 0, maxPostings+1)
+
+		for len(expanded) < maxPostings && p.Next() {
+			expanded = append(expanded, p.At())
+		}
+
+		// Did we reach end of postings?
+		reachedEnd := true
+		if len(expanded) == maxPostings && p.Next() {
+			reachedEnd = false
+			expanded = append(expanded, p.At())
+		}
+
+		if reachedEnd {
+			// We have expanded all the postings. Given that number of postings is
+			// much smaller than number of all label values, let's compute label
+			// values from series instead.
+			// (If we did this for all postings, it would be very expensive.)
+			return labelValuesFromSeries(r, name, expanded)
+		}
+
+		// If we haven't reached end of postings, we prepend our expanded postings to "p", and continue.
+		p = newPrependPostings(expanded, p)
 	}
 
 	// If we have a matcher for the label name, we can filter out values that don't match
@@ -394,6 +429,78 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 	}
 
 	return values, nil
+}
+
+// labelValuesFromSeries returns all unique label values from for given label name from supplied series. Values are not sorted.
+func labelValuesFromSeries(r IndexReader, labelName string, refs []storage.SeriesRef) ([]string, error) {
+	values := map[string]struct{}{}
+
+	var builder labels.ScratchBuilder
+	for _, ref := range refs {
+		err := r.Series(ref, &builder, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "label values for label %s", labelName)
+		}
+
+		v := builder.Labels().Get(labelName)
+		if v != "" {
+			values[v] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(values))
+	for v := range values {
+		result = append(result, v)
+	}
+	return result, nil
+}
+
+func newPrependPostings(a []storage.SeriesRef, b index.Postings) index.Postings {
+	return &prependPostings{
+		ix:     -1,
+		prefix: a,
+		rest:   b,
+	}
+}
+
+// prependPostings returns series references from "prefix" before using "rest" postings.
+type prependPostings struct {
+	ix     int
+	prefix []storage.SeriesRef
+	rest   index.Postings
+}
+
+func (p *prependPostings) Next() bool {
+	p.ix++
+	if p.ix < len(p.prefix) {
+		return true
+	}
+	return p.rest.Next()
+}
+
+func (p *prependPostings) Seek(v storage.SeriesRef) bool {
+	for p.ix < len(p.prefix) {
+		if p.ix >= 0 && p.prefix[p.ix] >= v {
+			return true
+		}
+		p.ix++
+	}
+
+	return p.rest.Seek(v)
+}
+
+func (p *prependPostings) At() storage.SeriesRef {
+	if p.ix >= 0 && p.ix < len(p.prefix) {
+		return p.prefix[p.ix]
+	}
+	return p.rest.At()
+}
+
+func (p *prependPostings) Err() error {
+	if p.ix >= 0 && p.ix < len(p.prefix) {
+		return nil
+	}
+	return p.rest.Err()
 }
 
 func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]string, error) {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2733,3 +2733,115 @@ func TestQueryWithDeletedHistograms(t *testing.T) {
 		})
 	}
 }
+
+func TestPrependPostings(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		p := newPrependPostings(nil, index.NewListPostings(nil))
+		require.False(t, p.Next())
+	})
+
+	t.Run("next+At", func(t *testing.T) {
+		p := newPrependPostings([]storage.SeriesRef{10, 20, 30}, index.NewListPostings([]storage.SeriesRef{200, 300, 500}))
+
+		for _, s := range []storage.SeriesRef{10, 20, 30, 200, 300, 500} {
+			require.True(t, p.Next())
+			require.Equal(t, s, p.At())
+			require.Equal(t, s, p.At()) // Multiple calls return same value.
+		}
+		require.False(t, p.Next())
+	})
+
+	t.Run("seek+At", func(t *testing.T) {
+		p := newPrependPostings([]storage.SeriesRef{10, 20, 30}, index.NewListPostings([]storage.SeriesRef{200, 300, 500}))
+
+		require.True(t, p.Seek(5))
+		require.Equal(t, storage.SeriesRef(10), p.At())
+		require.Equal(t, storage.SeriesRef(10), p.At())
+
+		require.True(t, p.Seek(15))
+		require.Equal(t, storage.SeriesRef(20), p.At())
+		require.Equal(t, storage.SeriesRef(20), p.At())
+
+		require.True(t, p.Seek(20)) // Seeking to "current" value doesn't move postings iterator.
+		require.Equal(t, storage.SeriesRef(20), p.At())
+		require.Equal(t, storage.SeriesRef(20), p.At())
+
+		require.True(t, p.Seek(50))
+		require.Equal(t, storage.SeriesRef(200), p.At())
+		require.Equal(t, storage.SeriesRef(200), p.At())
+
+		require.False(t, p.Seek(1000))
+		require.False(t, p.Next())
+	})
+
+	t.Run("err", func(t *testing.T) {
+		err := fmt.Errorf("error")
+		p := newPrependPostings([]storage.SeriesRef{10, 20, 30}, index.ErrPostings(err))
+
+		for _, s := range []storage.SeriesRef{10, 20, 30} {
+			require.True(t, p.Next())
+			require.Equal(t, s, p.At())
+			require.NoError(t, p.Err())
+		}
+		// Advancing after prepended values returns false, and gives us access to error.
+		require.False(t, p.Next())
+		require.Equal(t, err, p.Err())
+	})
+}
+
+func TestLabelsValuesWithMatchersOptimization(t *testing.T) {
+	dir := t.TempDir()
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChunkDirRoot = dir
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, h.Close())
+	}()
+
+	app := h.Appender(context.Background())
+	addSeries := func(l labels.Labels) {
+		app.Append(0, l, 0, 0)
+	}
+
+	const maxI = minSeriesForPostingsLabelValues
+
+	allValuesOfI := make([]string, 0, maxI)
+	for i := 0; i < maxI; i++ {
+		allValuesOfI = append(allValuesOfI, strconv.Itoa(i))
+	}
+
+	for n := 0; n < 10; n++ {
+		for i := 0; i < minSeriesForPostingsLabelValues; i++ {
+			addSeries(labels.FromStrings("i", allValuesOfI[i], "n", strconv.Itoa(n), "j", "foo", "i_times_n", strconv.Itoa(i*n)))
+		}
+	}
+	require.NoError(t, app.Commit())
+
+	ir, err := h.Index()
+	require.NoError(t, err)
+
+	primesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "23") // It will match single i*n combination (n < 10)
+	nonPrimesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "20")
+	n3 := labels.MustNewMatcher(labels.MatchEqual, "n", "3")
+
+	cases := []struct {
+		name            string
+		labelName       string
+		matchers        []*labels.Matcher
+		expectedResults []string
+	}{
+		{name: `i with i_times_n=23`, labelName: "i", matchers: []*labels.Matcher{primesTimes}, expectedResults: []string{"23"}},
+		{name: `i with i_times_n=20`, labelName: "i", matchers: []*labels.Matcher{nonPrimesTimes}, expectedResults: []string{"4", "5", "10", "20"}},
+		{name: `n with n="3"`, labelName: "i", matchers: []*labels.Matcher{n3}, expectedResults: allValuesOfI},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			values, err := labelValuesWithMatchers(ir, c.labelName, c.matchers...)
+			require.NoError(t, err)
+			require.ElementsMatch(t, c.expectedResults, values)
+		})
+	}
+}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2805,7 +2805,7 @@ func TestLabelsValuesWithMatchersOptimization(t *testing.T) {
 		app.Append(0, l, 0, 0)
 	}
 
-	const maxI = minSeriesForPostingsLabelValues
+	const maxI = 10 * maxExpandedPostingsFactor
 
 	allValuesOfI := make([]string, 0, maxI)
 	for i := 0; i < maxI; i++ {
@@ -2813,7 +2813,7 @@ func TestLabelsValuesWithMatchersOptimization(t *testing.T) {
 	}
 
 	for n := 0; n < 10; n++ {
-		for i := 0; i < minSeriesForPostingsLabelValues; i++ {
+		for i := 0; i < maxI; i++ {
 			addSeries(labels.FromStrings("i", allValuesOfI[i], "n", strconv.Itoa(n), "j", "foo", "i_times_n", strconv.Itoa(i*n)))
 		}
 	}


### PR DESCRIPTION
This PR optimizes labelValues operation with matchers by iterating over all series matched by provided matchers, and collecting unique label values.

On its own this is pretty expensive operation, so this is only activated when number of matched series is tiny compared to number of all values for given label name.

Specifically, we require that queried label has at least 1000 unique label values, and matchers matched less than `(number of label values / 100)` series. (I did not do any analysis to compute these numbers, and I'm open to suggestions how to come with better ones.)

Benchmark for labelValuesForMatchers (updated for https://github.com/grafana/mimir-prometheus/pull/518/commits/e4d815d2383ba307c24a2cc72d55897d1e58179a):

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                                                         │   before.txt   │              after.txt              │
                                                                         │     sec/op     │    sec/op     vs base               │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                          1.159m ± 3%   1.142m ±  3%        ~ (p=0.310 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                          97.22m ± 4%   95.98m ±  4%        ~ (p=0.485 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                       119.8m ± 4%   119.4m ± 17%        ~ (p=0.937 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                 113.4m ± 4%   112.2m ±  3%        ~ (p=0.180 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10               18295.8µ ± 6%   908.4µ ±  2%  -95.04% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10           17927.7µ ± 6%   902.2µ ±  2%  -94.97% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                 90.19m ± 5%   83.65m ±  3%   -7.25% (p=0.004 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10       126.8m ± 7%   120.4m ±  8%        ~ (p=0.180 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=533701-10            375686.4µ ± 7%   893.0µ ±  2%  -99.76% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=20-10                233119.2µ ± 7%   898.4µ ±  4%  -99.61% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10             387.8m ± 5%   403.0m ±  3%        ~ (p=0.093 n=6)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                       248.6m ± 4%   247.8m ±  2%        ~ (p=0.310 n=6)
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                          5.301µ ± 1%   5.310µ ±  2%        ~ (p=0.937 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                         1.325m ± 1%   1.323m ±  2%        ~ (p=0.818 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                         86.92m ± 1%   89.00m ±  1%   +2.39% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                      101.2m ± 2%   101.4m ±  1%        ~ (p=0.818 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                152.4m ± 2%   159.0m ±  1%   +4.31% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10               45.283m ± 1%   1.193m ±  2%  -97.37% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10           45.355m ± 1%   1.205m ±  3%  -97.34% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                227.7m ± 1%   231.8m ±  1%   +1.80% (p=0.009 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10      155.0m ± 1%   162.3m ±  1%   +4.69% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=533701-10            123.369m ± 1%   1.098m ±  1%  -99.11% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=20-10                103.955m ± 1%   1.101m ±  2%  -98.94% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10            114.7m ± 0%   119.7m ±  1%   +4.30% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                      293.9m ± 2%   292.7m ±  1%   -0.41% (p=0.015 n=6)
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                         2.358m ± 1%   2.358m ±  1%        ~ (p=0.485 n=6)
geomean                                                                       47.22m        12.73m        -73.05%

                                                                         │  before.txt   │               after.txt               │
                                                                         │     B/op      │     B/op      vs base                 │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                        1.531Mi ± 0%   1.531Mi ± 0%        ~ (p=1.000 n=6) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                        16.14Mi ± 0%   16.15Mi ± 0%   +0.05% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                     32.31Mi ± 0%   32.32Mi ± 0%   +0.02% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10               16.14Mi ± 0%   16.15Mi ± 0%   +0.05% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10              10.695Mi ± 0%   1.539Mi ± 0%  -85.61% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10          10.695Mi ± 0%   1.539Mi ± 0%  -85.61% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10               16.14Mi ± 0%   16.15Mi ± 0%   +0.05% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10     17.67Mi ± 0%   17.68Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=533701-10            10.695Mi ± 0%   1.539Mi ± 0%  -85.61% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=20-10                10.695Mi ± 0%   1.540Mi ± 0%  -85.60% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10           19.89Mi ± 0%   19.90Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                     5.532Ki ± 0%   5.532Ki ± 0%        ~ (p=1.000 n=6)
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                        4.445Ki ± 0%   4.445Ki ± 0%        ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                       1.531Mi ± 0%   1.531Mi ± 0%        ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                       17.66Mi ± 0%   17.67Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                    33.84Mi ± 0%   33.85Mi ± 0%   +0.02% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10              17.66Mi ± 0%   17.67Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10             12.222Mi ± 0%   1.540Mi ± 0%  -87.40% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10         12.221Mi ± 0%   1.539Mi ± 0%  -87.40% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10              17.66Mi ± 0%   17.67Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10    19.19Mi ± 0%   19.20Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=533701-10           12.221Mi ± 0%   1.540Mi ± 0%  -87.40% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=20-10               12.221Mi ± 0%   1.540Mi ± 0%  -87.40% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10          21.41Mi ± 0%   21.42Mi ± 0%   +0.04% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                    7.078Ki ± 0%   7.078Ki ± 0%        ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                       5.977Ki ± 0%   5.977Ki ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                     3.902Mi        2.106Mi       -46.03%
¹ all samples are equal

                                                                         │   before.txt    │               after.txt               │
                                                                         │    allocs/op    │  allocs/op   vs base                  │
Querier/Head/labelValuesWithMatchers/i_with_i="1"-10                            5.000 ± 0%    5.000 ± 0%         ~ (p=1.000 n=6) ¹
Querier/Head/labelValuesWithMatchers/i_with_n="1"-10                           200.0k ± 0%   200.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="^.+$"-10                        300.1k ± 0%   300.1k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                  200.0k ± 0%   200.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10              200010.000 ± 0%    9.000 ± 0%  -100.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10           200012.00 ± 0%    11.00 ± 0%   -99.99% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                  200.0k ± 0%   200.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10        200.0k ± 0%   200.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=533701-10            200009.000 ± 0%    8.000 ± 0%  -100.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=20-10                 200011.00 ± 0%    11.00 ± 0%   -99.99% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10              208.9k ± 0%   208.9k ± 0%    +0.00% (p=0.002 n=6)
Querier/Head/labelValuesWithMatchers/n_with_j!="foo"-10                         98.00 ± 0%    98.00 ± 0%         ~ (p=1.000 n=6) ¹
Querier/Head/labelValuesWithMatchers/n_with_i="1"-10                            87.00 ± 0%    87.00 ± 0%         ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/i_with_i="1"-10                           7.000 ± 0%    7.000 ± 0%         ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/i_with_n="1"-10                          300.0k ± 0%   300.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="^.+$"-10                       400.1k ± 0%   400.1k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j!="foo"-10                 300.0k ± 0%   300.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"X.+"-10              300013.00 ± 0%    12.00 ± 0%  -100.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",j=~"XXX|YYY"-10          300012.00 ± 0%    11.00 ± 0%  -100.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="X",j!="foo"-10                 300.0k ± 0%   300.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_n="1",i=~"^.*$",j!="foo"-10       300.0k ± 0%   300.0k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=533701-10            300011.00 ± 0%    16.00 ± 0%   -99.99% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=20-10                300013.00 ± 0%    31.00 ± 0%   -99.99% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/i_with_i_times_n=~"12.*""-10             308.9k ± 0%   308.9k ± 0%    +0.00% (p=0.002 n=6)
Querier/Block/labelValuesWithMatchers/n_with_j!="foo"-10                        141.0 ± 0%    141.0 ± 0%         ~ (p=1.000 n=6) ¹
Querier/Block/labelValuesWithMatchers/n_with_i="1"-10                           129.0 ± 0%    129.0 ± 0%         ~ (p=1.000 n=6) ¹
geomean                                                                        34.09k        1.627k        -95.23%
¹ all samples are equal
```
