### PR TITLE
Check storage.ErrNotFound in labelValuesFromSeries

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -434,6 +434,10 @@ func labelValuesFromSeries(r IndexReader, labelName string, refs []storage.Serie
 	var builder labels.ScratchBuilder
 	for _, ref := range refs {
 		err := r.Series(ref, &builder, nil)
+		// Postings may be stale. Skip if no underlying series exists.
+		if errors.Cause(err) == storage.ErrNotFound {
+			continue
+		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "label values for label %s", labelName)
 		}


### PR DESCRIPTION
I'm not very comfortable with using an equality check on errors, but I'm copying the same code from Prometheus:

https://github.com/prometheus/prometheus/blob/f711d71aa8318dbb39522ac26f8ee77cc373f77b/tsdb/querier.go#L532-L533

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
