### PR TITLE
Update upstream prometheus to: fix `parser.VectorSelector.String()` with empty name matcher (#14015)

### DIFF
--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -204,8 +204,8 @@ func (node *VectorSelector) String() string {
 		labelStrings = make([]string, 0, len(node.LabelMatchers)-1)
 	}
 	for _, matcher := range node.LabelMatchers {
-		// Only include the __name__ label if its equality matching and matches the name.
-		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name {
+		// Only include the __name__ label if its equality matching and matches the name, but don't skip if it's an explicit empty name matcher.
+		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name && matcher.Value != "" {
 			continue
 		}
 		labelStrings = append(labelStrings, matcher.String())

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -135,6 +135,9 @@ func TestExprString(t *testing.T) {
 		{
 			in: `a[1m] @ end()`,
 		},
+		{
+			in: `{__name__="",a="x"}`,
+		},
 	}
 
 	for _, test := range inputs {
@@ -215,6 +218,16 @@ func TestVectorSelector_String(t *testing.T) {
 				},
 			},
 			expected: `{__name__="foobar"}`,
+		},
+		{
+			name: "empty name matcher",
+			vs: VectorSelector{
+				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, ""),
+					labels.MustNewMatcher(labels.MatchEqual, "a", "x"),
+				},
+			},
+			expected: `{__name__="",a="x"}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This brings the only new commit there's in upstream Prometheus:

> Fix `parser.VectorSelector.String()` with empty name matcher (#14015)