### PR TITLE
Check for context cancel before regex matching postings

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1816,7 +1816,12 @@ func (r *Reader) postingsForLabelMatchingV1(ctx context.Context, name string, ma
 	}
 
 	var its []Postings
+	count := 1
 	for val, offset := range e {
+		if count%1000 == 0 && ctx.Err() != nil {
+			return ErrPostings(ctx.Err())
+		}
+		count++
 		if !match(val) {
 			continue
 		}

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1818,7 +1818,7 @@ func (r *Reader) postingsForLabelMatchingV1(ctx context.Context, name string, ma
 	var its []Postings
 	count := 1
 	for val, offset := range e {
-		if count%1000 == 0 && ctx.Err() != nil {
+		if count%100 == 0 && ctx.Err() != nil {
 			return ErrPostings(ctx.Err())
 		}
 		count++

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -416,7 +416,12 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	}
 
 	var its []Postings
+	count := 1
 	for _, v := range vals {
+		if count%1000 == 0 && ctx.Err() != nil {
+			return ErrPostings(ctx.Err())
+		}
+		count++
 		if match(v) {
 			its = append(its, NewListPostings(e[v]))
 		}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -418,7 +418,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	var its []Postings
 	count := 1
 	for _, v := range vals {
-		if count%1000 == 0 && ctx.Err() != nil {
+		if count%100 == 0 && ctx.Err() != nil {
 			return ErrPostings(ctx.Err())
 		}
 		count++

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -359,7 +359,7 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexPostingsReader, m *l
 	} else {
 		count := 1
 		for _, val := range vals {
-			if count%1000 == 0 && ctx.Err() != nil {
+			if count%100 == 0 && ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			count++
@@ -393,7 +393,14 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, ma
 		// re-use the allValues slice to avoid allocations
 		// this is safe because the iteration is always ahead of the append
 		filteredValues := allValues[:0]
+		count := 1
+
 		for _, v := range allValues {
+			if count%100 == 0 && ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			count++
+
 			if m.Matches(v) {
 				filteredValues = append(filteredValues, v)
 			}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -357,7 +357,12 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexPostingsReader, m *l
 	if m.Type == labels.MatchEqual && m.Value == "" {
 		res = vals
 	} else {
+		count := 1
 		for _, val := range vals {
+			if count%1000 == 0 && ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			count++
 			if !m.Matches(val) {
 				res = append(res, val)
 			}


### PR DESCRIPTION
Regex matching can be heavy if the regex takes a lot of cycles to evaluate.
