### PR TITLE
Fix issue where a "cannot populate chunk XXX from block XXX: not found" error is returned when head compaction occurs between retrieving the list of chunks for a query and reading the chunk itself

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -747,6 +747,13 @@ func (p *populateWithDelGenericSeriesIterator) next(copyHeadChunk bool) bool {
 		p.currChkMeta.Chunk, p.err = p.chunks.Chunk(p.currChkMeta)
 	}
 	if p.err != nil {
+		if errors.Cause(p.err) == storage.ErrNotFound {
+			// Chunk reference is stale (eg. due to head compaction that occurred after retrieving chunk reference).
+			// Clear error and continue to next chunk.
+			p.err = nil
+			return p.next(copyHeadChunk)
+		}
+
 		p.err = errors.Wrapf(p.err, "cannot populate chunk %d from block %s", p.currChkMeta.Ref, p.blockID.String())
 		return false
 	}


### PR DESCRIPTION
If head compaction occurs after obtaining the chunk reference, but before reading the chunk, it's expected that `ChunkReader.Chunk()` will return `storage.NotFound`. In this case, the samples in the affected chunk will be included in other chunks, so we should ignore the error.

This PR is based on a similar change in https://github.com/grafana/mimir-prometheus/pull/528