### PR TITLE
Fix issue where `chainSampleIterator` can obscure errors

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -497,7 +497,12 @@ func (c *chainSampleIterator) Seek(t int64) chunkenc.ValueType {
 	c.consecutive = false
 	c.h = samplesIteratorHeap{}
 	for _, iter := range c.iterators {
-		if iter.Seek(t) != chunkenc.ValNone {
+		if iter.Seek(t) == chunkenc.ValNone {
+			if iter.Err() != nil {
+				// If any iterator is reporting an error, abort.
+				return chunkenc.ValNone
+			}
+		} else {
 			heap.Push(&c.h, iter)
 		}
 	}

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -1144,6 +1144,16 @@ func TestChainSampleIteratorSeek(t *testing.T) {
 	}
 }
 
+func TestChainSampleIteratorSeekFailingIterator(t *testing.T) {
+	merged := ChainSampleIteratorFromIterators(nil, []chunkenc.Iterator{
+		NewListSeriesIterator(samples{fSample{0, 0.1}, fSample{1, 1.1}, fSample{2, 2.1}}),
+		errIterator{errors.New("something went wrong")},
+	})
+
+	require.Equal(t, chunkenc.ValNone, merged.Seek(0))
+	require.EqualError(t, merged.Err(), "something went wrong")
+}
+
 func TestChainSampleIteratorSeekHistogramCounterResetHint(t *testing.T) {
 	for sampleType, sampleFunc := range map[string]func(int64, histogram.CounterResetHint) chunks.Sample{
 		"histogram":       func(ts int64, hint histogram.CounterResetHint) chunks.Sample { return histogramSample(ts, hint) },
@@ -1538,4 +1548,36 @@ func TestMergeGenericQuerierWithSecondaries_ErrorHandling(t *testing.T) {
 			})
 		})
 	}
+}
+
+type errIterator struct {
+	err error
+}
+
+func (e errIterator) Next() chunkenc.ValueType {
+	return chunkenc.ValNone
+}
+
+func (e errIterator) Seek(t int64) chunkenc.ValueType {
+	return chunkenc.ValNone
+}
+
+func (e errIterator) At() (int64, float64) {
+	return 0, 0
+}
+
+func (e errIterator) AtHistogram() (int64, *histogram.Histogram) {
+	return 0, nil
+}
+
+func (e errIterator) AtFloatHistogram() (int64, *histogram.FloatHistogram) {
+	return 0, nil
+}
+
+func (e errIterator) AtT() int64 {
+	return 0
+}
+
+func (e errIterator) Err() error {
+	return e.err
 }


### PR DESCRIPTION
If any iterator in a `chainSampleIterator` has a sample after the desired timestamp when `Seek()` is called, `Seek()` will not return `ValNone`. 

If some iterators have failed (ie. calling `innerIterator.Err()` returns a non-`nil` value) and others have not, this behaviour may hide errors from those iterators: callers of `Seek()` will not receive `ValNone` and therefore won't know to check `chainSampleIterator.Err()`.

`Next()` is susceptible to a similar issue if `Next()` is not called until the stream is completely exhausted. 

I'll submit this fix upstream once we've tested Mimir with it.