### PR TITLE
Cherry-pick "restore ability to match __name__ multiple times in selector"

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -791,20 +791,7 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			// Skip the check for non-empty matchers because an explicit
 			// metric name is a non-empty matcher.
 			break
-		} else {
-			// We also have to make sure a metric name was not set twice inside the
-			// braces.
-			foundMetricName := ""
-			for _, m := range n.LabelMatchers {
-				if m != nil && m.Name == labels.MetricName {
-					if foundMetricName != "" {
-						p.addParseErrf(n.PositionRange(), "metric name must not be set twice: %q or %q", foundMetricName, m.Value)
-					}
-					foundMetricName = m.Value
-				}
-			}
 		}
-
 		// A Vector selector must contain at least one non-empty matcher to prevent
 		// implicit selection of all metrics (e.g. by a typo).
 		notEmpty := false

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -1825,6 +1825,48 @@ var testExpr = []struct {
 		},
 	},
 	{
+		// Specifying __name__ twice inside the braces is ok.
+		input: `{__name__=~"bar", __name__!~"baz"}`,
+		expected: &VectorSelector{
+			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchRegexp, model.MetricNameLabel, "bar"),
+				MustLabelMatcher(labels.MatchNotRegexp, model.MetricNameLabel, "baz"),
+			},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   34,
+			},
+		},
+	},
+	{
+		// Specifying __name__ with equality twice inside the braces is even allowed.
+		input: `{__name__="bar", __name__="baz"}`,
+		expected: &VectorSelector{
+			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "bar"),
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "baz"),
+			},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   32,
+			},
+		},
+	},
+	{
+		// Because the above are allowed, this is also allowed.
+		input: `{"bar", __name__="baz"}`,
+		expected: &VectorSelector{
+			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "bar"),
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "baz"),
+			},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   23,
+			},
+		},
+	},
+	{
 		input:  `{`,
 		fail:   true,
 		errMsg: "unexpected end of input inside braces",
@@ -1906,6 +1948,8 @@ var testExpr = []struct {
 		fail:   true,
 		errMsg: "vector selector must contain at least one non-empty matcher",
 	},
+	// Although {"bar", __name__="baz"} is allowed (see above), specifying a
+	// metric name inside and outside the braces is not.
 	{
 		input:  `foo{__name__="bar"}`,
 		fail:   true,


### PR DESCRIPTION
Cherry-pick upstream PR [fix: restore ability to match __name__ multiple times in selector](https://github.com/prometheus/prometheus/pull/13674). This restores the ability to have multiple matches on `__name__` between the curly braces in a Prometheus query.