### PR TITLE
Pass ref to SeriesLifecycleCallback.PostDeletion (#12626)

### DIFF
--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
@@ -80,6 +81,6 @@ func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
 
 type failingSeriesLifecycleCallback struct{}
 
-func (failingSeriesLifecycleCallback) PreCreation(labels.Labels) error { return errors.New("failed") }
-func (failingSeriesLifecycleCallback) PostCreation(labels.Labels)      {}
-func (failingSeriesLifecycleCallback) PostDeletion(...labels.Labels)   {}
+func (failingSeriesLifecycleCallback) PreCreation(labels.Labels) error                     { return errors.New("failed") }
+func (failingSeriesLifecycleCallback) PostCreation(labels.Labels)                          {}
+func (failingSeriesLifecycleCallback) PostDeletion(map[chunks.HeadSeriesRef]labels.Labels) {}


### PR DESCRIPTION
When a particular SeriesLifecycleCallback tries to optimize and run closer to the Head, keeping track of the HeadSeriesRef instead of the labelsets, it's impossible to handle the PostDeletion callback properly as there's no way to know which series refs were deleted from the head.

This changes the callback to provide the series refs alongside the labelsets, so the implementation can choose what to do.