### PR TITLE
Use matrix Github job to test all buildtags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         buildtags:
-          - ""
+          - slicelabels # there's no such tag when this is being written, but it makes the CI job name more obvious.
           - stringlabels
           - dedupelabels
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        buildtags:
+          - ""
+          - stringlabels
+          - dedupelabels
     runs-on: ubuntu-20.04
     steps:
       - name: Upgrade golang
@@ -27,28 +33,4 @@ jobs:
         run: mkdir web/ui/static/react && touch web/ui/static/react/index.html
 
       - name: Run Tests
-        run: GO=/usr/local/go/bin/go make common-test
-
-  test-stringlabels:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Upgrade golang
-        run: |
-          cd /tmp
-          wget https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz
-          tar -zxvf go1.21.5.linux-amd64.tar.gz
-          sudo rm -fr /usr/local/go
-          sudo mv /tmp/go /usr/local/go
-          cd -
-          ls -l /usr/bin/go
-
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-
-      # This file would normally be created by `make assets`, here we just
-      #  mock it because the file is required for the tests to pass.
-      - name: Mock building of necessary react file
-        run: mkdir web/ui/static/react && touch web/ui/static/react/index.html
-
-      - name: Run Tests -tags=stringlabels
-        run: GO=/usr/local/go/bin/go GOOPTS=-tags=stringlabels make common-test
+        run: GO=/usr/local/go/bin/go GOOPTS=-tags=${{ matrix.buildtags }} make common-test


### PR DESCRIPTION
Instead of defining a new job each time, we can just use a matrix. Useful since now we have the dedupelabels build aswell.

This also adds a test job for `dedupelabels` tag, which wasn't present before.