### PR TITLE
Ensure manipulating the returned FastRegexMatcher.SetMatches() doesn't pollute the matcher's internal state

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -341,11 +342,7 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 func (m *FastRegexMatcher) SetMatches() []string {
 	// IMPORTANT: always return a copy, otherwise if the caller manipulate this slice it will
 	// also get manipulated in the cached FastRegexMatcher instance.
-	ret := make([]string, 0, len(m.setMatches))
-	for _, value := range m.setMatches {
-		ret = append(ret, value)
-	}
-	return ret
+	return slices.Clone(m.setMatches)
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -339,7 +339,13 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 }
 
 func (m *FastRegexMatcher) SetMatches() []string {
-	return m.setMatches
+	// IMPORTANT: always return a copy, otherwise if the caller manipulate this slice it will
+	// also get manipulated in the cached FastRegexMatcher instance.
+	ret := make([]string, 0, len(m.setMatches))
+	for _, value := range m.setMatches {
+		ret = append(ret, value)
+	}
+	return ret
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -344,6 +344,20 @@ func TestFindSetMatches(t *testing.T) {
 	}
 }
 
+func TestFastRegexMatcher_SetMatches_ShouldReturnACopy(t *testing.T) {
+	m, err := newFastRegexMatcherWithoutCache("a|b")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, m.SetMatches())
+
+	// Manipulate the returned slice.
+	matches := m.SetMatches()
+	matches[0] = "xxx"
+	matches[1] = "yyy"
+
+	// Ensure that if we call SetMatches() again we get the original one.
+	require.Equal(t, []string{"a", "b"}, m.SetMatches())
+}
+
 func BenchmarkFastRegexMatcher(b *testing.B) {
 	texts := generateRandomValues()
 


### PR DESCRIPTION
We're investigating some invalid query results which apparently happen when we have alternation regexp matchers (and so `FastRegexMatcher.SetMatches()` returns something). I have a weak theory that there may be a case when we manipulate the returned slice, thus polluting the cached `FastRegexMatcher`.

To avoid such headache, in this PR I do a simple change to always return a copy from `FastRegexMatcher.SetMatches()`.