### PR TITLE
`LabelValues()` with matchers should use cache

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -380,7 +380,7 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexPostingsReader, m *l
 const maxExpandedPostingsFactor = 100 // Division factor for maximum number of matched series.
 
 func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, matchers ...*labels.Matcher) ([]string, error) {
-	p, err := PostingsForMatchers(ctx, r, matchers...)
+	p, err := r.PostingsForMatchers(ctx, false, matchers...)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching postings for matchers")
 	}


### PR DESCRIPTION
When cache was introduced, `LabelValues(matchers...)` could never be called with `concurrent=true` flag so it didn't make sense to use the cached call through the Head.

However, since the introduction of forced cache, we should use it, as even with `concurrent=false` the cache may be used.
