### PR TITLE
Add engine tests for OOO native histograms with counter resets

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3284,7 +3284,7 @@ func TestNativeHistogramRateWithCounterResets(t *testing.T) {
 
 // The ZeroCount, Count, and Sum values in the expectedHistogram come from multiplying
 // the histogram that results from the histogramRate function by a factor. The factor is
-// determined by the formula: (extrapolateToInterval / sampledInterval) / seconds in interval
+// determined by the formula: (extrapolateToInterval / sampledInterval) / seconds in interval.
 func testNativeHistogramRateWithCounterResets(t *testing.T,
 	appendFunc func(appender storage.Appender, lbls labels.Labels, ts, value int64) (storage.SeriesRef, error),
 ) {
@@ -3582,7 +3582,7 @@ func testNativeHistogramRateWithCounterResets(t *testing.T,
 	}
 }
 
-// Tests the increase() function for native histograms with both in-order and OOO sample ingestion and counter resets
+// Tests the increase() function for native histograms with both in-order and OOO sample ingestion and counter resets.
 func TestNativeHistogramIncreaseWithCounterResets(t *testing.T) {
 	scenarios := map[string]struct {
 		appendFunc func(appender storage.Appender, lbls labels.Labels, ts, value int64) (storage.SeriesRef, error)
@@ -3923,7 +3923,7 @@ func testNativeHistogramIncreaseWithCounterResets(t *testing.T,
 	}
 }
 
-// Tests the resets() function for native histograms with both in-order and OOO sample ingestion
+// Tests the resets() function for native histograms with both in-order and OOO sample ingestion.
 func TestNativeHistogramResets(t *testing.T) {
 	scenarios := map[string]struct {
 		appendFunc func(appender storage.Appender, lbls labels.Labels, ts, value int64) (storage.SeriesRef, error)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3779,10 +3779,15 @@ func testNativeHistogramIncreaseWithCounterResets(t *testing.T,
 		{
 			name: "OOO samples with counter reset at beginning of interval",
 			batches: []sampleBatch{
-				// In-order batch with no counter resets
+				// In-order batches with no counter resets
 				{
 					from:        5,
 					until:       16,
+					shouldReset: defaultResetFunc,
+				},
+				{
+					from:        50,
+					until:       100,
 					shouldReset: defaultResetFunc,
 				},
 				// OOO samples without counter resets
@@ -3794,7 +3799,7 @@ func testNativeHistogramIncreaseWithCounterResets(t *testing.T,
 				// OOO samples with counter reset at beginning of interval
 				{
 					from:  16,
-					until: 100,
+					until: 50,
 					shouldReset: func(v int64) bool {
 						return v == 16
 					},


### PR DESCRIPTION
This PR adds tests in engine_test.go to test counter resets when using the rate() function on native histograms.