### PR TITLE
rules.Manager: check whether a Rule has dependents or dependencies and expose it through RuleDetail

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -327,7 +327,7 @@ func (r *AlertingRule) SetNoDependentRules(noDependentRules bool) {
 	r.noDependentRules.Store(noDependentRules)
 }
 
-func (r *AlertingRule) GetNoDependentRules() bool {
+func (r *AlertingRule) NoDependentRules() bool {
 	return r.noDependentRules.Load()
 }
 
@@ -335,7 +335,7 @@ func (r *AlertingRule) SetNoDependencyRules(noDependencyRules bool) {
 	r.noDependencyRules.Store(noDependencyRules)
 }
 
-func (r *AlertingRule) GetNoDependencyRules() bool {
+func (r *AlertingRule) NoDependencyRules() bool {
 	return r.noDependencyRules.Load()
 }
 

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -142,6 +142,9 @@ type AlertingRule struct {
 	active map[uint64]*Alert
 
 	logger log.Logger
+
+	noDependentRules  *atomic.Bool
+	noDependencyRules *atomic.Bool
 }
 
 // NewAlertingRule constructs a new AlertingRule.
@@ -168,6 +171,9 @@ func NewAlertingRule(
 		evaluationTimestamp: atomic.NewTime(time.Time{}),
 		evaluationDuration:  atomic.NewDuration(0),
 		lastError:           atomic.NewError(nil),
+
+		noDependentRules:  atomic.NewBool(false),
+		noDependencyRules: atomic.NewBool(false),
 	}
 }
 
@@ -315,6 +321,22 @@ func (r *AlertingRule) SetRestored(restored bool) {
 // Restored returns the restoration state of the alerting rule.
 func (r *AlertingRule) Restored() bool {
 	return r.restored.Load()
+}
+
+func (r *AlertingRule) SetNoDependentRules(noDependentRules bool) {
+	r.noDependentRules.Store(noDependentRules)
+}
+
+func (r *AlertingRule) GetNoDependentRules() bool {
+	return r.noDependentRules.Load()
+}
+
+func (r *AlertingRule) SetNoDependencyRules(noDependencyRules bool) {
+	r.noDependencyRules.Store(noDependencyRules)
+}
+
+func (r *AlertingRule) GetNoDependencyRules() bool {
+	return r.noDependencyRules.Load()
 }
 
 // resolvedRetention is the duration for which a resolved alert instance

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -933,13 +933,13 @@ func TestAlertingRule_SetNoDependentRules(t *testing.T) {
 		"",
 		true, log.NewNopLogger(),
 	)
-	require.False(t, rule.GetNoDependentRules())
+	require.False(t, rule.NoDependentRules())
 
 	rule.SetNoDependentRules(false)
-	require.False(t, rule.GetNoDependentRules())
+	require.False(t, rule.NoDependentRules())
 
 	rule.SetNoDependentRules(true)
-	require.True(t, rule.GetNoDependentRules())
+	require.True(t, rule.NoDependentRules())
 }
 
 func TestAlertingRule_SetNoDependencyRules(t *testing.T) {
@@ -954,11 +954,11 @@ func TestAlertingRule_SetNoDependencyRules(t *testing.T) {
 		"",
 		true, log.NewNopLogger(),
 	)
-	require.False(t, rule.GetNoDependencyRules())
+	require.False(t, rule.NoDependencyRules())
 
 	rule.SetNoDependencyRules(false)
-	require.False(t, rule.GetNoDependencyRules())
+	require.False(t, rule.NoDependencyRules())
 
 	rule.SetNoDependencyRules(true)
-	require.True(t, rule.GetNoDependencyRules())
+	require.True(t, rule.NoDependencyRules())
 }

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -920,3 +920,45 @@ func TestAlertingEvalWithOrigin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, detail, NewRuleDetail(rule))
 }
+
+func TestAlertingRule_SetNoDependentRules(t *testing.T) {
+	rule := NewAlertingRule(
+		"test",
+		&parser.NumberLiteral{Val: 1},
+		time.Minute,
+		0,
+		labels.FromStrings("test", "test"),
+		labels.EmptyLabels(),
+		labels.EmptyLabels(),
+		"",
+		true, log.NewNopLogger(),
+	)
+	require.False(t, rule.GetNoDependentRules())
+
+	rule.SetNoDependentRules(false)
+	require.False(t, rule.GetNoDependentRules())
+
+	rule.SetNoDependentRules(true)
+	require.True(t, rule.GetNoDependentRules())
+}
+
+func TestAlertingRule_SetNoDependencyRules(t *testing.T) {
+	rule := NewAlertingRule(
+		"test",
+		&parser.NumberLiteral{Val: 1},
+		time.Minute,
+		0,
+		labels.FromStrings("test", "test"),
+		labels.EmptyLabels(),
+		labels.EmptyLabels(),
+		"",
+		true, log.NewNopLogger(),
+	)
+	require.False(t, rule.GetNoDependencyRules())
+
+	rule.SetNoDependencyRules(false)
+	require.False(t, rule.GetNoDependencyRules())
+
+	rule.SetNoDependencyRules(true)
+	require.True(t, rule.GetNoDependencyRules())
+}

--- a/rules/dependency.go
+++ b/rules/dependency.go
@@ -1,0 +1,126 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import "github.com/prometheus/prometheus/promql/parser"
+
+// dependencyMap is a data-structure which contains the relationships between rules within a group.
+// It is used to describe the dependency associations between rules in a group whereby one rule uses the
+// output metric produced by another rule in its expression (i.e. as its "input").
+type dependencyMap map[Rule][]Rule
+
+// dependents returns the count of rules which use the output of the given rule as one of their inputs.
+func (m dependencyMap) dependents(r Rule) int {
+	return len(m[r])
+}
+
+// dependencies returns the count of rules on which the given rule is dependent for input.
+func (m dependencyMap) dependencies(r Rule) int {
+	if len(m) == 0 {
+		return 0
+	}
+
+	var count int
+	for _, children := range m {
+		for _, child := range children {
+			if child == r {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// isIndependent determines whether the given rule is not dependent on another rule for its input, nor is any other rule
+// dependent on its output.
+func (m dependencyMap) isIndependent(r Rule) bool {
+	if m == nil {
+		return false
+	}
+
+	return m.dependents(r)+m.dependencies(r) == 0
+}
+
+// buildDependencyMap builds a data-structure which contains the relationships between rules within a group.
+//
+// Alert rules, by definition, cannot have any dependents - but they can have dependencies. Any recording rule on whose
+// output an Alert rule depends will not be able to run concurrently.
+//
+// There is a class of rule expressions which are considered "indeterminate", because either relationships cannot be
+// inferred, or concurrent evaluation of rules depending on these series would produce undefined/unexpected behaviour:
+//   - wildcard queriers like {cluster="prod1"} which would match every series with that label selector
+//   - any "meta" series (series produced by Prometheus itself) like ALERTS, ALERTS_FOR_STATE
+//
+// Rules which are independent can run concurrently with no side-effects.
+func buildDependencyMap(rules []Rule) dependencyMap {
+	dependencies := make(dependencyMap)
+
+	if len(rules) <= 1 {
+		// No relationships if group has 1 or fewer rules.
+		return nil
+	}
+
+	inputs := make(map[string][]Rule, len(rules))
+	outputs := make(map[string][]Rule, len(rules))
+
+	var indeterminate bool
+
+	for _, rule := range rules {
+		rule := rule
+
+		name := rule.Name()
+		outputs[name] = append(outputs[name], rule)
+
+		parser.Inspect(rule.Query(), func(node parser.Node, path []parser.Node) error {
+			if n, ok := node.(*parser.VectorSelector); ok {
+				// A wildcard metric expression means we cannot reliably determine if this rule depends on any other,
+				// which means we cannot safely run any rules concurrently.
+				if n.Name == "" && len(n.LabelMatchers) > 0 {
+					indeterminate = true
+					return nil
+				}
+
+				// Rules which depend on "meta-metrics" like ALERTS and ALERTS_FOR_STATE will have undefined behaviour
+				// if they run concurrently.
+				if n.Name == alertMetricName || n.Name == alertForStateMetricName {
+					indeterminate = true
+					return nil
+				}
+
+				inputs[n.Name] = append(inputs[n.Name], rule)
+			}
+			return nil
+		})
+	}
+
+	if indeterminate {
+		return nil
+	}
+
+	if len(inputs) == 0 || len(outputs) == 0 {
+		// No relationships can be inferred.
+		return nil
+	}
+
+	for output, outRules := range outputs {
+		for _, outRule := range outRules {
+			if rs, found := inputs[output]; found && len(rs) > 0 {
+				dependencies[outRule] = append(dependencies[outRule], rs...)
+			}
+		}
+	}
+
+	return dependencies
+}

--- a/rules/dependency_test.go
+++ b/rules/dependency_test.go
@@ -1,0 +1,236 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestDependencyMap(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	expr, err := parser.ParseExpr("sum by (user) (rate(requests[1m]))")
+	require.NoError(t, err)
+	rule := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+	expr, err = parser.ParseExpr("user:requests:rate1m <= 0")
+	require.NoError(t, err)
+	rule2 := NewAlertingRule("ZeroRequests", expr, 0, 0, labels.Labels{}, labels.Labels{}, labels.EmptyLabels(), "", true, log.NewNopLogger())
+
+	expr, err = parser.ParseExpr("sum by (user) (rate(requests[5m]))")
+	require.NoError(t, err)
+	rule3 := NewRecordingRule("user:requests:rate5m", expr, labels.Labels{})
+
+	expr, err = parser.ParseExpr("increase(user:requests:rate1m[1h])")
+	require.NoError(t, err)
+	rule4 := NewRecordingRule("user:requests:increase1h", expr, labels.Labels{})
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    []Rule{rule, rule2, rule3, rule4},
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+
+	require.Zero(t, depMap.dependencies(rule))
+	require.Equal(t, 2, depMap.dependents(rule))
+	require.False(t, depMap.isIndependent(rule))
+
+	require.Zero(t, depMap.dependents(rule2))
+	require.Equal(t, 1, depMap.dependencies(rule2))
+	require.False(t, depMap.isIndependent(rule2))
+
+	require.Zero(t, depMap.dependents(rule3))
+	require.Zero(t, depMap.dependencies(rule3))
+	require.True(t, depMap.isIndependent(rule3))
+
+	require.Zero(t, depMap.dependents(rule4))
+	require.Equal(t, 1, depMap.dependencies(rule4))
+	require.False(t, depMap.isIndependent(rule4))
+}
+
+func TestNoDependency(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	expr, err := parser.ParseExpr("sum by (user) (rate(requests[1m]))")
+	require.NoError(t, err)
+	rule := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    []Rule{rule},
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+	// A group with only one rule cannot have dependencies.
+	require.Empty(t, depMap)
+}
+
+func TestDependenciesEdgeCases(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	t.Run("empty group", func(t *testing.T) {
+		group := NewGroup(GroupOptions{
+			Name:     "rule_group",
+			Interval: time.Second,
+			Rules:    []Rule{}, // empty group
+			Opts:     opts,
+		})
+
+		expr, err := parser.ParseExpr("sum by (user) (rate(requests[1m]))")
+		require.NoError(t, err)
+		rule := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+		depMap := buildDependencyMap(group.rules)
+		// A group with no rules has no dependency map, but doesn't panic if the map is queried.
+		require.Nil(t, depMap)
+		require.False(t, depMap.isIndependent(rule))
+	})
+
+	t.Run("rules which reference no series", func(t *testing.T) {
+		expr, err := parser.ParseExpr("one")
+		require.NoError(t, err)
+		rule1 := NewRecordingRule("1", expr, labels.Labels{})
+
+		expr, err = parser.ParseExpr("two")
+		require.NoError(t, err)
+		rule2 := NewRecordingRule("2", expr, labels.Labels{})
+
+		group := NewGroup(GroupOptions{
+			Name:     "rule_group",
+			Interval: time.Second,
+			Rules:    []Rule{rule1, rule2},
+			Opts:     opts,
+		})
+
+		depMap := buildDependencyMap(group.rules)
+		// A group with rules which reference no series will still produce a dependency map
+		require.True(t, depMap.isIndependent(rule1))
+		require.True(t, depMap.isIndependent(rule2))
+	})
+}
+
+func TestNoMetricSelector(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	expr, err := parser.ParseExpr("sum by (user) (rate(requests[1m]))")
+	require.NoError(t, err)
+	rule := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+	expr, err = parser.ParseExpr(`count({user="bob"})`)
+	require.NoError(t, err)
+	rule2 := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    []Rule{rule, rule2},
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+	// A rule with no metric selector cannot be reliably determined to have no dependencies on other rules, and therefore
+	// all rules are not considered independent.
+	require.False(t, depMap.isIndependent(rule))
+	require.False(t, depMap.isIndependent(rule2))
+}
+
+func TestDependentRulesWithNonMetricExpression(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	expr, err := parser.ParseExpr("sum by (user) (rate(requests[1m]))")
+	require.NoError(t, err)
+	rule := NewRecordingRule("user:requests:rate1m", expr, labels.Labels{})
+
+	expr, err = parser.ParseExpr("user:requests:rate1m <= 0")
+	require.NoError(t, err)
+	rule2 := NewAlertingRule("ZeroRequests", expr, 0, 0, labels.Labels{}, labels.Labels{}, labels.EmptyLabels(), "", true, log.NewNopLogger())
+
+	expr, err = parser.ParseExpr("3")
+	require.NoError(t, err)
+	rule3 := NewRecordingRule("three", expr, labels.Labels{})
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    []Rule{rule, rule2, rule3},
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+	require.False(t, depMap.isIndependent(rule))
+	require.False(t, depMap.isIndependent(rule2))
+	require.True(t, depMap.isIndependent(rule3))
+}
+
+func TestRulesDependentOnMetaMetrics(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  log.NewNopLogger(),
+	}
+
+	// This rule is not dependent on any other rules in its group but it does depend on `ALERTS`, which is produced by
+	// the rule engine, and is therefore not independent.
+	expr, err := parser.ParseExpr("count(ALERTS)")
+	require.NoError(t, err)
+	rule := NewRecordingRule("alert_count", expr, labels.Labels{})
+
+	// Create another rule so a dependency map is built (no map is built if a group contains one or fewer rules).
+	expr, err = parser.ParseExpr("1")
+	require.NoError(t, err)
+	rule2 := NewRecordingRule("one", expr, labels.Labels{})
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    []Rule{rule, rule2},
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+	require.False(t, depMap.isIndependent(rule))
+}

--- a/rules/fixtures/rules_multiple.yaml
+++ b/rules/fixtures/rules_multiple.yaml
@@ -1,0 +1,14 @@
+groups:
+  - name: test
+    rules:
+      # independents
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+
+      # dependents
+      - record: job:http_requests:rate15m
+        expr: sum by (job)(rate(http_requests_total[15m]))
+      - record: TooManyRequests
+        expr: job:http_requests:rate15m > 100

--- a/rules/fixtures/rules_multiple_independent.yaml
+++ b/rules/fixtures/rules_multiple_independent.yaml
@@ -1,0 +1,15 @@
+groups:
+  - name: independents
+    rules:
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+      - record: job:http_requests:rate15m
+        expr: sum by (job)(rate(http_requests_total[15m]))
+      - record: job:http_requests:rate30m
+        expr: sum by (job)(rate(http_requests_total[30m]))
+      - record: job:http_requests:rate1h
+        expr: sum by (job)(rate(http_requests_total[1h]))
+      - record: job:http_requests:rate2h
+        expr: sum by (job)(rate(http_requests_total[2h]))

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -323,6 +323,13 @@ func (m *Manager) LoadGroups(
 				))
 			}
 
+			// Check dependencies between rules and store it on the Rule itself.
+			depMap := buildDependencyMap(rules)
+			for _, r := range rules {
+				r.SetNoDependentRules(depMap.dependents(r) == 0)
+				r.SetNoDependencyRules(depMap.dependencies(r) == 0)
+			}
+
 			groups[GroupKey(fn, rg.Name)] = NewGroup(GroupOptions{
 				Name:                          rg.Name,
 				File:                          fn,

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1776,6 +1776,9 @@ func TestRuleGroupEvalIterationFunc(t *testing.T) {
 			evaluationTimestamp: atomic.NewTime(time.Time{}),
 			evaluationDuration:  atomic.NewDuration(0),
 			lastError:           atomic.NewError(nil),
+
+			noDependentRules:  atomic.NewBool(false),
+			noDependencyRules: atomic.NewBool(false),
 		}
 
 		group := NewGroup(GroupOptions{
@@ -1867,4 +1870,64 @@ func TestNativeHistogramsInRecordingRules(t *testing.T) {
 	require.Equal(t, ts.Add(10*time.Second).UnixMilli(), tsp)
 	require.Equal(t, expHist, fh)
 	require.Equal(t, chunkenc.ValNone, it.Next())
+}
+
+func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependencies(t *testing.T) {
+	storage := teststorage.New(t)
+	t.Cleanup(func() {
+		require.NoError(t, storage.Close())
+	})
+
+	ruleManager := NewManager(&ManagerOptions{
+		Context:    context.Background(),
+		Logger:     log.NewNopLogger(),
+		Appendable: storage,
+		QueryFunc:  func(ctx context.Context, q string, ts time.Time) (promql.Vector, error) { return nil, nil },
+	})
+
+	t.Run("load a mix of dependent and independent rules", func(t *testing.T) {
+		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple.yaml"}...)
+		require.Empty(t, errs)
+		require.Len(t, groups, 1)
+
+		expected := map[string]struct {
+			noDependentRules  bool
+			noDependencyRules bool
+		}{
+			"job:http_requests:rate1m": {
+				noDependentRules:  true,
+				noDependencyRules: true,
+			},
+			"job:http_requests:rate5m": {
+				noDependentRules:  true,
+				noDependencyRules: true,
+			},
+			"job:http_requests:rate15m": {
+				noDependentRules:  true,
+				noDependencyRules: false,
+			},
+			"TooManyRequests": {
+				noDependentRules:  false,
+				noDependencyRules: true,
+			},
+		}
+
+		for _, r := range ruleManager.Rules() {
+			exp, ok := expected[r.Name()]
+			require.Truef(t, ok, "rule: %s", r.String())
+			require.Equalf(t, exp.noDependentRules, r.GetNoDependentRules(), "rule: %s", r.String())
+			require.Equalf(t, exp.noDependencyRules, r.GetNoDependencyRules(), "rule: %s", r.String())
+		}
+	})
+
+	t.Run("load only independent rules", func(t *testing.T) {
+		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple_independent.yaml"}...)
+		require.Empty(t, errs)
+		require.Len(t, groups, 1)
+
+		for _, r := range ruleManager.Rules() {
+			require.Truef(t, r.GetNoDependentRules(), "rule: %s", r.String())
+			require.Truef(t, r.GetNoDependencyRules(), "rule: %s", r.String())
+		}
+	})
 }

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1915,8 +1915,8 @@ func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependenci
 		for _, r := range ruleManager.Rules() {
 			exp, ok := expected[r.Name()]
 			require.Truef(t, ok, "rule: %s", r.String())
-			require.Equalf(t, exp.noDependentRules, r.GetNoDependentRules(), "rule: %s", r.String())
-			require.Equalf(t, exp.noDependencyRules, r.GetNoDependencyRules(), "rule: %s", r.String())
+			require.Equalf(t, exp.noDependentRules, r.NoDependentRules(), "rule: %s", r.String())
+			require.Equalf(t, exp.noDependencyRules, r.NoDependencyRules(), "rule: %s", r.String())
 		}
 	})
 
@@ -1926,8 +1926,8 @@ func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependenci
 		require.Len(t, groups, 1)
 
 		for _, r := range ruleManager.Rules() {
-			require.Truef(t, r.GetNoDependentRules(), "rule: %s", r.String())
-			require.Truef(t, r.GetNoDependencyRules(), "rule: %s", r.String())
+			require.Truef(t, r.NoDependentRules(), "rule: %s", r.String())
+			require.Truef(t, r.NoDependencyRules(), "rule: %s", r.String())
 		}
 	})
 }

--- a/rules/origin.go
+++ b/rules/origin.go
@@ -61,8 +61,8 @@ func NewRuleDetail(r Rule) RuleDetail {
 		Labels: r.Labels(),
 		Kind:   kind,
 
-		NoDependentRules:  r.GetNoDependentRules(),
-		NoDependencyRules: r.GetNoDependencyRules(),
+		NoDependentRules:  r.NoDependentRules(),
+		NoDependencyRules: r.NoDependencyRules(),
 	}
 }
 

--- a/rules/origin.go
+++ b/rules/origin.go
@@ -28,6 +28,14 @@ type RuleDetail struct {
 	Query  string
 	Labels labels.Labels
 	Kind   string
+
+	// NoDependentRules is set to true if it's guaranteed that in the rule group there's no other rule
+	// which depends on this one.
+	NoDependentRules bool
+
+	// NoDependencyRules is set to true if it's guaranteed that this rule doesn't depend on any other
+	// rule within the rule group.
+	NoDependencyRules bool
 }
 
 const (
@@ -52,6 +60,9 @@ func NewRuleDetail(r Rule) RuleDetail {
 		Query:  r.Query().String(),
 		Labels: r.Labels(),
 		Kind:   kind,
+
+		NoDependentRules:  r.GetNoDependentRules(),
+		NoDependencyRules: r.GetNoDependencyRules(),
 	}
 }
 

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -45,10 +45,10 @@ func (u unknownRule) GetEvaluationDuration() time.Duration { return 0 }
 func (u unknownRule) SetEvaluationTimestamp(time.Time)     {}
 func (u unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
 
-func (u unknownRule) SetNoDependentRules(bool)   {}
-func (u unknownRule) GetNoDependentRules() bool  { return false }
-func (u unknownRule) SetNoDependencyRules(bool)  {}
-func (u unknownRule) GetNoDependencyRules() bool { return false }
+func (u unknownRule) SetNoDependentRules(bool)  {}
+func (u unknownRule) NoDependentRules() bool    { return false }
+func (u unknownRule) SetNoDependencyRules(bool) {}
+func (u unknownRule) NoDependencyRules() bool   { return false }
 
 func TestNewRuleDetailPanics(t *testing.T) {
 	require.PanicsWithValue(t, `unknown rule type "rules.unknownRule"`, func() {

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -44,8 +45,73 @@ func (u unknownRule) GetEvaluationDuration() time.Duration { return 0 }
 func (u unknownRule) SetEvaluationTimestamp(time.Time)     {}
 func (u unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
 
+func (u unknownRule) SetNoDependentRules(bool)   {}
+func (u unknownRule) GetNoDependentRules() bool  { return false }
+func (u unknownRule) SetNoDependencyRules(bool)  {}
+func (u unknownRule) GetNoDependencyRules() bool { return false }
+
 func TestNewRuleDetailPanics(t *testing.T) {
 	require.PanicsWithValue(t, `unknown rule type "rules.unknownRule"`, func() {
 		NewRuleDetail(unknownRule{})
+	})
+}
+
+func TestFromOriginContext(t *testing.T) {
+	t.Run("should return zero value if RuleDetail is missing in the context", func(t *testing.T) {
+		detail := FromOriginContext(context.Background())
+		require.Zero(t, detail)
+
+		// The zero value for NoDependentRules must be the most conservative option.
+		require.False(t, detail.NoDependentRules)
+
+		// The zero value for NoDependencyRules must be the most conservative option.
+		require.False(t, detail.NoDependencyRules)
+	})
+}
+
+func TestNewRuleDetail(t *testing.T) {
+	t.Run("should populate NoDependentRules and NoDependencyRules for a RecordingRule", func(t *testing.T) {
+		rule := NewRecordingRule("test", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
+		detail := NewRuleDetail(rule)
+		require.False(t, detail.NoDependentRules)
+		require.False(t, detail.NoDependencyRules)
+
+		rule.SetNoDependentRules(true)
+		detail = NewRuleDetail(rule)
+		require.True(t, detail.NoDependentRules)
+		require.False(t, detail.NoDependencyRules)
+
+		rule.SetNoDependencyRules(true)
+		detail = NewRuleDetail(rule)
+		require.True(t, detail.NoDependentRules)
+		require.True(t, detail.NoDependencyRules)
+	})
+
+	t.Run("should populate NoDependentRules and NoDependencyRules for a AlertingRule", func(t *testing.T) {
+		rule := NewAlertingRule(
+			"test",
+			&parser.NumberLiteral{Val: 1},
+			time.Minute,
+			0,
+			labels.FromStrings("test", "test"),
+			labels.EmptyLabels(),
+			labels.EmptyLabels(),
+			"",
+			true, log.NewNopLogger(),
+		)
+
+		detail := NewRuleDetail(rule)
+		require.False(t, detail.NoDependentRules)
+		require.False(t, detail.NoDependencyRules)
+
+		rule.SetNoDependentRules(true)
+		detail = NewRuleDetail(rule)
+		require.True(t, detail.NoDependentRules)
+		require.False(t, detail.NoDependencyRules)
+
+		rule.SetNoDependencyRules(true)
+		detail = NewRuleDetail(rule)
+		require.True(t, detail.NoDependentRules)
+		require.True(t, detail.NoDependencyRules)
 	})
 }

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -41,6 +41,9 @@ type RecordingRule struct {
 	lastError *atomic.Error
 	// Duration of how long it took to evaluate the recording rule.
 	evaluationDuration *atomic.Duration
+
+	noDependentRules  *atomic.Bool
+	noDependencyRules *atomic.Bool
 }
 
 // NewRecordingRule returns a new recording rule.
@@ -53,6 +56,9 @@ func NewRecordingRule(name string, vector parser.Expr, lset labels.Labels) *Reco
 		evaluationTimestamp: atomic.NewTime(time.Time{}),
 		evaluationDuration:  atomic.NewDuration(0),
 		lastError:           atomic.NewError(nil),
+
+		noDependentRules:  atomic.NewBool(false),
+		noDependencyRules: atomic.NewBool(false),
 	}
 }
 
@@ -165,4 +171,20 @@ func (rule *RecordingRule) SetEvaluationTimestamp(ts time.Time) {
 // GetEvaluationTimestamp returns the time the evaluation took place.
 func (rule *RecordingRule) GetEvaluationTimestamp() time.Time {
 	return rule.evaluationTimestamp.Load()
+}
+
+func (rule *RecordingRule) SetNoDependentRules(noDependentRules bool) {
+	rule.noDependentRules.Store(noDependentRules)
+}
+
+func (rule *RecordingRule) GetNoDependentRules() bool {
+	return rule.noDependentRules.Load()
+}
+
+func (rule *RecordingRule) SetNoDependencyRules(noDependencyRules bool) {
+	rule.noDependencyRules.Store(noDependencyRules)
+}
+
+func (rule *RecordingRule) GetNoDependencyRules() bool {
+	return rule.noDependencyRules.Load()
 }

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -177,7 +177,7 @@ func (rule *RecordingRule) SetNoDependentRules(noDependentRules bool) {
 	rule.noDependentRules.Store(noDependentRules)
 }
 
-func (rule *RecordingRule) GetNoDependentRules() bool {
+func (rule *RecordingRule) NoDependentRules() bool {
 	return rule.noDependentRules.Load()
 }
 
@@ -185,6 +185,6 @@ func (rule *RecordingRule) SetNoDependencyRules(noDependencyRules bool) {
 	rule.noDependencyRules.Store(noDependencyRules)
 }
 
-func (rule *RecordingRule) GetNoDependencyRules() bool {
+func (rule *RecordingRule) NoDependencyRules() bool {
 	return rule.noDependencyRules.Load()
 }

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -249,3 +249,25 @@ func TestRecordingEvalWithOrigin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, detail, NewRuleDetail(rule))
 }
+
+func TestRecordingRule_SetNoDependentRules(t *testing.T) {
+	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
+	require.False(t, rule.GetNoDependentRules())
+
+	rule.SetNoDependentRules(false)
+	require.False(t, rule.GetNoDependentRules())
+
+	rule.SetNoDependentRules(true)
+	require.True(t, rule.GetNoDependentRules())
+}
+
+func TestRecordingRule_SetNoDependencyRules(t *testing.T) {
+	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
+	require.False(t, rule.GetNoDependencyRules())
+
+	rule.SetNoDependencyRules(false)
+	require.False(t, rule.GetNoDependencyRules())
+
+	rule.SetNoDependencyRules(true)
+	require.True(t, rule.GetNoDependencyRules())
+}

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -252,22 +252,22 @@ func TestRecordingEvalWithOrigin(t *testing.T) {
 
 func TestRecordingRule_SetNoDependentRules(t *testing.T) {
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
-	require.False(t, rule.GetNoDependentRules())
+	require.False(t, rule.NoDependentRules())
 
 	rule.SetNoDependentRules(false)
-	require.False(t, rule.GetNoDependentRules())
+	require.False(t, rule.NoDependentRules())
 
 	rule.SetNoDependentRules(true)
-	require.True(t, rule.GetNoDependentRules())
+	require.True(t, rule.NoDependentRules())
 }
 
 func TestRecordingRule_SetNoDependencyRules(t *testing.T) {
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
-	require.False(t, rule.GetNoDependencyRules())
+	require.False(t, rule.NoDependencyRules())
 
 	rule.SetNoDependencyRules(false)
-	require.False(t, rule.GetNoDependencyRules())
+	require.False(t, rule.NoDependencyRules())
 
 	rule.SetNoDependencyRules(true)
-	require.True(t, rule.GetNoDependencyRules())
+	require.True(t, rule.NoDependencyRules())
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -62,4 +62,12 @@ type Rule interface {
 	// GetEvaluationTimestamp returns last evaluation timestamp.
 	// NOTE: Used dynamically by rules.html template.
 	GetEvaluationTimestamp() time.Time
+
+	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
+	SetNoDependentRules(bool)
+	GetNoDependentRules() bool
+
+	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
+	SetNoDependencyRules(bool)
+	GetNoDependencyRules() bool
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -65,9 +65,9 @@ type Rule interface {
 
 	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
 	SetNoDependentRules(bool)
-	GetNoDependentRules() bool
+	NoDependentRules() bool
 
 	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
 	SetNoDependencyRules(bool)
-	GetNoDependencyRules() bool
+	NoDependencyRules() bool
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -65,9 +65,17 @@ type Rule interface {
 
 	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
 	SetNoDependentRules(bool)
+
+	// NoDependentRules returns true if it's guaranteed that in the rule group there's no other rule
+	// which depends on this one. In case this function returns false there's no such guarantee, which
+	// means there may or may not be other rules depending on this one.
 	NoDependentRules() bool
 
 	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
 	SetNoDependencyRules(bool)
+
+	// NoDependencyRules returns true if it's guaranteed that this rule doesn't depend on the output of
+	// any other rule in the group. In case this function returns false there's no such guarantee, which
+	// means the rule may or may not depend on other rules.
 	NoDependencyRules() bool
 }


### PR DESCRIPTION
This is a simplified version of https://github.com/grafana/mimir-prometheus/pull/584 which doesn't include the support to concurrently evaluate rules, but just analyse whether a Rule has dependents or dependencies and expose the info through RuleDetail. The content of `rules/dependency.go` and `rules/dependency_test.go` is a copy-paste from [Danny's PR](https://github.com/prometheus/prometheus/pull/12946).

Notes:
- The changes done in this PR have been designed to be as much isolated as possible from Prometheus code, in order to reduce the future conflicts when synching.
- Why did I call the fields / functions "**no** dependent/cy rules" (negative) instead of a positive "dependent/cy rules"? Reason is that I wanted the zero value to be the safest option (so zero value means "yes, there are dependant/cy"). I don't feel strong about this tho.