### PR TITLE
Log out of order when writing a block

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -755,6 +755,7 @@ func (c *LeveledCompactor) Write(dest string, b BlockReader, mint, maxt int64, p
 		"maxt", meta.MaxTime,
 		"ulid", meta.ULID,
 		"duration", time.Since(start),
+		"ooo", meta.Compaction.FromOutOfOrder(),
 	)
 	return uid, nil
 }


### PR DESCRIPTION
When analyzing prometheus logs, it would be helpful to distinguish when a block that's created is from the out of order head or not. Currently there is an indication when OOO compaction runs ([code](https://github.com/prometheus/prometheus/blob/31491eb37c556a81b071ec25a7452114e0714e82/tsdb/db.go#L1332-L1335)), but this doesn't include the mint and maxt for each block. Having this information all together is useful, for example, when analyzing how blocks came to be created for different time ranges.

This PR adds an "ooo" meta field (other naming welcome) to the block creation logging, so that it's possible to easily find OOO blocks for certain min and max times.

Upstream PR: https://github.com/prometheus/prometheus/pull/13888