### PR TITLE
Fuzz 10m for main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set -fuzztime=10m for 'main' branch
-        id: fuzztime
         if: github.ref == 'refs/heads/main'
         run: echo "fuzztime=10m" >> $GITHUB_ENV
 
       - name: Set -fuzztime=1m for non-'main' branches
-        id: fuzztime
         if: github.ref != 'refs/heads/main'
         run: echo "fuzztime=1m" >> $GITHUB_ENV
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,15 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
+      - name: Set -fuzztime=10m for 'main' branch
+        id: fuzztime
+        if: github.ref == 'refs/heads/main'
+        run: echo "::set-output name=fuzztime::10m"
+
+      - name: Set -fuzztime=1m for non-'main' branches
+        id: fuzztime
+        if: github.ref != 'refs/heads/main'
+        run: echo "::set-output name=fuzztime::1m"
+
       - name: Fuzz
-        run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=1m ${{ matrix.package }}
+        run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=${{ jobs.fuzztime.outputs.fuzztime }}  ${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Set -fuzztime=10m for 'main' branch
         id: fuzztime
         if: github.ref == 'refs/heads/main'
-        run: echo "fuzztime=10m" >> $GITHUB_OUTPUT
+        run: echo "fuzztime=10m" >> $GITHUB_ENV
 
       - name: Set -fuzztime=1m for non-'main' branches
         id: fuzztime
         if: github.ref != 'refs/heads/main'
-        run: echo "fuzztime=1m" >> $GITHUB_OUTPUT
+        run: echo "fuzztime=1m" >> $GITHUB_ENV
 
       - name: Fuzz
         run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=$fuzztime  ${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Set -fuzztime=10m for 'main' branch
         id: fuzztime
         if: github.ref == 'refs/heads/main'
-        run: echo "::set-output name=fuzztime::10m"
+        run: echo "fuzztime=10m" >> $GITHUB_OUTPUT
 
       - name: Set -fuzztime=1m for non-'main' branches
         id: fuzztime
         if: github.ref != 'refs/heads/main'
-        run: echo "::set-output name=fuzztime::1m"
+        run: echo "fuzztime=1m" >> $GITHUB_OUTPUT
 
       - name: Fuzz
-        run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=${{ jobs.fuzztime.outputs.fuzztime }}  ${{ matrix.package }}
+        run: go test -run=NOTHING -fuzz=${{ matrix.fuzz }} -fuzztime=$fuzztime  ${{ matrix.package }}


### PR DESCRIPTION
We don't want to wait 10m for the CI to merge a PR, but we can afford spending 10m fuzzying `main` branch.

This PR changes the `-fuzztime` arg dynamically to `10m` for `main` branch.