### PR TITLE
GitHub Workflows: Upgrade to checkout v4.1.4

### DIFF
--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
       - name: Set docker hub repo name
         run: echo "DOCKER_REPO_NAME=$(make docker-repo-name)" >> $GITHUB_ENV
       - name: Push README to Dockerhub
@@ -37,7 +37,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
       - name: Set quay.io org name
         run: echo "DOCKER_REPO=$(echo quay.io/${GITHUB_REPOSITORY_OWNER} | tr -d '-')" >> $GITHUB_ENV
       - name: Set quay.io repo name

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: '~1.21.5'
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # This file would normally be created by `make assets`, here we just
       #  mock it because the file is required for the tests to pass.
@@ -44,7 +44,7 @@ jobs:
           go-version: '~1.21.5'
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fuzz
         run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=1m ${{ matrix.package }}

--- a/.github/workflows/ui_build_and_release.yml
+++ b/.github/workflows/ui_build_and_release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install nodejs
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Upgrade to actions/checkout v4.1.4 in our GitHub workflows. I noticed we were using inconsistent versions of it (v2, v3, v4), so why not upgrade to the latest.