### PR TITLE
cherry-pick "storage: Fix mixed samples handling in sampleRing"

### DIFF
--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -90,6 +90,54 @@ func TestSampleRing(t *testing.T) {
 	}
 }
 
+func TestSampleRingMixed(t *testing.T) {
+	h1 := tsdbutil.GenerateTestHistogram(1)
+	h2 := tsdbutil.GenerateTestHistogram(2)
+
+	// With ValNone as the preferred type, nothing should be initialized.
+	r := newSampleRing(10, 2, chunkenc.ValNone)
+	require.Zero(t, len(r.fBuf))
+	require.Zero(t, len(r.hBuf))
+	require.Zero(t, len(r.fhBuf))
+	require.Zero(t, len(r.iBuf))
+
+	// But then mixed adds should work as expected.
+	r.addF(fSample{t: 1, f: 3.14})
+	r.addH(hSample{t: 2, h: h1})
+
+	it := r.iterator()
+
+	require.Equal(t, chunkenc.ValFloat, it.Next())
+	ts, f := it.At()
+	require.Equal(t, int64(1), ts)
+	require.Equal(t, 3.14, f)
+	require.Equal(t, chunkenc.ValHistogram, it.Next())
+	var h *histogram.Histogram
+	ts, h = it.AtHistogram()
+	require.Equal(t, int64(2), ts)
+	require.Equal(t, h1, h)
+	require.Equal(t, chunkenc.ValNone, it.Next())
+
+	r.reset()
+	it = r.iterator()
+	require.Equal(t, chunkenc.ValNone, it.Next())
+
+	r.addF(fSample{t: 3, f: 4.2})
+	r.addH(hSample{t: 4, h: h2})
+
+	it = r.iterator()
+
+	require.Equal(t, chunkenc.ValFloat, it.Next())
+	ts, f = it.At()
+	require.Equal(t, int64(3), ts)
+	require.Equal(t, 4.2, f)
+	require.Equal(t, chunkenc.ValHistogram, it.Next())
+	ts, h = it.AtHistogram()
+	require.Equal(t, int64(4), ts)
+	require.Equal(t, h2, h)
+	require.Equal(t, chunkenc.ValNone, it.Next())
+}
+
 func TestBufferedSeriesIterator(t *testing.T) {
 	var it *BufferedSeriesIterator
 


### PR DESCRIPTION
cherry picked from commit https://github.com/prometheus/prometheus/pull/13055/commits/4696b46dd5ef89e4e23554dfec9e838c6bbaf23e which was only merged to a release branch and not to `upstream/main` yet

> Two issues are fixed here, that lead to the same problem:
> 
> 1. If `newSampleRing` is called with an unknown ValueType including ValueNone, we have initialized the interface buffer (`iBuf`). However, we would still use a specialized buffer for the first sample, opportunistically assuming that we might still not encounter mixed samples and we should go down the more efficient road.
> 
> 2. If the `sampleRing` is `reset`, we leave all buffers alone, including `iBuf`, which is generally fine, but not for `iBuf`, see below.
> 
> In both cases, `iBuf` already contains values, but we will fill one of the specialized buffers first. Once we then actually encounter mixed samples, the content of the specialized buffer is copied into `iBuf` using `append`. That's by itself the right idea because `iBuf` might be `nil`, and even if not, it might or might not have the right capacity. However, this approach assumes that `iBuf` is empty, or more precisely has a length of zero.
> 
> This commit makes sure that `iBuf` does not get needlessly initialized in `newSampleRing` and that it is emptied upon `reset`.
> 
> A test case is added to demonstrate both issues above.
> 
> Signed-off-by: beorn7 <beorn@grafana.com>
> 

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
