### PR TITLE
Fuzz in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,23 @@ jobs:
 
       - name: Run Tests
         run: GOOPTS=-tags=${{ matrix.buildtags }} make common-test
+
+  fuzz:
+    strategy:
+      matrix:
+        include:
+          - package: ./model/labels
+            fuzz: FuzzFastRegexMatcher_WithStaticallyDefinedRegularExpressions
+          - package: ./model/labels
+            fuzz: FuzzFastRegexMatcher_WithFuzzyRegularExpressions
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '~1.21.5'
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Fuzz
+        run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=1m ${{ matrix.package }}


### PR DESCRIPTION
There's no much value in our fuzz tests if they're not ran in CI. This adds the configuration to run them for a minute.
