### PR TITLE
Correct precision errors introduced by query sharding for bucketQuantile

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1164,7 +1164,7 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	for _, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
-			res, forcedMonotonicity := bucketQuantile(q, mb.buckets)
+			res, forcedMonotonicity, _ := bucketQuantile(q, mb.buckets)
 			enh.Out = append(enh.Out, Sample{
 				Metric: mb.metric,
 				F:      res,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1164,13 +1164,16 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	for _, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
-			res, forcedMonotonicity, _ := bucketQuantile(q, mb.buckets)
+			res, forcedMonotonicity, fixedPrecision := bucketQuantile(q, mb.buckets)
 			enh.Out = append(enh.Out, Sample{
 				Metric: mb.metric,
 				F:      res,
 			})
 			if forcedMonotonicity {
 				annos.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(mb.metric.Get(labels.MetricName), args[1].PositionRange()))
+			}
+			if fixedPrecision {
+				annos.Add(annotations.NewHistogramQuantileFixedPrecisionInfo(args[1].PositionRange()))
 			}
 		}
 	}

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -73,15 +73,15 @@ type metricWithBuckets struct {
 // If q>1, +Inf is returned.
 //
 // We also return a bool to indicate if monotonicity needed to be forced.
-func bucketQuantile(q float64, buckets buckets) (float64, bool) {
+func bucketQuantile(q float64, buckets buckets) (float64, bool, bool) {
 	if math.IsNaN(q) {
-		return math.NaN(), false
+		return math.NaN(), false, false
 	}
 	if q < 0 {
-		return math.Inf(-1), false
+		return math.Inf(-1), false, false
 	}
 	if q > 1 {
-		return math.Inf(+1), false
+		return math.Inf(+1), false, false
 	}
 	slices.SortFunc(buckets, func(a, b bucket) int {
 		// We don't expect the bucket boundary to be a NaN.
@@ -94,27 +94,28 @@ func bucketQuantile(q float64, buckets buckets) (float64, bool) {
 		return 0
 	})
 	if !math.IsInf(buckets[len(buckets)-1].upperBound, +1) {
-		return math.NaN(), false
+		return math.NaN(), false, false
 	}
 
 	buckets = coalesceBuckets(buckets)
+	fixedPrecision := correctPrecisionErrors(buckets, 1e-12)
 	forcedMonotonic := ensureMonotonic(buckets)
 
 	if len(buckets) < 2 {
-		return math.NaN(), false
+		return math.NaN(), false, false
 	}
 	observations := buckets[len(buckets)-1].count
 	if observations == 0 {
-		return math.NaN(), false
+		return math.NaN(), false, false
 	}
 	rank := q * observations
 	b := sort.Search(len(buckets)-1, func(i int) bool { return buckets[i].count >= rank })
 
 	if b == len(buckets)-1 {
-		return buckets[len(buckets)-2].upperBound, forcedMonotonic
+		return buckets[len(buckets)-2].upperBound, forcedMonotonic, fixedPrecision
 	}
 	if b == 0 && buckets[0].upperBound <= 0 {
-		return buckets[0].upperBound, forcedMonotonic
+		return buckets[0].upperBound, forcedMonotonic, fixedPrecision
 	}
 	var (
 		bucketStart float64
@@ -126,7 +127,7 @@ func bucketQuantile(q float64, buckets buckets) (float64, bool) {
 		count -= buckets[b-1].count
 		rank -= buckets[b-1].count
 	}
-	return bucketStart + (bucketEnd-bucketStart)*(rank/count), forcedMonotonic
+	return bucketStart + (bucketEnd-bucketStart)*(rank/count), forcedMonotonic, fixedPrecision
 }
 
 // histogramQuantile calculates the quantile 'q' based on the given histogram.
@@ -373,6 +374,28 @@ func ensureMonotonic(buckets buckets) bool {
 		}
 	}
 	return forced
+}
+
+// Query sharding in Mimir results in precision errors in the bucket counts
+// which can make them non-monotonic. This function corrects those errors.
+func correctPrecisionErrors(buckets buckets, tolerance float64) bool {
+	fixed := false
+	prev := buckets[0].count
+	for i := 1; i < len(buckets); i++ {
+		curr := buckets[i].count // Assumed always positive.
+		delta := math.Abs(curr - prev)
+		if delta == 0 {
+			continue
+		}
+		eps := delta / curr
+		if eps <= tolerance {
+			buckets[i].count = prev
+			fixed = true
+		} else {
+			prev = curr
+		}
+	}
+	return fixed
 }
 
 // quantile calculates the given quantile of a vector of samples.

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -1,0 +1,348 @@
+package promql
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
+	eps := 1e-12
+
+	t.Run("simple - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 10,
+					count:      10,
+				}, {
+					upperBound: 15,
+					count:      15,
+				}, {
+					upperBound: 20,
+					count:      15,
+				}, {
+					upperBound: 30,
+					count:      15,
+				}, {
+					upperBound: math.Inf(1),
+					count:      15,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 15., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 14.85, res)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 13.5, res)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 7.5, res)
+	})
+
+	t.Run("simple - non-monotonic middle", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 10,
+					count:      10,
+				}, {
+					upperBound: 15,
+					count:      15,
+				}, {
+					upperBound: 20,
+					count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 30,
+					count:      15,
+				}, {
+					upperBound: math.Inf(1),
+					count:      15,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 15., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 14.85, res)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 13.5, res)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 7.5, res)
+	})
+
+	t.Run("real example - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 1,
+					count:      6454661.3014166197,
+				}, {
+					upperBound: 5,
+					count:      8339611.2001912938,
+				}, {
+					upperBound: 10,
+					count:      14118319.2444762159,
+				}, {
+					upperBound: 25,
+					count:      14130031.5272856522,
+				}, {
+					upperBound: 50,
+					count:      46001270.3030008152,
+				}, {
+					upperBound: 64,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 80,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 100,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 250,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 1000,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: math.Inf(1),
+					count:      46008473.8585563600,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 64., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 49.64475715376406, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 46.39671690938454, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 31.96098248992002, res, eps)
+	})
+
+	t.Run("real example - non-monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 1,
+					count:      6454661.3014166225,
+				}, {
+					upperBound: 5,
+					count:      8339611.2001912957,
+				}, {
+					upperBound: 10,
+					count:      14118319.2444762159,
+				}, {
+					upperBound: 25,
+					count:      14130031.5272856504,
+				}, {
+					upperBound: 50,
+					count:      46001270.3030008227,
+				}, {
+					upperBound: 64,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 80,
+					count:      46008473.8585563898,
+				}, {
+					upperBound: 100,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 250,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 1000,
+					count:      46008473.8585563898,
+				}, {
+					upperBound: math.Inf(1),
+					count:      46008473.8585563824,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 64., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 49.64475715376406, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 46.39671690938454, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 31.96098248992002, res, eps)
+	})
+
+	t.Run("real example 2 - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 0.005,
+					count:      9.6,
+				}, {
+					upperBound: 0.01,
+					count:      9.688888889,
+				}, {
+					upperBound: 0.025,
+					count:      9.755555556,
+				}, {
+					upperBound: 0.05,
+					count:      9.844444444,
+				}, {
+					upperBound: 0.1,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.25,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 1,
+					count:      9.888888889,
+				}, {
+					upperBound: 2.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 5,
+					count:      9.888888889,
+				}, {
+					upperBound: 10,
+					count:      9.888888889,
+				}, {
+					upperBound: 25,
+					count:      9.888888889,
+				}, {
+					upperBound: 50,
+					count:      9.888888889,
+				}, {
+					upperBound: 100,
+					count:      9.888888889,
+				}, {
+					upperBound: math.Inf(1),
+					count:      9.888888889,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 0.1, res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.03468750000281261, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.00463541666671875, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
+	})
+
+	t.Run("real example 2 - non-monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 0.005,
+					count:      9.6,
+				}, {
+					upperBound: 0.01,
+					count:      9.688888889,
+				}, {
+					upperBound: 0.025,
+					count:      9.755555556,
+				}, {
+					upperBound: 0.05,
+					count:      9.844444444,
+				}, {
+					upperBound: 0.1,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.25,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 1,
+					count:      9.888888889,
+				}, {
+					upperBound: 2.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 5,
+					count:      9.888888889,
+				}, {
+					upperBound: 10,
+					count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 25,
+					count:      9.888888889,
+				}, {
+					upperBound: 50,
+					count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 100,
+					count:      9.888888889,
+				}, {
+					upperBound: math.Inf(1),
+					count:      9.888888889,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 0.1, res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.03468750000281261, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.00463541666671875, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
+	})
+}

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -10,339 +10,288 @@ import (
 func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	eps := 1e-12
 
-	t.Run("simple - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 10,
-					count:      10,
-				}, {
-					upperBound: 15,
-					count:      15,
-				}, {
-					upperBound: 20,
-					count:      15,
-				}, {
-					upperBound: 30,
-					count:      15,
-				}, {
-					upperBound: math.Inf(1),
-					count:      15,
-				},
+	for name, tc := range map[string]struct {
+		getInput       func() buckets // The buckets can be modified in-place so return a new one each time.
+		expectedForced bool
+		expectedValues map[float64]float64
+	}{
+		"simple - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 10,
+						count:      10,
+					}, {
+						upperBound: 15,
+						count:      15,
+					}, {
+						upperBound: 20,
+						count:      15,
+					}, {
+						upperBound: 30,
+						count:      15,
+					}, {
+						upperBound: math.Inf(1),
+						count:      15,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    15.,
+				0.99: 14.85,
+				0.9:  13.5,
+				0.5:  7.5,
+			},
+		},
+		"simple - non-monotonic middle": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 10,
+						count:      10,
+					}, {
+						upperBound: 15,
+						count:      15,
+					}, {
+						upperBound: 20,
+						count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 30,
+						count:      15,
+					}, {
+						upperBound: math.Inf(1),
+						count:      15,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    15.,
+				0.99: 14.85,
+				0.9:  13.5,
+				0.5:  7.5,
+			},
+		},
+		"real example - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 1,
+						count:      6454661.3014166197,
+					}, {
+						upperBound: 5,
+						count:      8339611.2001912938,
+					}, {
+						upperBound: 10,
+						count:      14118319.2444762159,
+					}, {
+						upperBound: 25,
+						count:      14130031.5272856522,
+					}, {
+						upperBound: 50,
+						count:      46001270.3030008152,
+					}, {
+						upperBound: 64,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 80,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 100,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 250,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 1000,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: math.Inf(1),
+						count:      46008473.8585563600,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    64.,
+				0.99: 49.64475715376406,
+				0.9:  46.39671690938454,
+				0.5:  31.96098248992002,
+			},
+		},
+		"real example - non-monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 1,
+						count:      6454661.3014166225,
+					}, {
+						upperBound: 5,
+						count:      8339611.2001912957,
+					}, {
+						upperBound: 10,
+						count:      14118319.2444762159,
+					}, {
+						upperBound: 25,
+						count:      14130031.5272856504,
+					}, {
+						upperBound: 50,
+						count:      46001270.3030008227,
+					}, {
+						upperBound: 64,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 80,
+						count:      46008473.8585563898,
+					}, {
+						upperBound: 100,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 250,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 1000,
+						count:      46008473.8585563898,
+					}, {
+						upperBound: math.Inf(1),
+						count:      46008473.8585563824,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    64.,
+				0.99: 49.64475715376406,
+				0.9:  46.39671690938454,
+				0.5:  31.96098248992002,
+			},
+		},
+		"real example 2 - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 0.005,
+						count:      9.6,
+					}, {
+						upperBound: 0.01,
+						count:      9.688888889,
+					}, {
+						upperBound: 0.025,
+						count:      9.755555556,
+					}, {
+						upperBound: 0.05,
+						count:      9.844444444,
+					}, {
+						upperBound: 0.1,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.25,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 1,
+						count:      9.888888889,
+					}, {
+						upperBound: 2.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 5,
+						count:      9.888888889,
+					}, {
+						upperBound: 10,
+						count:      9.888888889,
+					}, {
+						upperBound: 25,
+						count:      9.888888889,
+					}, {
+						upperBound: 50,
+						count:      9.888888889,
+					}, {
+						upperBound: 100,
+						count:      9.888888889,
+					}, {
+						upperBound: math.Inf(1),
+						count:      9.888888889,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    0.1,
+				0.99: 0.03468750000281261,
+				0.9:  0.00463541666671875,
+				0.5:  0.0025752314815104174,
+			},
+		},
+		"real example 2 - non-monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 0.005,
+						count:      9.6,
+					}, {
+						upperBound: 0.01,
+						count:      9.688888889,
+					}, {
+						upperBound: 0.025,
+						count:      9.755555556,
+					}, {
+						upperBound: 0.05,
+						count:      9.844444444,
+					}, {
+						upperBound: 0.1,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.25,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 1,
+						count:      9.888888889,
+					}, {
+						upperBound: 2.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 5,
+						count:      9.888888889,
+					}, {
+						upperBound: 10,
+						count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 25,
+						count:      9.888888889,
+					}, {
+						upperBound: 50,
+						count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 100,
+						count:      9.888888889,
+					}, {
+						upperBound: math.Inf(1),
+						count:      9.888888889,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    0.1,
+				0.99: 0.03468750000281261,
+				0.9:  0.00463541666671875,
+				0.5:  0.0025752314815104174,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for q, v := range tc.expectedValues {
+				res, forced := bucketQuantile(q, tc.getInput())
+				assert.Equal(t, tc.expectedForced, forced)
+				assert.InEpsilon(t, v, res, eps)
 			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 15., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 14.85, res)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 13.5, res)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 7.5, res)
-	})
-
-	t.Run("simple - non-monotonic middle", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 10,
-					count:      10,
-				}, {
-					upperBound: 15,
-					count:      15,
-				}, {
-					upperBound: 20,
-					count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 30,
-					count:      15,
-				}, {
-					upperBound: math.Inf(1),
-					count:      15,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 15., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 14.85, res)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 13.5, res)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 7.5, res)
-	})
-
-	t.Run("real example - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 1,
-					count:      6454661.3014166197,
-				}, {
-					upperBound: 5,
-					count:      8339611.2001912938,
-				}, {
-					upperBound: 10,
-					count:      14118319.2444762159,
-				}, {
-					upperBound: 25,
-					count:      14130031.5272856522,
-				}, {
-					upperBound: 50,
-					count:      46001270.3030008152,
-				}, {
-					upperBound: 64,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 80,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 100,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 250,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 1000,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: math.Inf(1),
-					count:      46008473.8585563600,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 64., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 49.64475715376406, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 46.39671690938454, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 31.96098248992002, res, eps)
-	})
-
-	t.Run("real example - non-monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 1,
-					count:      6454661.3014166225,
-				}, {
-					upperBound: 5,
-					count:      8339611.2001912957,
-				}, {
-					upperBound: 10,
-					count:      14118319.2444762159,
-				}, {
-					upperBound: 25,
-					count:      14130031.5272856504,
-				}, {
-					upperBound: 50,
-					count:      46001270.3030008227,
-				}, {
-					upperBound: 64,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 80,
-					count:      46008473.8585563898,
-				}, {
-					upperBound: 100,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 250,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 1000,
-					count:      46008473.8585563898,
-				}, {
-					upperBound: math.Inf(1),
-					count:      46008473.8585563824,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 64., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 49.64475715376406, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 46.39671690938454, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 31.96098248992002, res, eps)
-	})
-
-	t.Run("real example 2 - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 0.005,
-					count:      9.6,
-				}, {
-					upperBound: 0.01,
-					count:      9.688888889,
-				}, {
-					upperBound: 0.025,
-					count:      9.755555556,
-				}, {
-					upperBound: 0.05,
-					count:      9.844444444,
-				}, {
-					upperBound: 0.1,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.25,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 1,
-					count:      9.888888889,
-				}, {
-					upperBound: 2.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 5,
-					count:      9.888888889,
-				}, {
-					upperBound: 10,
-					count:      9.888888889,
-				}, {
-					upperBound: 25,
-					count:      9.888888889,
-				}, {
-					upperBound: 50,
-					count:      9.888888889,
-				}, {
-					upperBound: 100,
-					count:      9.888888889,
-				}, {
-					upperBound: math.Inf(1),
-					count:      9.888888889,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 0.1, res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.03468750000281261, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.00463541666671875, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
-	})
-
-	t.Run("real example 2 - non-monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 0.005,
-					count:      9.6,
-				}, {
-					upperBound: 0.01,
-					count:      9.688888889,
-				}, {
-					upperBound: 0.025,
-					count:      9.755555556,
-				}, {
-					upperBound: 0.05,
-					count:      9.844444444,
-				}, {
-					upperBound: 0.1,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.25,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 1,
-					count:      9.888888889,
-				}, {
-					upperBound: 2.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 5,
-					count:      9.888888889,
-				}, {
-					upperBound: 10,
-					count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 25,
-					count:      9.888888889,
-				}, {
-					upperBound: 50,
-					count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 100,
-					count:      9.888888889,
-				}, {
-					upperBound: math.Inf(1),
-					count:      9.888888889,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 0.1, res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.03468750000281261, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.00463541666671875, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
-	})
+		})
+	}
 }

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -13,6 +13,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	for name, tc := range map[string]struct {
 		getInput       func() buckets // The buckets can be modified in-place so return a new one each time.
 		expectedForced bool
+		expectedFixed  bool
 		expectedValues map[float64]float64
 	}{
 		"simple - monotonic": {
@@ -37,6 +38,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    15.,
 				0.99: 14.85,
@@ -65,7 +67,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    15.,
 				0.99: 14.85,
@@ -113,6 +116,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    64.,
 				0.99: 49.64475715376406,
@@ -159,7 +163,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    64.,
 				0.99: 49.64475715376406,
@@ -219,6 +224,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    0.1,
 				0.99: 0.03468750000281261,
@@ -277,7 +283,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    0.1,
 				0.99: 0.03468750000281261,
@@ -288,8 +295,9 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			for q, v := range tc.expectedValues {
-				res, forced := bucketQuantile(q, tc.getInput())
+				res, forced, fixed := bucketQuantile(q, tc.getInput())
 				assert.Equal(t, tc.expectedForced, forced)
+				assert.Equal(t, tc.expectedFixed, fixed)
 				assert.InEpsilon(t, v, res, eps)
 			}
 		})

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -107,6 +107,7 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (and may give inaccurate results) for metric name", PromQLInfo)
+	HistogramQuantileFixedPrecisionInfo     = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for floating point imprecision (and may give inaccurate results)", PromQLInfo)
 )
 
 type annoErr struct {
@@ -174,5 +175,15 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", HistogramQuantileForcedMonotonicityInfo, metricName),
+	}
+}
+
+// NewHistogramQuantileFixedPrecisionInfo is used when the input (classic histograms) to
+// histogram_quantile was fixed to ignore small differences in bucket counts which are assumed
+// to be due to floating point imprecision accumulated from query sharding in Mimir.
+func NewHistogramQuantileFixedPrecisionInfo(pos posrange.PositionRange) annoErr {
+	return annoErr{
+		PositionRange: pos,
+		Err:           HistogramQuantileFixedPrecisionInfo,
 	}
 }


### PR DESCRIPTION
After seeing the number of `NewHistogramQuantileForcedMonotonicityInfo` warnings in dev env, it seems to happen quite often, so the workaround https://github.com/grafana/mimir/pull/6501 might not be the best solution. This approach should theoretically fix the wrong results, and also get rid of the warnings which may confuse end-users. For now we show a new kind of warning so we can verify if it's happening or not in Mimir unit tests, but we can consider removing the warning later.

The fix: ignoring numerically insignificant (relative delta below a certain tolerance) changes in counts between classic histogram buckets before running `bucketQuantile`.

The currently set tolerance is 1e-12. Testing on real data with this bug locally, on the first set of data the safe range was from 1e-05 to 1e-15, the second set was from 1e-06 to 1e-15. Anything to the left of that would cause non-query-sharded data to be corrected for precision errors (unnecessary and we should avoid this), and anything to the right of that would cause query-sharded data to not be corrected (so the problem won't be fixed).

Putting it here instead of upstream because Prometheus doesn't really have this problem without Mimir's query sharding.

You can try the new unit tests before and after the fix to verify that it fails before and passes afterwards.