### PR TITLE
Don't drop rule name and index information from rule evaluation logs when adding trace ID

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -461,7 +461,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}(time.Now())
 
 			if sp.SpanContext().IsSampled() && sp.SpanContext().HasTraceID() {
-				logger = log.WithPrefix(g.logger, "traceID", sp.SpanContext().TraceID())
+				logger = log.WithPrefix(logger, "traceID", sp.SpanContext().TraceID())
 			}
 
 			g.metrics.EvalTotal.WithLabelValues(GroupKey(g.File(), g.Name())).Inc()


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/grafana/mimir-prometheus/pull/541 that was spotted as part of the upstream review: https://github.com/prometheus/prometheus/pull/13034#pullrequestreview-1703822504