### PR TITLE
Hide position info for warnings

### DIFF
--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -116,6 +116,9 @@ type annoErr struct {
 }
 
 func (e annoErr) Error() string {
+	if e.Query == "" {
+		return fmt.Sprintf("%s", e.Err)
+	}
 	return fmt.Sprintf("%s (%s)", e.Err, e.PositionRange.StartPosInput(e.Query, 0))
 }
 


### PR DESCRIPTION
This is needed in Mimir because sharded queries (hidden from user) are different from raw queries (not what is actually used), so we can't use either as reference for line positions.

Needed for https://github.com/grafana/mimir/pull/6391