### PR TITLE
TSDB: Don't compact the head block when empty

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -138,7 +138,7 @@ func (h *Head) Appender(_ context.Context) storage.Appender {
 
 	// The head cache might not have a starting point yet. The init appender
 	// picks up the first appended timestamp as the base.
-	if h.MinTime() == math.MaxInt64 {
+	if h.isUninitialized() {
 		return &initAppender{
 			head: h,
 		}
@@ -191,7 +191,7 @@ func (h *Head) appendableMinValidTime() int64 {
 // AppendableMinValidTime returns the minimum valid time for samples to be appended to the Head.
 // Returns false if Head hasn't been initialized yet and the minimum time isn't known yet.
 func (h *Head) AppendableMinValidTime() (int64, bool) {
-	if h.MinTime() == math.MaxInt64 {
+	if h.isUninitialized() {
 		return 0, false
 	}
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3121,6 +3121,22 @@ func TestHeadExemplars(t *testing.T) {
 	require.NoError(t, head.Close())
 }
 
+func TestHeadMinMaxTimeNotSet(t *testing.T) {
+	head, _ := newTestHead(t, 1000, wlog.CompressionNone, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+
+	require.True(t, head.isUninitialized())
+
+	app := head.Appender(context.Background())
+	_, err := app.Append(0, labels.FromStrings("a", "b"), 100, 100)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.False(t, head.isUninitialized())
+}
+
 func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	chunkRange := int64(2000)
 	head, _ := newTestHead(b, chunkRange, wlog.CompressionNone, false)


### PR DESCRIPTION
Don't compact the Head block if there have not yet been any samples appended.

Previously, the logic for determining if the head should be compacted relied on the default values for min and max time and integer overflow when they were checked in `Head.compactable()`. The check in `Head.compactable()` effectively did `math.MinInt64 - math.MaxInt64` which overflowed and wrapped to `1`. Since `1` is less than `1.5` times the chunk range, compaction did not happen. This was the correct behavior but relying on overflow wrapping is surprising.

This change add a method for checking if the min and max time for the head is unset and uses it to short-circuit compaction in that case. It also replaces several explicit checks for the default value to determine if the head has not yet had any samples added.

This is a cherry-pick of the upstream PR https://github.com/prometheus/prometheus/pull/13755

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
