### PR TITLE
Add timely head compaction support

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -211,6 +211,10 @@ type Options struct {
 	// EnableSharding enables query sharding support in TSDB.
 	EnableSharding bool
 
+	// Timely compaction allows head compaction to happen if the min block in the head is appendable, without requiring
+	// the head to exceed 1.5 times the chunk range.
+	TimelyCompaction bool
+
 	// HeadPostingsForMatchersCacheTTL is the TTL of the postings for matchers cache in the Head.
 	// If it's 0, the cache will only deduplicate in-flight requests, deleting the results once the first request has finished.
 	HeadPostingsForMatchersCacheTTL time.Duration
@@ -939,6 +943,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 	headOpts.OutOfOrderTimeWindow.Store(opts.OutOfOrderTimeWindow)
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	headOpts.EnableSharding = opts.EnableSharding
+	headOpts.TimelyCompaction = opts.TimelyCompaction
 	headOpts.PostingsForMatchersCacheTTL = opts.HeadPostingsForMatchersCacheTTL
 	headOpts.PostingsForMatchersCacheMaxItems = opts.HeadPostingsForMatchersCacheMaxItems
 	headOpts.PostingsForMatchersCacheMaxBytes = opts.HeadPostingsForMatchersCacheMaxBytes

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -211,8 +211,8 @@ type Options struct {
 	// EnableSharding enables query sharding support in TSDB.
 	EnableSharding bool
 
-	// Timely compaction allows head compaction to happen if the min block in the head is compactable, without requiring
-	// the head to exceed 1.5 times the chunk range.
+	// Timely compaction allows head compaction to happen when min block range can no longer be appended,
+	// without requiring 1.5x the chunk range worth of data in the head.
 	TimelyCompaction bool
 
 	// HeadPostingsForMatchersCacheTTL is the TTL of the postings for matchers cache in the Head.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -211,7 +211,7 @@ type Options struct {
 	// EnableSharding enables query sharding support in TSDB.
 	EnableSharding bool
 
-	// Timely compaction allows head compaction to happen if the min block in the head is appendable, without requiring
+	// Timely compaction allows head compaction to happen if the min block in the head is compactable, without requiring
 	// the head to exceed 1.5 times the chunk range.
 	TimelyCompaction bool
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -197,7 +197,7 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
-	// Timely compaction allows compaction to happen if the min block in the head is appendable, without requiring
+	// Timely compaction allows compaction to happen if the min block in the head is compactable, without requiring
 	// the head to exceed 1.5 times the chunk range.
 	TimelyCompaction bool
 
@@ -1657,7 +1657,7 @@ func (h *Head) MaxOOOTime() int64 {
 }
 
 // compactable returns whether the head has a compactable range.
-// When the TimelyCompaction option is enabled, the head is compactable when the min block is appendable.
+// When the TimelyCompaction option is enabled, the head is compactable when the min block end is .5 times the chunk range in the past.
 // Else the head has a compactable range when the head time range is 1.5 times the chunk range.
 // The 0.5 acts as a buffer of the appendable window.
 func (h *Head) compactable() bool {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -197,8 +197,8 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
-	// Timely compaction allows compaction to happen if the min block in the head is compactable, without requiring
-	// the head to exceed 1.5 times the chunk range.
+	// Timely compaction allows head compaction to happen when min block range can no longer be appended,
+	// without requiring 1.5x the chunk range worth of data in the head.
 	TimelyCompaction bool
 
 	PostingsForMatchersCacheTTL      time.Duration

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -197,6 +197,10 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
+	// Timely compaction allows compaction to happen if the min block in the head is appendable, without requiring
+	// the head to exceed 1.5 times the chunk range.
+	TimelyCompaction bool
+
 	PostingsForMatchersCacheTTL      time.Duration
 	PostingsForMatchersCacheMaxItems int
 	PostingsForMatchersCacheMaxBytes int64
@@ -1653,9 +1657,14 @@ func (h *Head) MaxOOOTime() int64 {
 }
 
 // compactable returns whether the head has a compactable range.
-// The head has a compactable range when the head time range is 1.5 times the chunk range.
+// When the TimelyCompaction option is enabled, the head is compactable when the min block is appendable.
+// Else the head has a compactable range when the head time range is 1.5 times the chunk range.
 // The 0.5 acts as a buffer of the appendable window.
 func (h *Head) compactable() bool {
+	if h.opts.TimelyCompaction {
+		minBlockEnd := rangeForTimestamp(h.MinTime(), h.chunkRange.Load())
+		return minBlockEnd < h.appendableMinValidTime()
+	}
 	return h.MaxTime()-h.MinTime() > h.chunkRange.Load()/2*3
 }
 


### PR DESCRIPTION
This PR introduces a new TSDB and head option: `TimelyCompaction`. This option, which defaults to `false`, allows compaction to happen if the min block range is no longer appendable, without requiring the head to exceed 1.5 times the chunk range, as the current behavior requires. When this option is not enabled, the current behavior applies. 

The goal of this setting is to allow compactions which might normally occur at a certain time, such as because of a previous early compaction, to still occur. For example: Consider a head with:

- minT=1:55
- maxT=3:01

If head compaction is attempted at 3:01, the current logic will prevent it since the head does not contain 1.5 times the block size. With `TimelyCompaction` enabled, the min-compactable block, which is from 1:00-2:00, is compactable since it ends more than .5 blocks (1h) prior to the maxT, so compaction will be allowed.

Partially addresses https://github.com/grafana/mimir/issues/7306

### Testing

I ran this for a day with heavy use of early compaction, and did not observe any blocks that were uploaded late, as they would be prior to this change.