### PR TITLE
Sync with upstream

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -217,6 +217,7 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 				level.Info(logger).Log("msg", "Experimental PromQL functions enabled.")
 			case "native-histograms":
 				c.tsdb.EnableNativeHistograms = true
+				c.scrape.EnableNativeHistogramsIngestion = true
 				// Change relevant global variables. Hacky, but it's hard to pass a new option or default to unmarshallers.
 				config.DefaultConfig.GlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols

--- a/discovery/metrics.go
+++ b/discovery/metrics.go
@@ -19,16 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var (
-	clientGoRequestMetrics  = &clientGoRequestMetricAdapter{}
-	clientGoWorkloadMetrics = &clientGoWorkqueueMetricsProvider{}
-)
-
-func init() {
-	clientGoRequestMetrics.RegisterWithK8sGoClient()
-	clientGoWorkloadMetrics.RegisterWithK8sGoClient()
-}
-
 // Metrics to be used with a discovery manager.
 type Metrics struct {
 	FailedConfigs     prometheus.Gauge

--- a/discovery/metrics_k8s_client.go
+++ b/discovery/metrics_k8s_client.go
@@ -36,6 +36,11 @@ const (
 )
 
 var (
+	clientGoRequestMetrics  = &clientGoRequestMetricAdapter{}
+	clientGoWorkloadMetrics = &clientGoWorkqueueMetricsProvider{}
+)
+
+var (
 	// Metrics for client-go's HTTP requests.
 	clientGoRequestResultMetricVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -135,6 +140,9 @@ func clientGoMetrics() []prometheus.Collector {
 }
 
 func RegisterK8sClientMetricsWithPrometheus(registerer prometheus.Registerer) error {
+	clientGoRequestMetrics.RegisterWithK8sGoClient()
+	clientGoWorkloadMetrics.RegisterWithK8sGoClient()
+
 	for _, collector := range clientGoMetrics() {
 		err := registerer.Register(collector)
 		if err != nil {

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -174,20 +174,25 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 			labels[instanceTagsLabel] = model.LabelValue(tags)
 		}
 
+		addr := ""
 		if server.IPv6 != nil {
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String())
+			addr = server.IPv6.Address.String()
 		}
 
 		if server.PublicIP != nil {
 			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String())
+			addr = server.PublicIP.Address.String()
 		}
 
 		if server.PrivateIP != nil {
 			labels[instancePrivateIPv4Label] = model.LabelValue(*server.PrivateIP)
+			addr = *server.PrivateIP
+		}
 
-			addr := net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
+		if addr != "" {
+			addr := net.JoinHostPort(addr, strconv.FormatUint(uint64(d.port), 10))
 			labels[model.AddressLabel] = model.LabelValue(addr)
-
 			targets = append(targets, labels)
 		}
 	}

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -60,7 +60,7 @@ api_url: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Len(t, tg.Targets, 2)
+	require.Len(t, tg.Targets, 3)
 
 	for i, lbls := range []model.LabelSet{
 		{
@@ -109,6 +109,28 @@ api_url: %s
 			"__meta_scaleway_instance_status":                 "running",
 			"__meta_scaleway_instance_type":                   "DEV1-S",
 			"__meta_scaleway_instance_zone":                   "fr-par-1",
+		},
+		{
+			"__address__":                                     "51.158.183.115:80",
+			"__meta_scaleway_instance_boot_type":              "local",
+			"__meta_scaleway_instance_hostname":               "routed-dualstack",
+			"__meta_scaleway_instance_id":                     "4904366a-7e26-4b65-b97b-6392c761247a",
+			"__meta_scaleway_instance_image_arch":             "x86_64",
+			"__meta_scaleway_instance_image_id":               "3e0a5b84-1d69-4993-8fa4-0d7df52d5160",
+			"__meta_scaleway_instance_image_name":             "Ubuntu 22.04 Jammy Jellyfish",
+			"__meta_scaleway_instance_location_cluster_id":    "19",
+			"__meta_scaleway_instance_location_hypervisor_id": "1201",
+			"__meta_scaleway_instance_location_node_id":       "24",
+			"__meta_scaleway_instance_name":                   "routed-dualstack",
+			"__meta_scaleway_instance_organization_id":        "20b3d507-96ac-454c-a795-bc731b46b12f",
+			"__meta_scaleway_instance_project_id":             "20b3d507-96ac-454c-a795-bc731b46b12f",
+			"__meta_scaleway_instance_public_ipv4":            "51.158.183.115",
+			"__meta_scaleway_instance_region":                 "nl-ams",
+			"__meta_scaleway_instance_security_group_id":      "984414da-9fc2-49c0-a925-fed6266fe092",
+			"__meta_scaleway_instance_security_group_name":    "Default security group",
+			"__meta_scaleway_instance_status":                 "running",
+			"__meta_scaleway_instance_type":                   "DEV1-S",
+			"__meta_scaleway_instance_zone":                   "nl-ams-1",
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/discovery/scaleway/testdata/instance.json
+++ b/discovery/scaleway/testdata/instance.json
@@ -216,6 +216,146 @@
       "placement_group": null,
       "private_nics": [],
       "zone": "fr-par-1"
+    },
+    {
+      "id": "4904366a-7e26-4b65-b97b-6392c761247a",
+      "name": "routed-dualstack",
+      "arch": "x86_64",
+      "commercial_type": "DEV1-S",
+      "boot_type": "local",
+      "organization": "20b3d507-96ac-454c-a795-bc731b46b12f",
+      "project": "20b3d507-96ac-454c-a795-bc731b46b12f",
+      "hostname": "routed-dualstack",
+      "image": {
+        "id": "3e0a5b84-1d69-4993-8fa4-0d7df52d5160",
+        "name": "Ubuntu 22.04 Jammy Jellyfish",
+        "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "project": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "root_volume": {
+          "id": "13d945b9-5e78-4f9d-8ac4-c4bc2fa7c31a",
+          "name": "Ubuntu 22.04 Jammy Jellyfish",
+          "volume_type": "unified",
+          "size": 10000000000
+        },
+        "extra_volumes": {},
+        "public": true,
+        "arch": "x86_64",
+        "creation_date": "2024-02-22T15:52:56.037007+00:00",
+        "modification_date": "2024-02-22T15:52:56.037007+00:00",
+        "default_bootscript": null,
+        "from_server": null,
+        "state": "available",
+        "tags": [],
+        "zone": "nl-ams-1"
+      },
+      "volumes": {
+        "0": {
+          "boot": false,
+          "id": "fe85c817-e67e-4e24-8f13-bde3e9f42620",
+          "name": "Ubuntu 22.04 Jammy Jellyfish",
+          "volume_type": "l_ssd",
+          "export_uri": null,
+          "organization": "20b3d507-96ac-454c-a795-bc731b46b12f",
+          "project": "20b3d507-96ac-454c-a795-bc731b46b12f",
+          "server": {
+            "id": "4904366a-7e26-4b65-b97b-6392c761247a",
+            "name": "routed-dualstack"
+          },
+          "size": 20000000000,
+          "state": "available",
+          "creation_date": "2024-04-19T14:50:14.019739+00:00",
+          "modification_date": "2024-04-19T14:50:14.019739+00:00",
+          "tags": [],
+          "zone": "nl-ams-1"
+        }
+      },
+      "tags": [],
+      "state": "running",
+      "protected": false,
+      "state_detail": "booted",
+      "public_ip": {
+        "id": "53f8f861-7a11-4b16-a4bc-fb8f4b4a11d0",
+        "address": "51.158.183.115",
+        "dynamic": false,
+        "gateway": "62.210.0.1",
+        "netmask": "32",
+        "family": "inet",
+        "provisioning_mode": "dhcp",
+        "tags": [],
+        "state": "attached",
+        "ipam_id": "ec3499ff-a664-49b7-818a-9fe4b95aee5e"
+      },
+      "public_ips": [
+        {
+          "id": "53f8f861-7a11-4b16-a4bc-fb8f4b4a11d0",
+          "address": "51.158.183.115",
+          "dynamic": false,
+          "gateway": "62.210.0.1",
+          "netmask": "32",
+          "family": "inet",
+          "provisioning_mode": "dhcp",
+          "tags": [],
+          "state": "attached",
+          "ipam_id": "ec3499ff-a664-49b7-818a-9fe4b95aee5e"
+        },
+        {
+          "id": "f52a8c81-0875-4aee-b96e-eccfc6bec367",
+          "address": "2001:bc8:1640:1568:dc00:ff:fe21:91b",
+          "dynamic": false,
+          "gateway": "fe80::dc00:ff:fe21:91c",
+          "netmask": "64",
+          "family": "inet6",
+          "provisioning_mode": "slaac",
+          "tags": [],
+          "state": "attached",
+          "ipam_id": "40d1e6ea-e932-42f9-8acb-55398bec7ad6"
+        }
+      ],
+      "mac_address": "de:00:00:21:09:1b",
+      "routed_ip_enabled": true,
+      "ipv6": null,
+      "extra_networks": [],
+      "dynamic_ip_required": false,
+      "enable_ipv6": false,
+      "private_ip": null,
+      "creation_date": "2024-04-19T14:50:14.019739+00:00",
+      "modification_date": "2024-04-19T14:52:21.181670+00:00",
+      "bootscript": {
+        "id": "5a520dda-96d6-4ed2-acd1-1d526b6859fe",
+        "public": true,
+        "title": "x86_64 mainline 4.4.182 rev1",
+        "architecture": "x86_64",
+        "organization": "11111111-1111-4111-8111-111111111111",
+        "project": "11111111-1111-4111-8111-111111111111",
+        "kernel": "http://10.196.2.9/kernel/x86_64-mainline-lts-4.4-4.4.182-rev1/vmlinuz-4.4.182",
+        "dtb": "",
+        "initrd": "http://10.196.2.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+        "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16",
+        "default": true,
+        "zone": "nl-ams-1"
+      },
+      "security_group": {
+        "id": "984414da-9fc2-49c0-a925-fed6266fe092",
+        "name": "Default security group"
+      },
+      "location": {
+        "zone_id": "ams1",
+        "platform_id": "23",
+        "cluster_id": "19",
+        "hypervisor_id": "1201",
+        "node_id": "24"
+      },
+      "maintenances": [],
+      "allowed_actions": [
+        "poweroff",
+        "terminate",
+        "reboot",
+        "stop_in_place",
+        "backup"
+      ],
+      "placement_group": null,
+      "private_nics": [],
+      "zone": "nl-ams-1"
     }
   ]
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2952,9 +2952,10 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_scaleway_instance_type`: commercial type of the server
 * `__meta_scaleway_instance_zone`: the zone of the server (ex: `fr-par-1`, complete list [here](https://developers.scaleway.com/en/products/instance/api/#introduction))
 
-This role uses the private IPv4 address by default. This can be
+This role uses the first address it finds in the following order: private IPv4, public IPv4, public IPv6. This can be
 changed with relabeling, as demonstrated in [the Prometheus scaleway-sd
 configuration file](/documentation/examples/prometheus-scaleway.yml).
+Should an instance have no address before relabeling, it will not be added to the target list and you will not be able to relabel it.
 
 #### Baremetal role
 

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -81,6 +81,8 @@ type Options struct {
 	// Option to enable the ingestion of the created timestamp as a synthetic zero sample.
 	// See: https://github.com/prometheus/proposals/blob/main/proposals/2023-06-13_created-timestamp.md
 	EnableCreatedTimestampZeroIngestion bool
+	// Option to enable the ingestion of native histograms.
+	EnableNativeHistogramsIngestion bool
 
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -252,6 +252,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelName }],
     },
     {
+      title: 'continue to autocomplete QuotedLabelName in aggregate modifier',
+      expr: 'sum by ("myL")',
+      pos: 12, // cursor is between the bracket after the string myL
+      expectedContext: [{ kind: ContextKind.LabelName }],
+    },
+    {
       title: 'autocomplete labelName in a list',
       expr: 'sum by (myLabel1,)',
       pos: 17, // cursor is between the bracket after the string myLab
@@ -261,6 +267,12 @@ describe('analyzeCompletion test', () => {
       title: 'autocomplete labelName in a list 2',
       expr: 'sum by (myLabel1, myLab)',
       pos: 23, // cursor is between the bracket after the string myLab
+      expectedContext: [{ kind: ContextKind.LabelName }],
+    },
+    {
+      title: 'autocomplete labelName in a list 2',
+      expr: 'sum by ("myLabel1", "myLab")',
+      pos: 27, // cursor is between the bracket after the string myLab
       expectedContext: [{ kind: ContextKind.LabelName }],
     },
     {
@@ -300,6 +312,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelName, metricName: '' }],
     },
     {
+      title: 'continue to autocomplete quoted labelName associated to a metric',
+      expr: '{"metric_"}',
+      pos: 10, // cursor is between the bracket after the string metric_
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: 'metric_' }],
+    },
+    {
       title: 'autocomplete the labelValue with metricName + labelName',
       expr: 'metric_name{labelName=""}',
       pos: 23, // cursor is between the quotes
@@ -337,6 +355,30 @@ describe('analyzeCompletion test', () => {
               name: 'labelName',
               type: Neq,
               value: '',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'autocomplete the labelValue with metricName + quoted labelName',
+      expr: 'metric_name{labelName="labelValue", "labelName"!=""}',
+      pos: 50, // cursor is between the quotes
+      expectedContext: [
+        {
+          kind: ContextKind.LabelValue,
+          metricName: 'metric_name',
+          labelName: 'labelName',
+          matchers: [
+            {
+              name: 'labelName',
+              type: Neq,
+              value: '',
+            },
+            {
+              name: 'labelName',
+              type: EqlSingle,
+              value: 'labelValue',
             },
           ],
         },
@@ -426,6 +468,12 @@ describe('analyzeCompletion test', () => {
       expr: 'metric_name{labelName!}',
       pos: 22, // cursor is after '!'
       expectedContext: [{ kind: ContextKind.MatchOp }],
+    },
+    {
+      title: 'autocomplete matchOp 3',
+      expr: 'metric_name{"labelName"!}',
+      pos: 24, // cursor is after '!'
+      expectedContext: [{ kind: ContextKind.BinOp }],
     },
     {
       title: 'autocomplete duration with offset',

--- a/web/ui/module/codemirror-promql/src/parser/matcher.ts
+++ b/web/ui/module/codemirror-promql/src/parser/matcher.ts
@@ -12,33 +12,75 @@
 // limitations under the License.
 
 import { SyntaxNode } from '@lezer/common';
-import { EqlRegex, EqlSingle, LabelName, MatchOp, Neq, NeqRegex, StringLiteral } from '@prometheus-io/lezer-promql';
+import {
+  EqlRegex,
+  EqlSingle,
+  LabelName,
+  MatchOp,
+  Neq,
+  NeqRegex,
+  StringLiteral,
+  UnquotedLabelMatcher,
+  QuotedLabelMatcher,
+  QuotedLabelName,
+} from '@prometheus-io/lezer-promql';
 import { EditorState } from '@codemirror/state';
 import { Matcher } from '../types';
 
 function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
   const matcher = new Matcher(0, '', '');
   const cursor = labelMatcher.cursor();
-  if (!cursor.next()) {
-    // weird case, that would mean the labelMatcher doesn't have any child.
-    return matcher;
-  }
-  do {
-    switch (cursor.type.id) {
-      case LabelName:
-        matcher.name = state.sliceDoc(cursor.from, cursor.to);
-        break;
-      case MatchOp:
-        const ope = cursor.node.firstChild;
-        if (ope) {
-          matcher.type = ope.type.id;
+  switch (cursor.type.id) {
+    case QuotedLabelMatcher:
+      if (!cursor.next()) {
+        // weird case, that would mean the QuotedLabelMatcher doesn't have any child.
+        return matcher;
+      }
+      do {
+        switch (cursor.type.id) {
+          case QuotedLabelName:
+            matcher.name = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
+            break;
+          case MatchOp:
+            const ope = cursor.node.firstChild;
+            if (ope) {
+              matcher.type = ope.type.id;
+            }
+            break;
+          case StringLiteral:
+            matcher.value = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
+            break;
         }
-        break;
-      case StringLiteral:
-        matcher.value = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
-        break;
-    }
-  } while (cursor.nextSibling());
+      } while (cursor.nextSibling());
+      break;
+    case UnquotedLabelMatcher:
+      if (!cursor.next()) {
+        // weird case, that would mean the UnquotedLabelMatcher doesn't have any child.
+        return matcher;
+      }
+      do {
+        switch (cursor.type.id) {
+          case LabelName:
+            matcher.name = state.sliceDoc(cursor.from, cursor.to);
+            break;
+          case MatchOp:
+            const ope = cursor.node.firstChild;
+            if (ope) {
+              matcher.type = ope.type.id;
+            }
+            break;
+          case StringLiteral:
+            matcher.value = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
+            break;
+        }
+      } while (cursor.nextSibling());
+      break;
+    case QuotedLabelName:
+      matcher.name = '__name__';
+      matcher.value = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
+      matcher.type = EqlSingle;
+      break;
+  }
   return matcher;
 }
 

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -205,12 +205,22 @@ describe('promql operations', () => {
       expectedDiag: [] as Diagnostic[],
     },
     {
+      expr: 'foo and on(test,"blub") bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
       expr: 'foo and on() bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },
     {
       expr: 'foo and ignoring(test,blub) bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo and ignoring(test,"blub") bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },
@@ -226,6 +236,11 @@ describe('promql operations', () => {
     },
     {
       expr: 'foo / on(test,blub) group_left(bar) bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo / on(test,blub) group_left("bar") bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },
@@ -822,6 +837,134 @@ describe('promql operations', () => {
     },
     {
       expr: 'sum (rate(foo[5m])) @ 456',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // with metric name in the middle
+      expr: '{a="b","foo",c~="d"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo", a="bc"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"colon:in:the:middle"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"dot.in.the.middle"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"😀 in metric name"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // quotes with escape
+      expr: '{"this is \"foo\" metric"}', // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","colon:in:the:middle"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","dot.in.the.middle"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","😀 in label name"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // quotes with escape
+      expr: '{"foo","this is \"bar\" label"="val"}', // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: 'foo{"bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 10,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", __name__="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 23,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", "__name__"="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 25,
+        },
+      ],
+    },
+    {
+      expr: '{"__name__"="foo", __name__="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 34,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", "bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          to: 14,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+        },
+      ],
+    },
+    {
+      expr: `{'foo\`metric':'bar'}`, // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{`foo\"metric`=`bar`}', // eslint-disable-line
       expectedValueType: ValueType.vector,
       expectedDiag: [],
     },

--- a/web/ui/module/codemirror-promql/src/parser/parser.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.ts
@@ -27,7 +27,6 @@ import {
   Gte,
   Gtr,
   Identifier,
-  LabelMatcher,
   LabelMatchers,
   Lss,
   Lte,
@@ -36,11 +35,14 @@ import {
   Or,
   ParenExpr,
   Quantile,
+  QuotedLabelMatcher,
+  QuotedLabelName,
   StepInvariantExpr,
   SubqueryExpr,
   Topk,
   UnaryExpr,
   Unless,
+  UnquotedLabelMatcher,
   VectorSelector,
 } from '@prometheus-io/lezer-promql';
 import { containsAtLeastOneChild } from './path-finder';
@@ -282,7 +284,11 @@ export class Parser {
 
   private checkVectorSelector(node: SyntaxNode): void {
     const matchList = node.getChild(LabelMatchers);
-    const labelMatchers = buildLabelMatchers(matchList ? matchList.getChildren(LabelMatcher) : [], this.state);
+    const labelMatcherOpts = [QuotedLabelName, QuotedLabelMatcher, UnquotedLabelMatcher];
+    let labelMatchers: Matcher[] = [];
+    for (const labelMatcherOpt of labelMatcherOpts) {
+      labelMatchers = labelMatchers.concat(buildLabelMatchers(matchList ? matchList.getChildren(labelMatcherOpt) : [], this.state));
+    }
     let vectorSelectorName = '';
     // VectorSelector ( Identifier )
     // https://github.com/promlabs/lezer-promql/blob/71e2f9fa5ae6f5c5547d5738966cd2512e6b99a8/src/promql.grammar#L200
@@ -301,6 +307,14 @@ export class Parser {
       // adding the metric name as a Matcher to avoid a false positive for this kind of expression:
       // foo{bare=''}
       labelMatchers.push(new Matcher(EqlSingle, '__name__', vectorSelectorName));
+    } else {
+      // In this case when metric name is not set outside the braces
+      // It is checking whether metric name is set twice like in :
+      // {__name__:"foo", "foo"}, {"foo", "bar"}
+      const labelMatchersMetricName = labelMatchers.filter((lm) => lm.name === '__name__');
+      if (labelMatchersMetricName.length > 1) {
+        this.addDiagnostic(node, `metric name must not be set twice: ${labelMatchersMetricName[0].value} or ${labelMatchersMetricName[1].value}`);
+      }
     }
 
     // A Vector selector must contain at least one non-empty matcher to prevent

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -97,7 +97,7 @@ binModifiers {
 }
 
 GroupingLabels {
-  "(" (LabelName ("," LabelName)* ","?)? ")"
+  "(" ((LabelName | QuotedLabelName) ("," (LabelName | QuotedLabelName))* ","?)? ")"
 }
 
 FunctionCall {
@@ -220,7 +220,7 @@ VectorSelector {
 }
 
 LabelMatchers {
-  "{" (LabelMatcher ("," LabelMatcher)* ","?)? "}"
+  "{" ((UnquotedLabelMatcher | QuotedLabelMatcher | QuotedLabelName)("," (UnquotedLabelMatcher | QuotedLabelMatcher | QuotedLabelName))* ","?)? "}"
 }
 
 MatchOp {
@@ -230,8 +230,16 @@ MatchOp {
   NeqRegex
 }
 
-LabelMatcher {
-  LabelName MatchOp StringLiteral
+UnquotedLabelMatcher {
+    LabelName MatchOp StringLiteral
+}
+
+QuotedLabelMatcher {
+    QuotedLabelName MatchOp StringLiteral
+}
+
+QuotedLabelName {
+    StringLiteral
 }
 
 StepInvariantExpr {

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -112,6 +112,54 @@ PromQL(
     )
 )
 
+# Quoted label name in grouping labels
+
+sum by("job", mode) (test_metric) / on("job") group_left sum by("job")(test_metric)
+
+==>
+
+PromQL(
+    BinaryExpr(
+        AggregateExpr(
+          AggregateOp(Sum),
+          AggregateModifier(
+            By,
+            GroupingLabels(
+                QuotedLabelName(StringLiteral),
+                LabelName
+            )
+          ),
+          FunctionCallBody(
+                VectorSelector(
+                  Identifier
+                )
+          )
+      ),
+      Div,
+        MatchingModifierClause(
+          On,
+          GroupingLabels(
+              QuotedLabelName(StringLiteral)
+          )
+          GroupLeft
+        ),
+        AggregateExpr(
+          AggregateOp(Sum),
+          AggregateModifier(
+            By,
+            GroupingLabels(
+                QuotedLabelName(StringLiteral)
+            )
+          ),
+          FunctionCallBody(
+                VectorSelector(
+                  Identifier
+                )
+          )
+        )
+    )
+)
+
 # Case insensitivity for aggregations and binop modifiers.
 
 SuM BY(testlabel1) (testmetric1) / IGNOring(testlabel2) AVG withOUT(testlabel3) (testmetric2)
@@ -226,25 +274,25 @@ PromQL(
     VectorSelector(
       Identifier,
       LabelMatchers(
-        LabelMatcher(
-          LabelName,
-          MatchOp(EqlSingle),
-          StringLiteral
+        UnquotedLabelMatcher(
+            LabelName,
+            MatchOp(EqlSingle),
+            StringLiteral
         ),
-        LabelMatcher(
-          LabelName,
-          MatchOp(Neq),
-          StringLiteral
+        UnquotedLabelMatcher(
+            LabelName,
+            MatchOp(Neq),
+            StringLiteral
         ),
-        LabelMatcher(
-          LabelName,
-          MatchOp(EqlRegex),
-          StringLiteral
+        UnquotedLabelMatcher(
+            LabelName,
+            MatchOp(EqlRegex),
+            StringLiteral
         ),
-        LabelMatcher(
-          LabelName,
-          MatchOp(NeqRegex),
-          StringLiteral
+        UnquotedLabelMatcher(
+            LabelName,
+            MatchOp(NeqRegex),
+            StringLiteral
         )
       )
     )
@@ -571,14 +619,14 @@ PromQL(NumberLiteral)
 NaN{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Trying to illegally use Inf as a metric name.
 
 Inf{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Negative offset
 
@@ -614,3 +662,24 @@ MetricName(Identifier)
 
 ==>
 PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,VectorSelector(Identifier))))
+
+# Testing quoted metric name
+
+{"metric_name"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName(StringLiteral))))
+
+# Testing quoted label name
+
+{"foo"="bar"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(QuotedLabelMatcher(QuotedLabelName(StringLiteral), MatchOp(EqlSingle), StringLiteral))))
+
+# Testing quoted metric name and label name
+
+{"metric_name", "foo"="bar"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName(StringLiteral), QuotedLabelMatcher(QuotedLabelName(StringLiteral), MatchOp(EqlSingle), StringLiteral))))


### PR DESCRIPTION
No relevant changes this time.

## Not relevant:

* [discovery(k8s): Only register client-go metrics adapters when needed](https://github.com/prometheus/prometheus/pull/13992)
* [UTF-8: updates UI parser to support UTF-8 characters](https://github.com/prometheus/prometheus/pull/13590)
* [fix(scaleway-sd): use public IPs if no private IP present](https://github.com/prometheus/prometheus/pull/13941)
* [bugfix: Decouple native histogram ingestions and protobuf parsing](https://github.com/prometheus/prometheus/pull/13987)
* [Improve comments around resending resolved alerts](https://github.com/prometheus/prometheus/pull/13990) 