### PR TITLE
Fix issue where `concatenatingChunkIterator` can obscure errors.

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -893,6 +893,9 @@ func (c *concatenatingChunkIterator) Next() bool {
 		c.curr = c.iterators[c.idx].At()
 		return true
 	}
+	if c.iterators[c.idx].Err() != nil {
+		return false
+	}
 	c.idx++
 	return c.Next()
 }


### PR DESCRIPTION
This PR fixes a similar issue to https://github.com/grafana/mimir-prometheus/pull/540, but this time for `concatenatingChunkIterator`: if a consumer of a `concatenatingChunkIterator` does not consume it all the way to the end (ie. until `Next()` returns `false`), it may not know to check for an error.

With this PR, `concatenatingChunkIterator.Next()` will instead begin returning `false` as soon as the current iterator reports an error.