### PR TITLE
Fix BenchmarkOptimizeEqualStringMatchers

### DIFF
--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -1183,7 +1183,11 @@ func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
 				require.IsType(b, orStringMatcher{}, unoptimized)
 
 				optimized := optimizeEqualStringMatchers(unoptimized, 0)
-				require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
+				if numAlternations < minEqualMultiStringMatcherMapThreshold {
+					require.IsType(b, &equalMultiStringSliceMatcher{}, optimized)
+				} else {
+					require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
+				}
 
 				b.Run("without optimizeEqualStringMatchers()", func(b *testing.B) {
 					for n := 0; n < b.N; n++ {


### PR DESCRIPTION
The logic has changed, and we create a slice-based matcher for smaller number of alternations. This fixes the benchmark.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
