### PR TITLE
WIP: Add context argument to PostingsForMatchers and SortedPostings

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1383,17 +1383,17 @@ func (s *readyStorage) StartTime() (int64, error) {
 }
 
 // Querier implements the Storage interface.
-func (s *readyStorage) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 	if x := s.get(); x != nil {
-		return x.Querier(ctx, mint, maxt)
+		return x.Querier(mint, maxt)
 	}
 	return nil, tsdb.ErrNotReady
 }
 
 // ChunkQuerier implements the Storage interface.
-func (s *readyStorage) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	if x := s.get(); x != nil {
-		return x.ChunkQuerier(ctx, mint, maxt)
+		return x.ChunkQuerier(mint, maxt)
 	}
 	return nil, tsdb.ErrNotReady
 }
@@ -1466,11 +1466,11 @@ func (s *readyStorage) CleanTombstones() error {
 }
 
 // Delete implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
-func (s *readyStorage) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
+func (s *readyStorage) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error {
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
-			return db.Delete(mint, maxt, ms...)
+			return db.Delete(ctx, mint, maxt, ms...)
 		case *agent.DB:
 			return agent.ErrUnsupported
 		default:

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -86,6 +86,8 @@ func main() {
 		httpConfigFilePath string
 	)
 
+	ctx := context.Background()
+
 	app := kingpin.New(filepath.Base(os.Args[0]), "Tooling for the Prometheus monitoring system.").UsageWriter(os.Stdout)
 	app.Version(version.Print("promtool"))
 	app.HelpFlag.Short('h')
@@ -376,7 +378,7 @@ func main() {
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))
 
 	case tsdbDumpCmd.FullCommand():
-		os.Exit(checkErr(dumpSamples(*dumpPath, *dumpMinTime, *dumpMaxTime, *dumpMatch)))
+		os.Exit(checkErr(dumpSamples(ctx, *dumpPath, *dumpMinTime, *dumpMaxTime, *dumpMatch)))
 	// TODO(aSquare14): Work on adding support for custom block size.
 	case openMetricsImportCmd.FullCommand():
 		os.Exit(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable, *importQuiet, *maxBlockDuration))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -619,7 +619,7 @@ func analyzeCompaction(block tsdb.BlockReader, indexr tsdb.IndexReader) (err err
 	return nil
 }
 
-func dumpSamples(path string, mint, maxt int64, match string) (err error) {
+func dumpSamples(ctx context.Context, path string, mint, maxt int64, match string) (err error) {
 	db, err := tsdb.OpenDBReadOnly(path, nil)
 	if err != nil {
 		return err
@@ -627,7 +627,7 @@ func dumpSamples(path string, mint, maxt int64, match string) (err error) {
 	defer func() {
 		err = tsdb_errors.NewMulti(err, db.Close()).Err()
 	}()
-	q, err := db.Querier(context.TODO(), mint, maxt)
+	q, err := db.Querier(mint, maxt)
 	if err != nil {
 		return err
 	}
@@ -637,7 +637,7 @@ func dumpSamples(path string, mint, maxt int64, match string) (err error) {
 	if err != nil {
 		return err
 	}
-	ss := q.Select(false, nil, matchers...)
+	ss := q.Select(ctx, false, nil, matchers...)
 
 	for ss.Next() {
 		series := ss.At()

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -670,14 +670,14 @@ func durationMilliseconds(d time.Duration) int64 {
 func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.EvalStmt) (parser.Value, storage.Warnings, error) {
 	prepareSpanTimer, ctxPrepare := query.stats.GetSpanTimer(ctx, stats.QueryPreparationTime, ng.metrics.queryPrepareTime)
 	mint, maxt := ng.findMinMaxTime(s)
-	querier, err := query.queryable.Querier(ctxPrepare, mint, maxt)
+	querier, err := query.queryable.Querier(mint, maxt)
 	if err != nil {
 		prepareSpanTimer.Finish()
 		return nil, nil, err
 	}
 	defer querier.Close()
 
-	ng.populateSeries(querier, s)
+	ng.populateSeries(ctxPrepare, querier, s)
 	prepareSpanTimer.Finish()
 
 	// Modify the offset of vector and matrix selectors for the @ modifier
@@ -891,7 +891,7 @@ func (ng *Engine) getLastSubqueryInterval(path []parser.Node) time.Duration {
 	return interval
 }
 
-func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
+func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s *parser.EvalStmt) {
 	// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
 	// The evaluation of the VectorSelector inside then evaluates the given range and unsets
 	// the variable.
@@ -914,7 +914,7 @@ func (ng *Engine) populateSeries(querier storage.Querier, s *parser.EvalStmt) {
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)
-			n.UnexpandedSeriesSet = querier.Select(false, hints, n.LabelMatchers...)
+			n.UnexpandedSeriesSet = querier.Select(ctx, false, hints, n.LabelMatchers...)
 
 		case *parser.MatrixSelector:
 			evalRange = n.Range

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -261,7 +261,7 @@ func (r *AlertingRule) forStateSample(alert *Alert, ts time.Time, v float64) pro
 }
 
 // QueryforStateSeries returns the series for ALERTS_FOR_STATE.
-func (r *AlertingRule) QueryforStateSeries(alert *Alert, q storage.Querier) (storage.Series, error) {
+func (r *AlertingRule) QueryforStateSeries(ctx context.Context, alert *Alert, q storage.Querier) (storage.Series, error) {
 	smpl := r.forStateSample(alert, time.Now(), 0)
 	var matchers []*labels.Matcher
 	smpl.Metric.Range(func(l labels.Label) {
@@ -271,7 +271,7 @@ func (r *AlertingRule) QueryforStateSeries(alert *Alert, q storage.Querier) (sto
 		}
 		matchers = append(matchers, mt)
 	})
-	sset := q.Select(false, nil, matchers...)
+	sset := q.Select(ctx, false, nil, matchers...)
 
 	var s storage.Series
 	for sset.Next() {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -844,7 +844,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 	// We allow restoration only if alerts were active before after certain time.
 	mint := ts.Add(-g.opts.OutageTolerance)
 	mintMS := int64(model.TimeFromUnixNano(mint.UnixNano()))
-	q, err := g.opts.Queryable.Querier(g.opts.Context, mintMS, maxtMS)
+	q, err := g.opts.Queryable.Querier(mintMS, maxtMS)
 	if err != nil {
 		level.Error(g.logger).Log("msg", "Failed to get Querier", "err", err)
 		return
@@ -873,7 +873,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 		alertRule.ForEachActiveAlert(func(a *Alert) {
 			var s storage.Series
 
-			s, err := alertRule.QueryforStateSeries(a, q)
+			s, err := alertRule.QueryforStateSeries(g.opts.Context, a, q)
 			if err != nil {
 				// Querier Warnings are ignored. We do not care unless we have an error.
 				level.Error(g.logger).Log(

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -72,15 +72,15 @@ func (f *fanout) StartTime() (int64, error) {
 	return firstTime, nil
 }
 
-func (f *fanout) Querier(ctx context.Context, mint, maxt int64) (Querier, error) {
-	primary, err := f.primary.Querier(ctx, mint, maxt)
+func (f *fanout) Querier(mint, maxt int64) (Querier, error) {
+	primary, err := f.primary.Querier(mint, maxt)
 	if err != nil {
 		return nil, err
 	}
 
 	secondaries := make([]Querier, 0, len(f.secondaries))
 	for _, storage := range f.secondaries {
-		querier, err := storage.Querier(ctx, mint, maxt)
+		querier, err := storage.Querier(mint, maxt)
 		if err != nil {
 			// Close already open Queriers, append potential errors to returned error.
 			errs := tsdb_errors.NewMulti(err, primary.Close())
@@ -94,15 +94,15 @@ func (f *fanout) Querier(ctx context.Context, mint, maxt int64) (Querier, error)
 	return NewMergeQuerier([]Querier{primary}, secondaries, ChainedSeriesMerge), nil
 }
 
-func (f *fanout) ChunkQuerier(ctx context.Context, mint, maxt int64) (ChunkQuerier, error) {
-	primary, err := f.primary.ChunkQuerier(ctx, mint, maxt)
+func (f *fanout) ChunkQuerier(mint, maxt int64) (ChunkQuerier, error) {
+	primary, err := f.primary.ChunkQuerier(mint, maxt)
 	if err != nil {
 		return nil, err
 	}
 
 	secondaries := make([]ChunkQuerier, 0, len(f.secondaries))
 	for _, storage := range f.secondaries {
-		querier, err := storage.ChunkQuerier(ctx, mint, maxt)
+		querier, err := storage.ChunkQuerier(mint, maxt)
 		if err != nil {
 			// Close already open Queriers, append potential errors to returned error.
 			errs := tsdb_errors.NewMulti(err, primary.Close())

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -75,7 +75,7 @@ func TestFanout_SelectSorted(t *testing.T) {
 	fanoutStorage := storage.NewFanout(nil, priStorage, remoteStorage1, remoteStorage2)
 
 	t.Run("querier", func(t *testing.T) {
-		querier, err := fanoutStorage.Querier(context.Background(), 0, 8000)
+		querier, err := fanoutStorage.Querier(0, 8000)
 		require.NoError(t, err)
 		defer querier.Close()
 
@@ -159,7 +159,7 @@ func TestFanoutErrors(t *testing.T) {
 		fanoutStorage := storage.NewFanout(nil, tc.primary, tc.secondary)
 
 		t.Run("samples", func(t *testing.T) {
-			querier, err := fanoutStorage.Querier(context.Background(), 0, 8000)
+			querier, err := fanoutStorage.Querier(0, 8000)
 			require.NoError(t, err)
 			defer querier.Close()
 
@@ -216,7 +216,7 @@ type errStorage struct{}
 
 type errQuerier struct{}
 
-func (errStorage) Querier(_ context.Context, _, _ int64) (storage.Querier, error) {
+func (errStorage) Querier(_, _ int64) (storage.Querier, error) {
 	return errQuerier{}, nil
 }
 

--- a/storage/generic.go
+++ b/storage/generic.go
@@ -17,12 +17,14 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/prometheus/prometheus/model/labels"
 )
 
 type genericQuerier interface {
 	LabelQuerier
-	Select(bool, *SelectHints, ...*labels.Matcher) genericSeriesSet
+	Select(context.Context, bool, *SelectHints, ...*labels.Matcher) genericSeriesSet
 }
 
 type genericSeriesSet interface {
@@ -58,11 +60,11 @@ type genericQuerierAdapter struct {
 	cq ChunkQuerier
 }
 
-func (q *genericQuerierAdapter) Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) genericSeriesSet {
+func (q *genericQuerierAdapter) Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) genericSeriesSet {
 	if q.q != nil {
-		return &genericSeriesSetAdapter{q.q.Select(sortSeries, hints, matchers...)}
+		return &genericSeriesSetAdapter{q.q.Select(ctx, sortSeries, hints, matchers...)}
 	}
-	return &genericChunkSeriesSetAdapter{q.cq.Select(sortSeries, hints, matchers...)}
+	return &genericChunkSeriesSetAdapter{q.cq.Select(ctx, sortSeries, hints, matchers...)}
 }
 
 func newGenericQuerierFrom(q Querier) genericQuerier {
@@ -85,8 +87,8 @@ func (a *seriesSetAdapter) At() Series {
 	return a.genericSeriesSet.At().(Series)
 }
 
-func (q *querierAdapter) Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet {
-	return &seriesSetAdapter{q.genericQuerier.Select(sortSeries, hints, matchers...)}
+func (q *querierAdapter) Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet {
+	return &seriesSetAdapter{q.genericQuerier.Select(ctx, sortSeries, hints, matchers...)}
 }
 
 type chunkQuerierAdapter struct {
@@ -101,8 +103,8 @@ func (a *chunkSeriesSetAdapter) At() ChunkSeries {
 	return a.genericSeriesSet.At().(ChunkSeries)
 }
 
-func (q *chunkQuerierAdapter) Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) ChunkSeriesSet {
-	return &chunkSeriesSetAdapter{q.genericQuerier.Select(sortSeries, hints, matchers...)}
+func (q *chunkQuerierAdapter) Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) ChunkSeriesSet {
+	return &chunkSeriesSetAdapter{q.genericQuerier.Select(ctx, sortSeries, hints, matchers...)}
 }
 
 type seriesMergerAdapter struct {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -91,7 +91,7 @@ type ExemplarStorage interface {
 // Use it when you need to have access to all samples without chunk encoding abstraction e.g promQL.
 type Queryable interface {
 	// Querier returns a new Querier on the storage.
-	Querier(ctx context.Context, mint, maxt int64) (Querier, error)
+	Querier(mint, maxt int64) (Querier, error)
 }
 
 // A MockQueryable is used for testing purposes so that a mock Querier can be used.
@@ -99,7 +99,7 @@ type MockQueryable struct {
 	MockQuerier Querier
 }
 
-func (q *MockQueryable) Querier(context.Context, int64, int64) (Querier, error) {
+func (q *MockQueryable) Querier(int64, int64) (Querier, error) {
 	return q.MockQuerier, nil
 }
 
@@ -110,7 +110,7 @@ type Querier interface {
 	// Select returns a set of series that matches the given label matchers.
 	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.
 	// It allows passing hints that can help in optimising select, but it's up to implementation how this is used if used at all.
-	Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet
+	Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet
 }
 
 // MockQuerier is used for test purposes to mock the selected series that is returned.
@@ -130,7 +130,7 @@ func (q *MockQuerier) Close() error {
 	return nil
 }
 
-func (q *MockQuerier) Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet {
+func (q *MockQuerier) Select(_ context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet {
 	return q.SelectMockFunction(sortSeries, hints, matchers...)
 }
 
@@ -138,7 +138,7 @@ func (q *MockQuerier) Select(sortSeries bool, hints *SelectHints, matchers ...*l
 // Use it when you need to have access to samples in encoded format.
 type ChunkQueryable interface {
 	// ChunkQuerier returns a new ChunkQuerier on the storage.
-	ChunkQuerier(ctx context.Context, mint, maxt int64) (ChunkQuerier, error)
+	ChunkQuerier(mint, maxt int64) (ChunkQuerier, error)
 }
 
 // ChunkQuerier provides querying access over time series data of a fixed time range.
@@ -148,7 +148,7 @@ type ChunkQuerier interface {
 	// Select returns a set of series that matches the given label matchers.
 	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.
 	// It allows passing hints that can help in optimising select, but it's up to implementation how this is used if used at all.
-	Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) ChunkSeriesSet
+	Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) ChunkSeriesSet
 }
 
 // LabelQuerier provides querying access over labels.
@@ -205,11 +205,11 @@ type SelectHints struct {
 // TODO(bwplotka): Move to promql/engine_test.go?
 // QueryableFunc is an adapter to allow the use of ordinary functions as
 // Queryables. It follows the idea of http.HandlerFunc.
-type QueryableFunc func(ctx context.Context, mint, maxt int64) (Querier, error)
+type QueryableFunc func(mint, maxt int64) (Querier, error)
 
 // Querier calls f() with the given parameters.
-func (f QueryableFunc) Querier(ctx context.Context, mint, maxt int64) (Querier, error) {
-	return f(ctx, mint, maxt)
+func (f QueryableFunc) Querier(mint, maxt int64) (Querier, error) {
+	return f(mint, maxt)
 }
 
 // Appender provides batched appends against a storage.

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -14,6 +14,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -24,7 +26,7 @@ func NoopQuerier() Querier {
 	return noopQuerier{}
 }
 
-func (noopQuerier) Select(bool, *SelectHints, ...*labels.Matcher) SeriesSet {
+func (noopQuerier) Select(context.Context, bool, *SelectHints, ...*labels.Matcher) SeriesSet {
 	return NoopSeriesSet()
 }
 
@@ -47,7 +49,7 @@ func NoopChunkedQuerier() ChunkQuerier {
 	return noopChunkQuerier{}
 }
 
-func (noopChunkQuerier) Select(bool, *SelectHints, ...*labels.Matcher) ChunkSeriesSet {
+func (noopChunkQuerier) Select(context.Context, bool, *SelectHints, ...*labels.Matcher) ChunkSeriesSet {
 	return NoopChunkedSeriesSet()
 }
 

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -48,9 +48,8 @@ func NewSampleAndChunkQueryableClient(
 	}
 }
 
-func (c *sampleAndChunkQueryableClient) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (c *sampleAndChunkQueryableClient) Querier(mint, maxt int64) (storage.Querier, error) {
 	q := &querier{
-		ctx:              ctx,
 		mint:             mint,
 		maxt:             maxt,
 		client:           c.client,
@@ -75,10 +74,9 @@ func (c *sampleAndChunkQueryableClient) Querier(ctx context.Context, mint, maxt 
 	return q, nil
 }
 
-func (c *sampleAndChunkQueryableClient) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+func (c *sampleAndChunkQueryableClient) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	cq := &chunkQuerier{
 		querier: querier{
-			ctx:              ctx,
 			mint:             mint,
 			maxt:             maxt,
 			client:           c.client,
@@ -125,7 +123,6 @@ func (c *sampleAndChunkQueryableClient) preferLocalStorage(mint, maxt int64) (cm
 }
 
 type querier struct {
-	ctx        context.Context
 	mint, maxt int64
 	client     ReadClient
 
@@ -140,7 +137,7 @@ type querier struct {
 //
 // If requiredMatchers are given, select returns a NoopSeriesSet if the given matchers don't match the label set of the
 // requiredMatchers. Otherwise it'll just call remote endpoint.
-func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (q *querier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	if len(q.requiredMatchers) > 0 {
 		// Copy to not modify slice configured by user.
 		requiredMatchers := append([]*labels.Matcher{}, q.requiredMatchers...)
@@ -167,7 +164,7 @@ func (q *querier) Select(sortSeries bool, hints *storage.SelectHints, matchers .
 		return storage.ErrSeriesSet(fmt.Errorf("toQuery: %w", err))
 	}
 
-	res, err := q.client.Read(q.ctx, query)
+	res, err := q.client.Read(ctx, query)
 	if err != nil {
 		return storage.ErrSeriesSet(fmt.Errorf("remote_read: %w", err))
 	}
@@ -235,9 +232,9 @@ type chunkQuerier struct {
 
 // Select implements storage.ChunkQuerier and uses the given matchers to read chunk series sets from the client.
 // It uses remote.querier.Select so it supports external labels and required matchers if specified.
-func (q *chunkQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+func (q *chunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
 	// TODO(bwplotka) Support remote read chunked and allow returning chunks directly (TODO ticket).
-	return storage.NewSeriesSetToChunkSet(q.querier.Select(sortSeries, hints, matchers...))
+	return storage.NewSeriesSetToChunkSet(q.querier.Select(ctx, sortSeries, hints, matchers...))
 }
 
 // Note strings in toFilter must be sorted.

--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -131,7 +131,7 @@ func (h *readHandler) remoteReadSamples(
 				return err
 			}
 
-			querier, err := h.queryable.Querier(ctx, query.StartTimestampMs, query.EndTimestampMs)
+			querier, err := h.queryable.Querier(query.StartTimestampMs, query.EndTimestampMs)
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ func (h *readHandler) remoteReadSamples(
 			}
 
 			var ws storage.Warnings
-			resp.Results[i], ws, err = ToQueryResult(querier.Select(false, hints, filteredMatchers...), h.remoteReadSampleLimit)
+			resp.Results[i], ws, err = ToQueryResult(querier.Select(ctx, false, hints, filteredMatchers...), h.remoteReadSampleLimit)
 			if err != nil {
 				return err
 			}
@@ -198,7 +198,7 @@ func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.Re
 				return err
 			}
 
-			querier, err := h.queryable.ChunkQuerier(ctx, query.StartTimestampMs, query.EndTimestampMs)
+			querier, err := h.queryable.ChunkQuerier(query.StartTimestampMs, query.EndTimestampMs)
 			if err != nil {
 				return err
 			}
@@ -225,7 +225,7 @@ func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.Re
 				NewChunkedWriter(w, f),
 				int64(i),
 				// The streaming API has to provide the series sorted.
-				querier.Select(true, hints, filteredMatchers...),
+				querier.Select(ctx, true, hints, filteredMatchers...),
 				sortedExternalLabels,
 				h.remoteReadMaxBytesInFrame,
 				h.marshalPool,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -152,14 +152,14 @@ func (s *Storage) StartTime() (int64, error) {
 // Returned querier will never return error as all queryables are assumed best effort.
 // Additionally all returned queriers ensure that its Select's SeriesSets have ready data after first `Next` invoke.
 // This is because Prometheus (fanout and secondary queries) can't handle the stream failing half way through by design.
-func (s *Storage) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (s *Storage) Querier(mint, maxt int64) (storage.Querier, error) {
 	s.mtx.Lock()
 	queryables := s.queryables
 	s.mtx.Unlock()
 
 	queriers := make([]storage.Querier, 0, len(queryables))
 	for _, queryable := range queryables {
-		q, err := queryable.Querier(ctx, mint, maxt)
+		q, err := queryable.Querier(mint, maxt)
 		if err != nil {
 			return nil, err
 		}
@@ -170,14 +170,14 @@ func (s *Storage) Querier(ctx context.Context, mint, maxt int64) (storage.Querie
 
 // ChunkQuerier returns a storage.MergeQuerier combining the remote client queriers
 // of each configured remote read endpoint.
-func (s *Storage) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+func (s *Storage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	s.mtx.Lock()
 	queryables := s.queryables
 	s.mtx.Unlock()
 
 	queriers := make([]storage.ChunkQuerier, 0, len(queryables))
 	for _, queryable := range queryables {
-		q, err := queryable.ChunkQuerier(ctx, mint, maxt)
+		q, err := queryable.ChunkQuerier(mint, maxt)
 		if err != nil {
 			return nil, err
 		}

--- a/storage/secondary.go
+++ b/storage/secondary.go
@@ -14,6 +14,7 @@
 package storage
 
 import (
+	"context"
 	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -63,12 +64,12 @@ func (s *secondaryQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, Wa
 	return names, w, nil
 }
 
-func (s *secondaryQuerier) Select(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) genericSeriesSet {
+func (s *secondaryQuerier) Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) genericSeriesSet {
 	if s.done {
 		panic("secondaryQuerier: Select invoked after first Next of any returned SeriesSet was done")
 	}
 
-	s.asyncSets = append(s.asyncSets, s.genericQuerier.Select(sortSeries, hints, matchers...))
+	s.asyncSets = append(s.asyncSets, s.genericQuerier.Select(ctx, sortSeries, hints, matchers...))
 	curr := len(s.asyncSets) - 1
 	return &lazyGenericSeriesSet{init: func() (genericSeriesSet, bool) {
 		s.once.Do(func() {

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -736,12 +736,12 @@ func (db *DB) StartTime() (int64, error) {
 }
 
 // Querier implements the Storage interface.
-func (db *DB) Querier(context.Context, int64, int64) (storage.Querier, error) {
+func (db *DB) Querier(int64, int64) (storage.Querier, error) {
 	return nil, ErrUnsupported
 }
 
 // ChunkQuerier implements the Storage interface.
-func (db *DB) ChunkQuerier(context.Context, int64, int64) (storage.ChunkQuerier, error) {
+func (db *DB) ChunkQuerier(int64, int64) (storage.ChunkQuerier, error) {
 	return nil, ErrUnsupported
 }
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -85,7 +85,7 @@ type IndexReader interface {
 
 	// SortedPostings returns a postings list that is reordered to be sorted
 	// by the label set of the underlying series.
-	SortedPostings(context.Context, index.Postings) index.Postings
+	SortedPostings(index.Postings) index.Postings
 
 	// ShardedPostings returns a postings list filtered by the provided shardIndex
 	// out of shardCount. For a given posting, its shard MUST be computed hashing
@@ -522,8 +522,8 @@ func (r blockIndexReader) PostingsForMatchers(ctx context.Context, concurrent bo
 	return r.ir.PostingsForMatchers(ctx, concurrent, ms...)
 }
 
-func (r blockIndexReader) SortedPostings(ctx context.Context, p index.Postings) index.Postings {
-	return r.ir.SortedPostings(ctx, p)
+func (r blockIndexReader) SortedPostings(p index.Postings) index.Postings {
+	return r.ir.SortedPostings(p)
 }
 
 func (r blockIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCount uint64) index.Postings {

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -196,7 +196,7 @@ func TestCorruptedChunk(t *testing.T) {
 			}
 			defer func() { require.NoError(t, b.Close()) }()
 
-			querier, err := NewBlockQuerier(b, 0, 1)
+			querier, err := NewBlockQuerier(context.Background(), b, 0, 1)
 			require.NoError(t, err)
 			defer func() { require.NoError(t, querier.Close()) }()
 			set := querier.Select(false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
@@ -353,12 +353,12 @@ func TestReadIndexFormatV1(t *testing.T) {
 		require.NoError(t, block.Close())
 	})
 
-	q, err := NewBlockQuerier(block, 0, 1000)
+	q, err := NewBlockQuerier(context.Background(), block, 0, 1000)
 	require.NoError(t, err)
 	require.Equal(t, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")),
 		map[string][]tsdbutil.Sample{`{foo="bar"}`: {sample{t: 1, f: 2}}})
 
-	q, err = NewBlockQuerier(block, 0, 1000)
+	q, err = NewBlockQuerier(context.Background(), block, 0, 1000)
 	require.NoError(t, err)
 	require.Equal(t, query(t, q, labels.MustNewMatcher(labels.MatchNotRegexp, "foo", "^.?$")),
 		map[string][]tsdbutil.Sample{

--- a/tsdb/blockwriter_test.go
+++ b/tsdb/blockwriter_test.go
@@ -49,7 +49,7 @@ func TestBlockWriter(t *testing.T) {
 	b, err := OpenBlock(nil, blockpath, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, b.Close()) }()
-	q, err := NewBlockQuerier(b, math.MinInt64, math.MaxInt64)
+	q, err := NewBlockQuerier(context.Background(), b, math.MinInt64, math.MaxInt64)
 	require.NoError(t, err)
 	series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
 	sample1 := []tsdbutil.Sample{sample{t: ts1, f: v1}}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -1013,7 +1013,7 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		if err != nil {
 			return err
 		}
-		all = indexr.SortedPostings(ctx, all)
+		all = indexr.SortedPostings(all)
 		// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
 		sets = append(sets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, all, minT, maxT-1, false))
 
@@ -1025,7 +1025,7 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 			if err != nil {
 				return err
 			}
-			all = indexr.SortedPostings(ctx, all)
+			all = indexr.SortedPostings(all)
 			// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
 			symbolsSets = append(symbolsSets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, all, minT, maxT-1, false))
 		} else {

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -1013,7 +1013,7 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		if err != nil {
 			return err
 		}
-		all = indexr.SortedPostings(all)
+		all = indexr.SortedPostings(ctx, all)
 		// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
 		sets = append(sets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, all, minT, maxT-1, false))
 
@@ -1025,7 +1025,7 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 			if err != nil {
 				return err
 			}
-			all = indexr.SortedPostings(all)
+			all = indexr.SortedPostings(ctx, all)
 			// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
 			symbolsSets = append(symbolsSets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, all, minT, maxT-1, false))
 		} else {

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1733,7 +1733,7 @@ func TestHeadCompactionWithHistograms(t *testing.T) {
 				require.NoError(t, block.Close())
 			})
 
-			q, err := NewBlockQuerier(block, block.MinTime(), block.MaxTime())
+			q, err := NewBlockQuerier(context.Background(), block, block.MinTime(), block.MaxTime())
 			require.NoError(t, err)
 
 			actHists := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4238,7 +4238,7 @@ func TestOOOCompaction(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -4369,7 +4369,7 @@ func TestOOOCompactionWithNormalCompaction(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -4469,7 +4469,7 @@ func TestOOOCompactionWithDisabledWriteLog(t *testing.T) {
 			series2.String(): series2Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
@@ -5257,7 +5257,7 @@ func TestOOOCompactionFailure(t *testing.T) {
 			series1.String(): series1Samples,
 		}
 
-		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		q, err := NewBlockQuerier(context.Background(), block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1449,13 +1449,13 @@ func (h *RangeHead) String() string {
 
 // Delete all samples in the range of [mint, maxt] for series that satisfy the given
 // label matchers.
-func (h *Head) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
+func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error {
 	// Do not delete anything beyond the currently valid range.
 	mint, maxt = clampInterval(mint, maxt, h.MinTime(), h.MaxTime())
 
 	ir := h.indexRange(mint, maxt)
 
-	p, err := ir.PostingsForMatchers(context.Background(), false, ms...)
+	p, err := ir.PostingsForMatchers(ctx, false, ms...)
 	if err != nil {
 		return errors.Wrap(err, "select series")
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -1454,7 +1455,7 @@ func (h *Head) Delete(mint, maxt int64, ms ...*labels.Matcher) error {
 
 	ir := h.indexRange(mint, maxt)
 
-	p, err := ir.PostingsForMatchers(false, ms...)
+	p, err := ir.PostingsForMatchers(context.Background(), false, ms...)
 	if err != nil {
 		return errors.Wrap(err, "select series")
 	}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -124,15 +124,11 @@ func (h *headIndexReader) PostingsForMatchers(ctx context.Context, concurrent bo
 	return h.head.pfmc.PostingsForMatchers(ctx, h, concurrent, ms...)
 }
 
-func (h *headIndexReader) SortedPostings(ctx context.Context, p index.Postings) index.Postings {
+func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 	series := make([]*memSeries, 0, 128)
 
 	// Fetch all the series only once.
 	for p.Next() {
-		if err := ctx.Err(); err != nil {
-			return index.ErrPostings(errors.Wrap(err, "expand postings"))
-		}
-
 		s := h.head.series.getByID(chunks.HeadSeriesRef(p.At()))
 		if s == nil {
 			level.Debug(h.head.logger).Log("msg", "Looked up series not found")

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1727,7 +1727,7 @@ func (r *Reader) Postings(name string, values ...string) (Postings, error) {
 
 // SortedPostings returns the given postings list reordered so that the backing series
 // are sorted.
-func (r *Reader) SortedPostings(_ context.Context, p Postings) Postings {
+func (r *Reader) SortedPostings(p Postings) Postings {
 	return p
 }
 

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1727,7 +1727,7 @@ func (r *Reader) Postings(name string, values ...string) (Postings, error) {
 
 // SortedPostings returns the given postings list reordered so that the backing series
 // are sorted.
-func (r *Reader) SortedPostings(p Postings) Postings {
+func (r *Reader) SortedPostings(_ context.Context, p Postings) Postings {
 	return p
 }
 

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -107,12 +107,12 @@ func (m mockIndex) Postings(name string, values ...string) (Postings, error) {
 	p := []Postings{}
 	for _, value := range values {
 		l := labels.Label{Name: name, Value: value}
-		p = append(p, m.SortedPostings(context.Background(), NewListPostings(m.postings[l])))
+		p = append(p, m.SortedPostings(NewListPostings(m.postings[l])))
 	}
 	return Merge(p...), nil
 }
 
-func (m mockIndex) SortedPostings(_ context.Context, p Postings) Postings {
+func (m mockIndex) SortedPostings(p Postings) Postings {
 	ep, err := ExpandPostings(p)
 	if err != nil {
 		return ErrPostings(errors.Wrap(err, "expand postings"))

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -107,12 +107,12 @@ func (m mockIndex) Postings(name string, values ...string) (Postings, error) {
 	p := []Postings{}
 	for _, value := range values {
 		l := labels.Label{Name: name, Value: value}
-		p = append(p, m.SortedPostings(NewListPostings(m.postings[l])))
+		p = append(p, m.SortedPostings(context.Background(), NewListPostings(m.postings[l])))
 	}
 	return Merge(p...), nil
 }
 
-func (m mockIndex) SortedPostings(p Postings) Postings {
+func (m mockIndex) SortedPostings(_ context.Context, p Postings) Postings {
 	ep, err := ExpandPostings(p)
 	if err != nil {
 		return ErrPostings(errors.Wrap(err, "expand postings"))

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -275,7 +275,7 @@ type OOOCompactionHead struct {
 // 4. Cuts a new WBL file for the OOO WBL.
 // All the above together have a bit of CPU and memory overhead, and can have a bit of impact
 // on the sample append latency. So call NewOOOCompactionHead only right before compaction.
-func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, error) {
+func NewOOOCompactionHead(head *Head) (*OOOCompactionHead, error) {
 	ch := &OOOCompactionHead{
 		chunkRange: head.chunkRange.Load(),
 		mint:       math.MaxInt64,
@@ -298,7 +298,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 	if err != nil {
 		return nil, err
 	}
-	p = ch.oooIR.SortedPostings(ctx, p)
+	p = ch.oooIR.SortedPostings(p)
 
 	var lastSeq, lastOff int
 	for p.Next() {
@@ -411,7 +411,7 @@ func (ir *OOOCompactionHeadIndexReader) Postings(name string, values ...string) 
 	return index.NewListPostings(ir.ch.postings), nil
 }
 
-func (ir *OOOCompactionHeadIndexReader) SortedPostings(_ context.Context, p index.Postings) index.Postings {
+func (ir *OOOCompactionHeadIndexReader) SortedPostings(p index.Postings) index.Postings {
 	// This will already be sorted from the Postings() call above.
 	return p
 }

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -2,6 +2,7 @@ package tsdb
 
 import (
 	"container/list"
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -60,18 +61,18 @@ type PostingsForMatchersCache struct {
 	// timeNow is the time.Now that can be replaced for testing purposes
 	timeNow func() time.Time
 	// postingsForMatchers can be replaced for testing purposes
-	postingsForMatchers func(ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error)
+	postingsForMatchers func(ctx context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error)
 }
 
-func (c *PostingsForMatchersCache) PostingsForMatchers(ix IndexPostingsReader, concurrent bool, ms ...*labels.Matcher) (index.Postings, error) {
+func (c *PostingsForMatchersCache) PostingsForMatchers(ctx context.Context, ix IndexPostingsReader, concurrent bool, ms ...*labels.Matcher) (index.Postings, error) {
 	if !concurrent && !c.force {
-		return c.postingsForMatchers(ix, ms...)
+		return c.postingsForMatchers(ctx, ix, ms...)
 	}
 	c.expire()
-	return c.postingsForMatchersPromise(ix, ms)()
+	return c.postingsForMatchersPromise(ctx, ix, ms)()
 }
 
-func (c *PostingsForMatchersCache) postingsForMatchersPromise(ix IndexPostingsReader, ms []*labels.Matcher) func() (index.Postings, error) {
+func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Context, ix IndexPostingsReader, ms []*labels.Matcher) func() (index.Postings, error) {
 	var (
 		wg       sync.WaitGroup
 		cloner   *index.PostingsCloner
@@ -94,7 +95,7 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ix IndexPostingsRe
 	}
 	defer wg.Done()
 
-	if postings, err := c.postingsForMatchers(ix, ms...); err != nil {
+	if postings, err := c.postingsForMatchers(ctx, ix, ms...); err != nil {
 		outerErr = err
 	} else {
 		cloner = index.NewPostingsCloner(postings)
@@ -198,8 +199,8 @@ type indexReaderWithPostingsForMatchers struct {
 	pfmc *PostingsForMatchersCache
 }
 
-func (ir indexReaderWithPostingsForMatchers) PostingsForMatchers(concurrent bool, ms ...*labels.Matcher) (index.Postings, error) {
-	return ir.pfmc.PostingsForMatchers(ir, concurrent, ms...)
+func (ir indexReaderWithPostingsForMatchers) PostingsForMatchers(ctx context.Context, concurrent bool, ms ...*labels.Matcher) (index.Postings, error) {
+	return ir.pfmc.PostingsForMatchers(ctx, ir, concurrent, ms...)
 }
 
 var _ IndexReader = indexReaderWithPostingsForMatchers{}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -168,7 +168,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := PostingsForMatchers(ir, c.matchers...)
+				_, err := PostingsForMatchers(context.Background(), ir, c.matchers...)
 				require.NoError(b, err)
 			}
 		})
@@ -213,7 +213,7 @@ func benchmarkLabelValuesWithMatchers(b *testing.B, ir IndexReader) {
 	for _, c := range cases {
 		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := labelValuesWithMatchers(ir, c.labelName, c.matchers...)
+				_, err := labelValuesWithMatchers(context.Background(), ir, c.labelName, c.matchers...)
 				require.NoError(b, err)
 			}
 		})
@@ -263,7 +263,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 			b.Run(fmt.Sprintf("%dof%d", s, numSeries), func(b *testing.B) {
 				mint := int64(0)
 				maxt := int64(s - 1)
-				q, err := NewBlockQuerier(br, mint, maxt)
+				q, err := NewBlockQuerier(context.Background(), br, mint, maxt)
 				require.NoError(b, err)
 
 				b.ResetTimer()

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -171,7 +171,6 @@ type blockQuerierTestCase struct {
 func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr ChunkReader, stones *tombstones.MemTombstones) {
 	t.Run("sample", func(t *testing.T) {
 		q := blockQuerier{
-			ctx: context.Background(),
 			blockBaseQuerier: &blockBaseQuerier{
 				index:      ir,
 				chunks:     cr,
@@ -182,7 +181,7 @@ func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr C
 			},
 		}
 
-		res := q.Select(false, c.hints, c.ms...)
+		res := q.Select(context.Background(), false, c.hints, c.ms...)
 		defer func() { require.NoError(t, q.Close()) }()
 
 		for {
@@ -208,7 +207,6 @@ func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr C
 
 	t.Run("chunk", func(t *testing.T) {
 		q := blockChunkQuerier{
-			ctx: context.Background(),
 			blockBaseQuerier: &blockBaseQuerier{
 				index:      ir,
 				chunks:     cr,
@@ -218,7 +216,7 @@ func testBlockQuerier(t *testing.T, c blockQuerierTestCase, ir IndexReader, cr C
 				maxt: c.maxt,
 			},
 		}
-		res := q.Select(false, c.hints, c.ms...)
+		res := q.Select(context.Background(), false, c.hints, c.ms...)
 		defer func() { require.NoError(t, q.Close()) }()
 
 		for {

--- a/web/federate.go
+++ b/web/federate.go
@@ -57,6 +57,8 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	h.mtx.RLock()
 	defer h.mtx.RUnlock()
 
+	ctx := req.Context()
+
 	if err := req.ParseForm(); err != nil {
 		http.Error(w, fmt.Sprintf("error parsing form values: %v", err), http.StatusBadRequest)
 		return
@@ -80,7 +82,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 	)
 	w.Header().Set("Content-Type", string(format))
 
-	q, err := h.localStorage.Querier(req.Context(), mint, maxt)
+	q, err := h.localStorage.Querier(mint, maxt)
 	if err != nil {
 		federationErrors.Inc()
 		if errors.Cause(err) == tsdb.ErrNotReady {
@@ -98,7 +100,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		s := q.Select(true, hints, mset...)
+		s := q.Select(ctx, true, hints, mset...)
 		sets = append(sets, s)
 	}
 


### PR DESCRIPTION
Prometheus PR https://github.com/prometheus/prometheus/pull/12359 adds context argument to `tsdb.IndexReader.PostingsForMatchers`, I'm porting that change to mimir-prometheus. I'm also adding context to the `SortedPostings` method, since it needs it too.