### PR TITLE
DB.UnorderedChunkQuerier: Remove unused ctx argument

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2084,7 +2084,7 @@ func (db *DB) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 
 // UnorderedChunkQuerier returns a new chunk querier over the data partition for the given time range.
 // The chunks can be overlapping and not sorted.
-func (db *DB) UnorderedChunkQuerier(_ context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+func (db *DB) UnorderedChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	blockQueriers, err := db.blockChunkQuerierForRange(mint, maxt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove unused `ctx` argument from `DB.UnorderedChunkQuerier`. Also `DB.ChunkQuerier` doesn't have a `ctx` argument any longer.

Note that `DB.UnorderedChunkQuerier` doesn't exist upstream.