### PR TITLE
Make `PostingsForMatchersCache.PostingsForMatchers` respect context cancellation

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -108,6 +108,7 @@ func (c *PostingsForMatchersCache) PostingsForMatchers(ctx context.Context, ix I
 	if c.calls[key] != nil {
 		// A promise has been injected into the cache in the meantime
 		promise = c.calls[key]
+		promise.waiting.Inc()
 		c.cachedMtx.Unlock()
 
 		return c.waitOnPromise(ctx, promise, key)


### PR DESCRIPTION
Make `PostingsForMatchersCache.PostingsForMatchers` respect context cancellation when executing queries (to populate cache), by executing them in a background goroutine taking a dedicated context, which gets canceled once no `PostingsForMatchers` caller needs it any more.

Fixes https://github.com/grafana/mimir-prometheus/issues/548.

TODO:

- [ ] Add test exercising concurrent access, where most accesses should use the cache