### PR TITLE
Fix zeroOrOneCharacterStringMatcher for multibyte runes

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/DmitriyVTitov/size"
 	"github.com/dgraph-io/ristretto"
@@ -874,7 +875,7 @@ type zeroOrOneCharacterStringMatcher struct {
 
 func (m *zeroOrOneCharacterStringMatcher) Matches(s string) bool {
 	// Zero or one.
-	if len(s) > 1 {
+	if utf8.RuneCountInString(s) > 1 {
 		return false
 	}
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -90,12 +90,13 @@ var (
 		".*foo.?",
 		".?foo.+",
 		"foo.?|bar",
+		"^(?:foo.?)$",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
 		"FOO", "Foo", "OO", "Oo", "\nfoo\n", strings.Repeat("f", 20), "prometheus", "prometheus_api_v1", "prometheus_api_v1_foo",
 		"10.0.1.20", "10.0.2.10", "10.0.3.30", "10.0.4.40",
-		"foofoo0", "foofoo",
+		"foofoo0", "foofoo", "常foo0",
 
 		// Values matching / not matching the test regexps on long alternations.
 		"zQPbMkNO", "zQPbMkNo", "jyyfj00j0061", "jyyfj00j006", "jyyfj00j00612", "NNSPdvMi", "NNSPdvMiXXX", "NNSPdvMixxx", "nnSPdvMi", "nnSPdvMiXXX",


### PR DESCRIPTION
[Fuzzying found this failing testcase.](https://github.com/grafana/mimir-prometheus/actions/runs/8983349729/job/24672920674#step:4:47) One rune is still matched by regexp dot, even if it's multibyte.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
