### PR TITLE
[mimir-release-2.10] Return a copy of strings from `FastRegexMatcher.SetMatches() `doesn'…`

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -341,11 +342,7 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 func (m *FastRegexMatcher) SetMatches() []string {
 	// IMPORTANT: always return a copy, otherwise if the caller manipulate this slice it will
 	// also get manipulated in the cached FastRegexMatcher instance.
-	ret := make([]string, 0, len(m.setMatches))
-	for _, value := range m.setMatches {
-		ret = append(ret, value)
-	}
-	return ret
+	return slices.Clone(m.setMatches)
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -339,7 +339,13 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 }
 
 func (m *FastRegexMatcher) SetMatches() []string {
-	return m.setMatches
+	// IMPORTANT: always return a copy, otherwise if the caller manipulate this slice it will
+	// also get manipulated in the cached FastRegexMatcher instance.
+	ret := make([]string, 0, len(m.setMatches))
+	for _, value := range m.setMatches {
+		ret = append(ret, value)
+	}
+	return ret
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -327,6 +327,20 @@ func TestFindSetMatches(t *testing.T) {
 	}
 }
 
+func TestFastRegexMatcher_SetMatches_ShouldReturnACopy(t *testing.T) {
+	m, err := newFastRegexMatcherWithoutCache("a|b")
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, m.SetMatches())
+
+	// Manipulate the returned slice.
+	matches := m.SetMatches()
+	matches[0] = "xxx"
+	matches[1] = "yyy"
+
+	// Ensure that if we call SetMatches() again we get the original one.
+	require.Equal(t, []string{"a", "b"}, m.SetMatches())
+}
+
 func BenchmarkFastRegexMatcher(b *testing.B) {
 	// Init the random seed with a constant, so that it doesn't change between runs.
 	randGenerator := rand.New(rand.NewSource(1))


### PR DESCRIPTION
Backporting #571 for Mimir's 2.10 release branch.