### PR TITLE
Fix FastRegexMatcher to skip nested capture groups

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -284,7 +284,8 @@ func findSetMatchesFromAlternate(re *syntax.Regexp, base string) (matches []stri
 // clearCapture removes capture operation as they are not used for matching.
 func clearCapture(regs ...*syntax.Regexp) {
 	for _, r := range regs {
-		if r.Op == syntax.OpCapture {
+		// Iterate on the regexp because capture groups could be nested.
+		for r.Op == syntax.OpCapture {
 			*r = *r.Sub[0]
 		}
 	}

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -286,6 +286,8 @@ func TestFindSetMatches(t *testing.T) {
 		// Simple sets alternate and concat and alternates with empty matches
 		// parsed as  b(ar|(?:)|uzz) where b(?:) means literal b.
 		{"bar|b|buzz", []string{"bar", "b", "buzz"}, true},
+		// Skip nested capture groups.
+		{"^((bar|b|buzz))$", []string{"bar", "b", "buzz"}, true},
 		// Skip outer anchors (it's enforced anyway at the root).
 		{"^(bar|b|buzz)$", []string{"bar", "b", "buzz"}, true},
 		{"^(?:prod|production)$", []string{"prod", "production"}, true},
@@ -395,6 +397,8 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{"^foo$", &equalStringMatcher{s: "foo", caseSensitive: true}},
 		{"^(?i:foo)$", &equalStringMatcher{s: "FOO", caseSensitive: false}},
 		{"^((?i:foo)|(bar))$", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "bar", caseSensitive: true}})},
+		{`(?i:((foo|bar)))`, orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "BAR", caseSensitive: false}})},
+		{`(?i:((foo1|foo2|bar)))`, orStringMatcher([]StringMatcher{orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO1", caseSensitive: false}, &equalStringMatcher{s: "FOO2", caseSensitive: false}}), &equalStringMatcher{s: "BAR", caseSensitive: false}})},
 		{"^((?i:foo|oo)|(bar))$", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "OO", caseSensitive: false}, &equalStringMatcher{s: "bar", caseSensitive: true}})},
 		{"(?i:(foo1|foo2|bar))", orStringMatcher([]StringMatcher{orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO1", caseSensitive: false}, &equalStringMatcher{s: "FOO2", caseSensitive: false}}), &equalStringMatcher{s: "BAR", caseSensitive: false}})},
 		{".*foo.*", &containsStringMatcher{substrings: []string{"foo"}, left: anyStringWithoutNewlineMatcher{}, right: anyStringWithoutNewlineMatcher{}}},


### PR DESCRIPTION
`FastRegexMatcher` ignores capture group by design. This is done calling `clearCapture()`. However, `clearCapture()` removes a single capture group. This means that when a regexp has nested capture groups (e.g. `((a|b))`) the optimization doesn't trigger because we remove the 1st capture group but not the 2nd (nested) one.

This PR fixes it. To clarify, this is not a logic bug, but we're missing the opportunity to optimize regexp with nested capture groups.