### PR TITLE
Remove OpEmptyMatch from regex concatenations

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -291,18 +291,12 @@ func clearCapture(regs ...*syntax.Regexp) {
 	}
 }
 
-// clearCapture removes capture operation as they are not used for matching.
+// removeEmptyMatches returns the slice with syntax.OpEmptyMatch regexps removed.
+// Note: it modifies the input slice (the returned slice is a sub-slice of the input).
 func removeEmptyMatches(regs []*syntax.Regexp) []*syntax.Regexp {
-	for i := 0; i < len(regs); i++ {
-		if regs[i].Op == syntax.OpEmptyMatch {
-			regs = slices.Delete(regs, i, i+1)
-		}
-		// Don't remove the last one.
-		if len(regs) == 1 {
-			return regs
-		}
-	}
-	return regs
+	return slices.DeleteFunc(regs, func(r *syntax.Regexp) bool {
+		return r.Op == syntax.OpEmptyMatch
+	})
 }
 
 // clearBeginEndText removes the begin and end text from the regexp. Prometheus regexp are anchored to the beginning and end of the string.

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -412,6 +412,7 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{"^.+$", &anyNonEmptyStringMatcher{matchNL: false}},
 		{"(.+)", &anyNonEmptyStringMatcher{matchNL: false}},
 		{"", emptyStringMatcher{}},
+		{"()", emptyStringMatcher{}},
 		{"^$", emptyStringMatcher{}},
 		{"^foo$", &equalStringMatcher{s: "foo", caseSensitive: true}},
 		{"^foo()$", &equalStringMatcher{s: "foo", caseSensitive: true}},

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -400,6 +400,9 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		exp     StringMatcher
 	}{
 		{".*", anyStringWithoutNewlineMatcher{}},
+		{"().*", anyStringWithoutNewlineMatcher{}},
+		{".*()", anyStringWithoutNewlineMatcher{}},
+		{"().*()", anyStringWithoutNewlineMatcher{}},
 		{".*?", anyStringWithoutNewlineMatcher{}},
 		{"(?s:.*)", trueMatcher{}},
 		{"(.*)", anyStringWithoutNewlineMatcher{}},
@@ -411,6 +414,8 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{"", emptyStringMatcher{}},
 		{"^$", emptyStringMatcher{}},
 		{"^foo$", &equalStringMatcher{s: "foo", caseSensitive: true}},
+		{"^foo()$", &equalStringMatcher{s: "foo", caseSensitive: true}},
+		{"^()foo$", &equalStringMatcher{s: "foo", caseSensitive: true}},
 		{"^(?i:foo)$", &equalStringMatcher{s: "FOO", caseSensitive: false}},
 		{"^((?i:foo)|(bar))$", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "bar", caseSensitive: true}})},
 		{`(?i:((foo|bar)))`, orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "BAR", caseSensitive: false}})},

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -34,7 +34,9 @@ var (
 	asciiRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
 	regexes    = []string{
 		"",
+		"()",
 		"foo",
+		"foo()",
 		"^foo",
 		"(foo|bar)",
 		"foo.*",
@@ -42,7 +44,11 @@ var (
 		"^.*foo$",
 		"^.+foo$",
 		".*",
+		"().*",
+		".*()",
+		"().*()",
 		".+",
+		".+()",
 		"foo.+",
 		".+foo",
 		"foo\n.+",


### PR DESCRIPTION
OpEmptyMatch is regex's nop operation, but it breaks some optimizations which aren't designed for a concatenation of multiple operations.

I saw a `pod=~"().*"` matcher in the wild and wondered whether it would be optimized, and was suprised to see that it wasn't.
