### PR TITLE
fix: increase function results do not reflect normal trends when ther…

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -103,17 +103,25 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		numSamplesMinusOne = len(samples.Floats) - 1
 		firstT = samples.Floats[0].T
 		lastT = samples.Floats[numSamplesMinusOne].T
-		resultFloat = samples.Floats[numSamplesMinusOne].F - samples.Floats[0].F
 		if !isCounter {
+			resultFloat = samples.Floats[numSamplesMinusOne].F - samples.Floats[0].F
 			break
 		}
 		// Handle counter resets:
 		prevValue := samples.Floats[0].F
 		for _, currPoint := range samples.Floats[1:] {
 			if currPoint.F < prevValue {
-				resultFloat += prevValue
+				// counter reset
+				if currPoint.F == 0 {
+					resultFloat += prevValue
+					prevValue = 0
+				}
+				// else: counter value is not reset but decreased, ignored
+			} else if currPoint.F > prevValue {
+				resultFloat += currPoint.F - prevValue
+				prevValue = currPoint.F
 			}
-			prevValue = currPoint.F
+			// else: counter value is not changed, ignored
 		}
 	default:
 		// TODO: add RangeTooShortWarning


### PR DESCRIPTION
**When there is out-of-order data (counter types of time series may occasionally have non-incremental data), the results returned by using increase queries do not reflect the actual trend.**

**The time series is directly queried here, as follows：**
<img width="1476" alt="image" src="https://github.com/grafana/mimir-prometheus/assets/48707349/6f5698a9-192f-49cc-9f86-84917fae39e7">

**When queried using the increase function, the result is the following:**
<img width="1447" alt="image" src="https://github.com/grafana/mimir-prometheus/assets/48707349/9aa592a1-ef8c-4197-83c3-a869dc2a36fd">

**I call the query_range api directly, and the query finds that the sample value at a certain point in time is smaller than the previous point in time.**
![image](https://github.com/grafana/mimir-prometheus/assets/48707349/83aaa944-796d-45a7-b6b2-7758eca33714)

**After modifying the relevant calculation logic of functions.go, the query results are in line with expectations.**
<img width="364" alt="image" src="https://github.com/grafana/mimir-prometheus/assets/48707349/2571a130-867d-401b-8e9d-164d5f55a352">


