### PR TITLE
Remove NewPossibleNonCounterInfo until it can be made more efficient

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2536,7 +2536,7 @@ type groupedAggregation struct {
 func (ev *evaluator) aggregation(e *parser.AggregateExpr, grouping []string, param interface{}, vec Vector, seriesHelper []EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	op := e.Op
 	without := e.Without
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 	result := map[uint64]*groupedAggregation{}
 	orderedResult := []*groupedAggregation{}
 	var k int64

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -77,7 +77,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		resultHistogram    *histogram.FloatHistogram
 		firstT, lastT      int64
 		numSamplesMinusOne int
-		annos              = annotations.Annotations{}
+		annos              annotations.Annotations
 	)
 
 	// We need either at least two Histograms and no Floats, or at least two
@@ -85,6 +85,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	// Vector element.
 	metricName := samples.Metric.Get(labels.MetricName)
 	if len(samples.Histograms) > 0 && len(samples.Floats) > 0 {
+		annos := annotations.Annotations{}
 		return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, args[0].PositionRange()))
 	}
 
@@ -96,6 +97,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		var newAnnos annotations.Annotations
 		resultHistogram, newAnnos = histogramRate(samples.Histograms, isCounter, metricName, args[0].PositionRange())
 		if resultHistogram == nil {
+			annos := annotations.Annotations{}
 			// The histograms are not compatible with each other.
 			return enh.Out, annos.Merge(newAnnos)
 		}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -88,14 +88,6 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, args[0].PositionRange()))
 	}
 
-	if isCounter && metricName != "" && len(samples.Floats) > 0 &&
-		!strings.HasSuffix(metricName, "_total") &&
-		!strings.HasSuffix(metricName, "_sum") &&
-		!strings.HasSuffix(metricName, "_count") &&
-		!strings.HasSuffix(metricName, "_bucket") {
-		annos.Add(annotations.NewPossibleNonCounterInfo(metricName, args[0].PositionRange()))
-	}
-
 	switch {
 	case len(samples.Histograms) > 1:
 		numSamplesMinusOne = len(samples.Histograms) - 1

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -85,7 +85,6 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	// Vector element.
 	metricName := samples.Metric.Get(labels.MetricName)
 	if len(samples.Histograms) > 0 && len(samples.Floats) > 0 {
-		annos := annotations.Annotations{}
 		return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, args[0].PositionRange()))
 	}
 
@@ -97,7 +96,6 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		var newAnnos annotations.Annotations
 		resultHistogram, newAnnos = histogramRate(samples.Histograms, isCounter, metricName, args[0].PositionRange())
 		if resultHistogram == nil {
-			annos := annotations.Annotations{}
 			// The histograms are not compatible with each other.
 			return enh.Out, annos.Merge(newAnnos)
 		}
@@ -636,7 +634,7 @@ func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *Eva
 		return enh.Out, nil
 	}
 
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 	if math.IsNaN(q) || q < 0 || q > 1 {
 		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
 	}
@@ -1099,7 +1097,7 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	q := vals[0].(Vector)[0].F
 	inVec := vals[1].(Vector)
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 
 	if math.IsNaN(q) || q < 0 || q > 1 {
 		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))


### PR DESCRIPTION
According to benchmarks, this is very inefficient for many rate queries, temporarily removing until we find a better way.

With before as without the removed code, and after as with:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                                  │ BenchmarkRangeQuery_before.txt │    BenchmarkRangeQuery_after.txt     │
                                                  │             sec/op             │   sec/op     vs base                 │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                      15.33m ± 2%   89.57m ± 3%  +484.36% (p=0.000 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │      BenchmarkRangeQuery_after.txt      │
                                                  │              B/op              │     B/op       vs base                  │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                     4.946Mi ± 0%   66.805Mi ± 0%  +1250.79% (p=0.000 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │    BenchmarkRangeQuery_after.txt     │
                                                  │           allocs/op            │  allocs/op   vs base                 │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                      105.4k ± 0%   806.3k ± 0%  +665.22% (p=0.000 n=10)
```