### PR TITLE
Use setup-go 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         run: mkdir web/ui/static/react && touch web/ui/static/react/index.html
 
       - name: Run Tests
-        run: GO=/usr/local/go/bin/go GOOPTS=-tags=${{ matrix.buildtags }} make common-test
+        run: GOOPTS=-tags=${{ matrix.buildtags }} make common-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,9 @@ jobs:
           - dedupelabels
     runs-on: ubuntu-20.04
     steps:
-      - name: Upgrade golang
-        run: |
-          cd /tmp
-          wget https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz
-          tar -zxvf go1.21.5.linux-amd64.tar.gz
-          sudo rm -fr /usr/local/go
-          sudo mv /tmp/go /usr/local/go
-          cd -
-          ls -l /usr/bin/go
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.22.1'
 
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21.5'
+          go-version: '~1.21.5'
 
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.22.1'
+          go-version: '^1.21.5'
 
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Using the pre-defined action should be faster than installing golang from scrach each time.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
