### PR TITLE
Improve requireEqualSamples

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4407,7 +4407,7 @@ func testOOOCompaction(t *testing.T, scenario sampleTypeScenario) {
 		q, err := db.Querier(math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	verifyDBSamples() // Before any compaction.
@@ -4633,7 +4633,7 @@ func testOOOCompactionWithNormalCompaction(t *testing.T, scenario sampleTypeScen
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	// Checking for expected data in the blocks.
@@ -4744,7 +4744,7 @@ func testOOOCompactionWithDisabledWriteLog(t *testing.T, scenario sampleTypeScen
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	// Checking for expected data in the blocks.
@@ -4847,7 +4847,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	// Checking for expected ooo data from mmap chunks.
@@ -5383,7 +5383,7 @@ func testOOOAppendAndQuery(t *testing.T, scenario sampleTypeScenario) {
 				expSamples[k] = append(expSamples[k], s)
 			}
 		}
-		requireEqualSamples(t, expSamples, seriesSet)
+		requireEqualSamples(t, expSamples, seriesSet, true)
 		require.Equal(t, float64(totalSamples-2), prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamplesAppended), "number of ooo appended samples mismatch")
 	}
 
@@ -5501,7 +5501,7 @@ func testOOODisabled(t *testing.T, scenario sampleTypeScenario) {
 	require.NoError(t, err)
 
 	seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar."))
-	requireEqualSamples(t, expSamples, seriesSet)
+	requireEqualSamples(t, expSamples, seriesSet, true)
 	require.Equal(t, float64(0), prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamplesAppended), "number of ooo appended samples mismatch")
 	require.Equal(t, float64(failedSamples),
 		prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamples.WithLabelValues(scenario.sampleType))+prom_testutil.ToFloat64(db.head.metrics.outOfBoundSamples.WithLabelValues(scenario.sampleType)),
@@ -5569,7 +5569,7 @@ func testWBLAndMmapReplay(t *testing.T, scenario sampleTypeScenario) {
 			})
 			exp[k] = v
 		}
-		requireEqualSamples(t, exp, seriesSet)
+		requireEqualSamples(t, exp, seriesSet, true)
 	}
 
 	// In-order samples.
@@ -5850,7 +5850,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	// Checking for expected data in the blocks.
@@ -6087,7 +6087,7 @@ func testOOOMmapCorruption(t *testing.T, scenario sampleTypeScenario) {
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	verifySamples(allSamples)
@@ -6216,7 +6216,7 @@ func testOutOfOrderRuntimeConfig(t *testing.T, scenario sampleTypeScenario) {
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	doOOOCompaction := func(t *testing.T, db *DB) {
@@ -6427,7 +6427,7 @@ func testNoGapAfterRestartWithOOO(t *testing.T, scenario sampleTypeScenario) {
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	cases := []struct {
@@ -6557,7 +6557,7 @@ func testWblReplayAfterOOODisableAndRestart(t *testing.T, scenario sampleTypeSce
 		require.NoError(t, err)
 
 		actRes := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar.*"))
-		requireEqualSamples(t, expRes, actRes)
+		requireEqualSamples(t, expRes, actRes, true)
 	}
 
 	verifySamples(allSamples)

--- a/tsdb/testutil.go
+++ b/tsdb/testutil.go
@@ -61,8 +61,7 @@ var sampleTypeScenarios = map[string]sampleTypeScenario{
 }
 
 // requireEqualSamples checks that the actual series are equal to the expected ones. It ignores the counter reset hints for histograms.
-// TODO(fionaliao): understand counter reset behaviour, might want to unignore hints later
-func requireEqualSamples(t *testing.T, expected, actual map[string][]chunks.Sample) {
+func requireEqualSamples(t *testing.T, expected, actual map[string][]chunks.Sample, ignoreCounterResets bool) {
 	for name, expectedItem := range expected {
 		actualItem, ok := actual[name]
 		require.True(t, ok, "Expected series %s not found", name)
@@ -70,22 +69,26 @@ func requireEqualSamples(t *testing.T, expected, actual map[string][]chunks.Samp
 		for i, s := range expectedItem {
 			expectedSample := s
 			actualSample := actualItem[i]
-			require.Equal(t, expectedSample.Type().String(), actualSample.Type().String(), "Different types for %s[%d]", name, i)
-			switch {
-			case s.H() != nil:
+			require.Equal(t, expectedSample.T(), expectedSample.T(), "Different timestamps for %s[%d]", name, i)
+			require.Equal(t, expectedSample.Type().String(), actualSample.Type().String(), "Different types for %s[%d] at ts %d", name, i, expectedSample.T())
+			if s.H() != nil {
 				expectedHist := expectedSample.H()
 				actualHist := actualSample.H()
-				expectedHist.CounterResetHint = histogram.UnknownCounterReset
-				actualHist.CounterResetHint = histogram.UnknownCounterReset
-				require.Equal(t, expectedHist, actualHist, "Unexpected sample for %s[%d]", name, i)
-			case s.FH() != nil:
+				if ignoreCounterResets {
+					expectedHist.CounterResetHint = histogram.UnknownCounterReset
+					actualHist.CounterResetHint = histogram.UnknownCounterReset
+				}
+				require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
+			} else if s.FH() != nil {
 				expectedHist := expectedSample.FH()
 				actualHist := actualSample.FH()
-				expectedHist.CounterResetHint = histogram.UnknownCounterReset
-				actualHist.CounterResetHint = histogram.UnknownCounterReset
-				require.Equal(t, expectedHist, actualHist, "Unexpected sample for %s[%d]", name, i)
-			default:
-				require.Equal(t, expectedSample, expectedSample, "Unexpected sample for %s[%d]", name, i)
+				if ignoreCounterResets {
+					expectedHist.CounterResetHint = histogram.UnknownCounterReset
+					actualHist.CounterResetHint = histogram.UnknownCounterReset
+				}
+				require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
+			} else {
+				require.Equal(t, expectedSample, expectedSample, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
 			}
 		}
 	}

--- a/tsdb/testutil.go
+++ b/tsdb/testutil.go
@@ -71,23 +71,28 @@ func requireEqualSamples(t *testing.T, expected, actual map[string][]chunks.Samp
 			actualSample := actualItem[i]
 			require.Equal(t, expectedSample.T(), expectedSample.T(), "Different timestamps for %s[%d]", name, i)
 			require.Equal(t, expectedSample.Type().String(), actualSample.Type().String(), "Different types for %s[%d] at ts %d", name, i, expectedSample.T())
-			if s.H() != nil {
-				expectedHist := expectedSample.H()
-				actualHist := actualSample.H()
-				if ignoreCounterResets {
-					expectedHist.CounterResetHint = histogram.UnknownCounterReset
-					actualHist.CounterResetHint = histogram.UnknownCounterReset
+			switch {
+			case s.H() != nil:
+				{
+					expectedHist := expectedSample.H()
+					actualHist := actualSample.H()
+					if ignoreCounterResets {
+						expectedHist.CounterResetHint = histogram.UnknownCounterReset
+						actualHist.CounterResetHint = histogram.UnknownCounterReset
+					}
+					require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
 				}
-				require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
-			} else if s.FH() != nil {
-				expectedHist := expectedSample.FH()
-				actualHist := actualSample.FH()
-				if ignoreCounterResets {
-					expectedHist.CounterResetHint = histogram.UnknownCounterReset
-					actualHist.CounterResetHint = histogram.UnknownCounterReset
+			case s.FH() != nil:
+				{
+					expectedHist := expectedSample.FH()
+					actualHist := actualSample.FH()
+					if ignoreCounterResets {
+						expectedHist.CounterResetHint = histogram.UnknownCounterReset
+						actualHist.CounterResetHint = histogram.UnknownCounterReset
+					}
+					require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
 				}
-				require.Equal(t, expectedHist, actualHist, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
-			} else {
+			default:
 				require.Equal(t, expectedSample, expectedSample, "Sample doesn't match for %s[%d] at ts %d", name, i, expectedSample.T())
 			}
 		}


### PR DESCRIPTION
- Allow counter reset header to be compared
- Add timestamp value check
- Add timestamp to error message

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
