### PR TITLE
Fix regexp set matches for literal matchers

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -366,7 +366,7 @@ func optimizeAlternatingLiterals(s string) (StringMatcher, []string) {
 	// If there are no alternates, check if the string is a literal
 	if estimatedAlternates == 1 {
 		if regexp.QuoteMeta(s) == s {
-			return &equalStringMatcher{s: s, caseSensitive: true}, nil
+			return &equalStringMatcher{s: s, caseSensitive: true}, []string{s}
 		}
 		return nil, nil
 	}

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -342,6 +342,14 @@ func TestFindSetMatches(t *testing.T) {
 			matches, actualCaseSensitive := findSetMatches(parsed)
 			require.Equal(t, c.expMatches, matches)
 			require.Equal(t, c.expCaseSensitive, actualCaseSensitive)
+
+			if c.expCaseSensitive {
+				// When the regexp is case sensitive, we want to ensure that the
+				// set matches are maintained in the final matcher.
+				r, err := newFastRegexMatcherWithoutCache(c.pattern)
+				require.NoError(t, err)
+				require.Equal(t, c.expMatches, r.SetMatches())
+			}
 		})
 	}
 }

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -125,6 +125,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iNotAlternate := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "(1|2|3|4|5|6|20|55)")
 	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
 	iNotXYZ := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "X|Y|Z")
+	literalRegexp := labels.MustNewMatcher(labels.MatchRegexp, "i_times_n", "0")
 	cases := []struct {
 		name     string
 		matchers []*labels.Matcher
@@ -168,6 +169,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`n="1",i=~".+",i!~"2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNot2Star, jFoo}},
 		{`n="1",i=~".+",i!~".*2.*",j="foo"`, []*labels.Matcher{n1, iPlus, iNotStar2Star, jFoo}},
 		{`n="X",i=~".+",i!~".*2.*",j="foo"`, []*labels.Matcher{nX, iPlus, iNotStar2Star, jFoo}},
+		{`i_times_n=~"0"`, []*labels.Matcher{literalRegexp}},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
While testing a feature for Adaptive Metrics, I was surprised to find out that posting lookups for `foo=~"(bar|bar)"` are faster than `foo=~"bar"`. It turns out I introduced a performance regression in https://github.com/grafana/mimir-prometheus/pull/463.

When we added the `optimizeAlternatingLiterals` function, we subtly broke one edge case. A regexp matcher which matches a single literal, like `foo=~"bar"` used to return `bar` from `SetMatches()`, but currently does not. The implication is that the tsdb will first do a LabelValues call to get all values for `foo`, then match them against the regexp `bar`. This PR restores the previous behavior which is able to directly lookup postings for `foo="bar"` instead. In a random sample of 1M queries from a large dedicated cell, about 11% of queries had at least one matcher in this form.

I've added a new benchmark to show the difference for a label with high cardinality:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                                    │   before.txt    │              after.txt              │
                                                    │     sec/op      │   sec/op     vs base                │
Querier/Head/PostingsForMatchers/i_times_n=~"0"-10    7136391.5n ± 4%   362.0n ± 1%  -99.99% (p=0.000 n=10)
Querier/Block/PostingsForMatchers/i_times_n=~"0"-10     7578.47µ ± 0%   49.29µ ± 1%  -99.35% (p=0.000 n=10)
geomean                                                   7.354m        4.224µ       -99.94%

                                                    │   before.txt    │              after.txt              │
                                                    │      B/op       │    B/op     vs base                 │
Querier/Head/PostingsForMatchers/i_times_n=~"0"-10    7372864.00 ± 0%   64.00 ± 0%  -100.00% (p=0.000 n=10)
Querier/Block/PostingsForMatchers/i_times_n=~"0"-10   7372896.00 ± 0%   80.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                                                  7.031Mi        71.55       -100.00%

                                                    │ before.txt │             after.txt              │
                                                    │ allocs/op  │ allocs/op   vs base                │
Querier/Head/PostingsForMatchers/i_times_n=~"0"-10    4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
Querier/Block/PostingsForMatchers/i_times_n=~"0"-10   6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.000 n=10)
geomean                                               4.899        3.464       -29.29%

```