### PR TITLE
Optimize .? in the FastRegexMatcher

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -482,7 +482,7 @@ func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
 		return anyStringWithoutNewlineMatcher{}
 	case syntax.OpQuest:
 		// Only optimize for ".?".
-		if len(re.Sub) != 1 || re.Sub[0].Op != syntax.OpAnyChar && re.Sub[0].Op != syntax.OpAnyCharNotNL {
+		if len(re.Sub) != 1 || (re.Sub[0].Op != syntax.OpAnyChar && re.Sub[0].Op != syntax.OpAnyCharNotNL) {
 			return nil
 		}
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -78,6 +78,13 @@ var (
 		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*|qbvKMimS.*|IecrXtPa.*|seTckYqt.*|NxnyHkgB.*|fIDlOgKb.*|UhlWIygH.*|OtNoJxHG.*|cUTkFVIV.*|mTgFIHjr.*|jQkoIDtE.*|PPMKxRXl.*|AwMfwVkQ.*|CQyMrTQJ.*|BzrqxVSi.*|nTpcWuhF.*|PertdywG.*|ZZDgCtXN.*|WWdDPyyE.*|uVtNQsKk.*|BdeCHvPZ.*|wshRnFlH.*|aOUIitIp.*|RxZeCdXT.*|CFZMslCj.*|AVBZRDxl.*|IzIGCnhw.*|ythYuWiz.*|oztXVXhl.*|VbLkwqQx.*|qvaUgyVC.*|VawUjPWC.*|ecloYJuj.*|boCLTdSU.*|uPrKeAZx.*|hrMWLWBq.*|JOnUNHRM.*|rYnujkPq.*|dDEdZhIj.*|DRrfvugG.*|yEGfDxVV.*|YMYdJWuP.*|PHUQZNWM.*|AmKNrLis.*|zTxndVfn.*|FPsHoJnc.*|EIulZTua.*|KlAPhdzg.*|ScHJJCLt.*|NtTfMzME.*|eMCwuFdo.*|SEpJVJbR.*|cdhXZeCx.*|sAVtBwRh.*|kVFEVcMI.*|jzJrxraA.*|tGLHTell.*|NNWoeSaw.*|DcOKSetX.*|UXZAJyka.*|THpMphDP.*|rizheevl.*|kDCBRidd.*|pCZZRqyu.*|pSygkitl.*|SwZGkAaW.*|wILOrfNX.*|QkwVOerj.*|kHOMxPDr.*|EwOVycJv.*|AJvtzQFS.*|yEOjKYYB.*|LizIINLL.*|JBRSsfcG.*|YPiUqqNl.*|IsdEbvee.*|MjEpGcBm.*|OxXZVgEQ.*|xClXGuxa.*|UzRCGFEb.*|buJbvfvA.*|IPZQxRet.*|oFYShsMc.*|oBHffuHO.*|bzzKrcBR.*|KAjzrGCl.*|IPUsAVls.*|OGMUMbIU.*|gyDccHuR.*|bjlalnDd.*|ZLWjeMna.*|fdsuIlxQ.*|dVXtiomV.*|XxedTjNg.*|XWMHlNoA.*|nnyqArQX.*|opfkWGhb.*|wYtnhdYb.*))",
 		// A long case insensitive alternation where each entry starts with ".*".
 		"(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWuuSoAl|.*qbvKMimS|.*IecrXtPa|.*seTckYqt|.*NxnyHkgB|.*fIDlOgKb|.*UhlWIygH|.*OtNoJxHG|.*cUTkFVIV|.*mTgFIHjr|.*jQkoIDtE|.*PPMKxRXl|.*AwMfwVkQ|.*CQyMrTQJ|.*BzrqxVSi|.*nTpcWuhF|.*PertdywG|.*ZZDgCtXN|.*WWdDPyyE|.*uVtNQsKk|.*BdeCHvPZ|.*wshRnFlH|.*aOUIitIp|.*RxZeCdXT|.*CFZMslCj|.*AVBZRDxl|.*IzIGCnhw|.*ythYuWiz|.*oztXVXhl|.*VbLkwqQx|.*qvaUgyVC|.*VawUjPWC|.*ecloYJuj|.*boCLTdSU|.*uPrKeAZx|.*hrMWLWBq|.*JOnUNHRM|.*rYnujkPq|.*dDEdZhIj|.*DRrfvugG|.*yEGfDxVV|.*YMYdJWuP|.*PHUQZNWM|.*AmKNrLis|.*zTxndVfn|.*FPsHoJnc|.*EIulZTua|.*KlAPhdzg|.*ScHJJCLt|.*NtTfMzME|.*eMCwuFdo|.*SEpJVJbR|.*cdhXZeCx|.*sAVtBwRh|.*kVFEVcMI|.*jzJrxraA|.*tGLHTell|.*NNWoeSaw|.*DcOKSetX|.*UXZAJyka|.*THpMphDP|.*rizheevl|.*kDCBRidd|.*pCZZRqyu|.*pSygkitl|.*SwZGkAaW|.*wILOrfNX|.*QkwVOerj|.*kHOMxPDr|.*EwOVycJv|.*AJvtzQFS|.*yEOjKYYB|.*LizIINLL|.*JBRSsfcG|.*YPiUqqNl|.*IsdEbvee|.*MjEpGcBm|.*OxXZVgEQ|.*xClXGuxa|.*UzRCGFEb|.*buJbvfvA|.*IPZQxRet|.*oFYShsMc|.*oBHffuHO|.*bzzKrcBR|.*KAjzrGCl|.*IPUsAVls|.*OGMUMbIU|.*gyDccHuR|.*bjlalnDd|.*ZLWjeMna|.*fdsuIlxQ|.*dVXtiomV|.*XxedTjNg|.*XWMHlNoA|.*nnyqArQX|.*opfkWGhb|.*wYtnhdYb))",
+		// Quest ".?".
+		"fo.?",
+		"foo.?",
+		"f.?o",
+		".*foo.?",
+		".?foo.+",
+		"foo.?|bar",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
@@ -418,6 +425,13 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{"foo.+.+", nil},
 		{".*.*foo", nil},
 		{".+.+foo", nil},
+		{"aaa.?.?", nil},
+		{"aaa.?.*", nil},
+		// Regexps with ".?".
+		{"ext.?|xfs", orStringMatcher{&literalPrefixStringMatcher{prefix: "ext", prefixCaseSensitive: true, right: &zeroOrOneCharacterStringMatcher{matchNL: false}}, &equalStringMatcher{s: "xfs", caseSensitive: true}}},
+		{"(?s)(ext.?|xfs)", orStringMatcher{&literalPrefixStringMatcher{prefix: "ext", prefixCaseSensitive: true, right: &zeroOrOneCharacterStringMatcher{matchNL: true}}, &equalStringMatcher{s: "xfs", caseSensitive: true}}},
+		{"foo.?", &literalPrefixStringMatcher{prefix: "foo", prefixCaseSensitive: true, right: &zeroOrOneCharacterStringMatcher{matchNL: false}}},
+		{"f.?o", nil},
 	} {
 		c := c
 		t.Run(c.pattern, func(t *testing.T) {
@@ -570,6 +584,88 @@ func TestStringMatcherFromRegexp_LiteralSuffix(t *testing.T) {
 			})
 
 			require.Equal(t, c.expectedLiteralSuffixMatchers, numSuffixMatchers)
+
+			for _, value := range c.expectedMatches {
+				assert.Truef(t, matcher.Matches(value), "Value: %s", value)
+
+				// Ensure the golang regexp engine would return the same.
+				assert.Truef(t, re.MatchString(value), "Value: %s", value)
+			}
+
+			for _, value := range c.expectedNotMatches {
+				assert.Falsef(t, matcher.Matches(value), "Value: %s", value)
+
+				// Ensure the golang regexp engine would return the same.
+				assert.Falsef(t, re.MatchString(value), "Value: %s", value)
+			}
+		})
+	}
+}
+
+func TestStringMatcherFromRegexp_Quest(t *testing.T) {
+	for _, c := range []struct {
+		pattern                   string
+		expectedZeroOrOneMatchers int
+		expectedMatches           []string
+		expectedNotMatches        []string
+	}{
+		// Not match newline.
+		{
+			pattern:                   "test.?",
+			expectedZeroOrOneMatchers: 1,
+			expectedMatches:           []string{"test", "test!"},
+			expectedNotMatches:        []string{"test\n", "tes", "test!!"},
+		}, {
+			pattern:                   ".?test",
+			expectedZeroOrOneMatchers: 1,
+			expectedMatches:           []string{"test", "!test"},
+			expectedNotMatches:        []string{"\ntest", "tes", "test!"},
+		}, {
+			pattern:                   "(aaa.?|bbb.?)",
+			expectedZeroOrOneMatchers: 2,
+			expectedMatches:           []string{"aaa", "aaaX", "bbb", "bbbX"},
+			expectedNotMatches:        []string{"aa", "aaaXX", "aaa\n", "bb", "bbbXX", "bbb\n"},
+		}, {
+			pattern:                   ".*aaa.?",
+			expectedZeroOrOneMatchers: 1,
+			expectedMatches:           []string{"aaa", "Xaaa", "aaaX", "XXXaaa", "XXXaaaX"},
+			expectedNotMatches:        []string{"aa", "aaaXX", "XXXaaaXXX", "XXXaaa\n"},
+		},
+
+		// Match newline.
+		{
+			pattern:                   "(?s)test.?",
+			expectedZeroOrOneMatchers: 1,
+			expectedMatches:           []string{"test", "test!", "test\n"},
+			expectedNotMatches:        []string{"tes", "test!!", "test\n\n"},
+		},
+
+		// Mixed flags (a part matches newline another doesn't).
+		{
+			pattern:                   "(aaa.?|((?s).?bbb.+))",
+			expectedZeroOrOneMatchers: 2,
+			expectedMatches:           []string{"aaa", "aaaX", "bbbX", "XbbbX", "bbbXXX", "\nbbbX"},
+			expectedNotMatches:        []string{"aa", "aaa\n", "Xbbb", "\nbbb"},
+		},
+	} {
+		t.Run(c.pattern, func(t *testing.T) {
+			parsed, err := syntax.Parse(c.pattern, syntax.Perl)
+			require.NoError(t, err)
+
+			matcher := stringMatcherFromRegexp(parsed)
+			require.NotNil(t, matcher)
+
+			re := regexp.MustCompile("^" + c.pattern + "$")
+
+			// Pre-condition check: ensure it contains zeroOrOneCharacterStringMatcher.
+			numZeroOrOneMatchers := 0
+			visitStringMatcher(matcher, func(matcher StringMatcher) {
+				if _, ok := matcher.(*zeroOrOneCharacterStringMatcher); ok {
+					numZeroOrOneMatchers++
+				}
+			})
+
+			require.Equal(t, c.expectedZeroOrOneMatchers, numZeroOrOneMatchers)
 
 			for _, value := range c.expectedMatches {
 				assert.Truef(t, matcher.Matches(value), "Value: %s", value)
@@ -1104,6 +1200,22 @@ func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
 			})
 		}
 	}
+}
+
+func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
+	matcher := &zeroOrOneCharacterStringMatcher{matchNL: true}
+	assert.True(t, matcher.Matches(""))
+	assert.True(t, matcher.Matches("x"))
+	assert.True(t, matcher.Matches("\n"))
+	assert.False(t, matcher.Matches("xx"))
+	assert.False(t, matcher.Matches("\n\n"))
+
+	matcher = &zeroOrOneCharacterStringMatcher{matchNL: false}
+	assert.True(t, matcher.Matches(""))
+	assert.True(t, matcher.Matches("x"))
+	assert.False(t, matcher.Matches("\n"))
+	assert.False(t, matcher.Matches("xx"))
+	assert.False(t, matcher.Matches("\n\n"))
 }
 
 func TestLiteralPrefixStringMatcher(t *testing.T) {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -615,17 +615,20 @@ func TestStringMatcherFromRegexp_Quest(t *testing.T) {
 			expectedZeroOrOneMatchers: 1,
 			expectedMatches:           []string{"test", "test!"},
 			expectedNotMatches:        []string{"test\n", "tes", "test!!"},
-		}, {
+		},
+		{
 			pattern:                   ".?test",
 			expectedZeroOrOneMatchers: 1,
 			expectedMatches:           []string{"test", "!test"},
 			expectedNotMatches:        []string{"\ntest", "tes", "test!"},
-		}, {
+		},
+		{
 			pattern:                   "(aaa.?|bbb.?)",
 			expectedZeroOrOneMatchers: 2,
 			expectedMatches:           []string{"aaa", "aaaX", "bbb", "bbbX"},
 			expectedNotMatches:        []string{"aa", "aaaXX", "aaa\n", "bb", "bbbXX", "bbb\n"},
-		}, {
+		},
+		{
 			pattern:                   ".*aaa.?",
 			expectedZeroOrOneMatchers: 1,
 			expectedMatches:           []string{"aaa", "Xaaa", "aaaX", "XXXaaa", "XXXaaaX"},


### PR DESCRIPTION
This PR builds on top of #536 and optimize for the ".?" case. I don't feel strong about this optimization, but we believe it's not too risky (from a correctness perspective), may be another bullet in our optimization arsenal.

Performance change for the queries containing ".?":

```
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                              │ before-quest.txt │           after-quest.txt           │
                              │      sec/op      │   sec/op     vs base                │
FastRegexMatcher/fo.?-12             191.5n ± 1%   141.3n ± 1%  -26.21% (p=0.000 n=10)
FastRegexMatcher/foo.?-12            193.9n ± 3%   140.8n ± 2%  -27.40% (p=0.000 n=10)
FastRegexMatcher/f.?o-12             136.5n ± 2%   138.2n ± 2%   +1.28% (p=0.017 n=10)
FastRegexMatcher/.*foo.?-12         1843.0n ± 2%   298.2n ± 7%  -83.82% (p=0.000 n=10)
FastRegexMatcher/.?foo.+-12          850.9n ± 2%   289.7n ± 5%  -65.96% (p=0.000 n=10)
FastRegexMatcher/foo.?|bar-12        961.7n ± 2%   224.7n ± 2%  -76.63% (p=0.000 n=10)
geomean
```