### PR TITLE
Improve context cancellation handling in PostingsForMatchersCache

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -467,3 +467,10 @@ func (t *contextsTracker) onTrackedContextDone() {
 		t.unsafeClose(errContextsTrackerCanceled{})
 	}
 }
+
+func (t *contextsTracker) trackedContextsCount() int {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	return t.trackedCount
+}

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -292,7 +292,6 @@ func (c *PostingsForMatchersCache) onPromiseExecutionDone(ctx context.Context, k
 
 	// Do not cache if the promise execution was canceled (it gets cancelled once all the callers contexts have
 	// been canceled).
-	// TODO unit test.
 	if errors.Is(err, context.Canceled) {
 		span.AddEvent("not caching promise result because execution has been canceled")
 		c.calls.Delete(key)

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -122,14 +122,13 @@ func (c *PostingsForMatchersCache) PostingsForMatchers(ctx context.Context, ix I
 }
 
 type postingsForMatcherPromise struct {
-	done chan struct{}
-
 	// Keep track of all callers contexts in order to cancel the execution context if all
 	// callers contexts get canceled.
 	callersCtxTracker *contextsTracker
 
 	// The result of the promise is stored either in cloner or err (only of the two is valued).
 	// Do not access these fields until the done channel is closed.
+	done   chan struct{}
 	cloner *index.PostingsCloner
 	err    error
 }

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -508,6 +508,9 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled)
 		}()
 
+		// Give some time to let the 2nd request attach to the 1st one (we have no better way in tests to detect it).
+		time.Sleep(100 * time.Millisecond)
+
 		close(cancelRequests)
 		wg.Wait()
 

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -572,6 +572,24 @@ func TestContextsTracker(t *testing.T) {
 		// We expect the 2nd context deadline to expire immediately.
 		requireContextsTrackerExecutionContextDone(t, execCtx, true)
 	})
+
+	t.Run("add() context to tracker but the tracker is already closed", func(t *testing.T) {
+		t.Parallel()
+
+		tracker, execCtx := newContextsTracker()
+		t.Cleanup(tracker.close)
+
+		requireContextsTrackerExecutionContextDone(t, execCtx, false)
+
+		require.True(t, tracker.add(context.Background()))
+		requireContextsTrackerExecutionContextDone(t, execCtx, false)
+
+		tracker.close()
+		requireContextsTrackerExecutionContextDone(t, execCtx, true)
+
+		require.False(t, tracker.add(context.Background()))
+		requireContextsTrackerExecutionContextDone(t, execCtx, true)
+	})
 }
 
 // TODO add concurrency test


### PR DESCRIPTION
The `PostingsForMatchersCache` has a comment that says:

```
// FIXME: do we need to cancel the call to postingsForMatchers if all the callers waiting for the result have
// cancelled their context?
```

During the weekend we learned the hard way that, yes, we should. The reason is that the underlying `PostingsForMatchers()` honor context cancellation, but when it's called through the single flight promise used by the cache, we run it with a new `context.Background()` and so it never gets canceled.

If the execution of the underlying `PostingsForMatchers()` takes a very long time (e.g. due to an insanely complex regexp), then it's undesirable keep it running if the request has been canceled. We prefer to cancel the `PostingsForMatchers()` execution.

This PR addresses it.