### PR TITLE
metalabels: move label matching in separate metadata.go

### DIFF
--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -744,7 +744,7 @@ func TestRemoteWriteWithNewMetadata(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 	require.Equal(t, http.StatusNoContent, recorder.Code)
-	require.Equal(t, uint64(2), db.Head().NumSeries())
+	require.Equal(t, uint64(1), db.Head().NumSeries())
 }
 
 func BenchmarkRemoteWriteOOOSamples(b *testing.B) {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -327,6 +327,13 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		return 0, storage.ErrOutOfBounds
 	}
 
+	// here we need to separate metalabels from normal labels
+	// and store them in the metadata store
+	// if the metadata store is enabled
+	metaLabels, lset := seperateMetaLabels(lset)
+	if metaLabels.Len() > 0 {
+		fmt.Println("TODO: write metadata to the metadata store, now we simply drop meta labels")
+	}
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
 	if s == nil {
 		var err error

--- a/tsdb/metadata.go
+++ b/tsdb/metadata.go
@@ -1,0 +1,43 @@
+package tsdb
+
+import (
+	"github.com/grafana/regexp"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const metaDataPrefix = `^__metadata__`
+
+func seperateMetaMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
+	// here we get the posting matches metadata
+	re := regexp.MustCompile(metaDataPrefix)
+
+	// get the label matchers related to metadata
+	metaMatchers := make([]*labels.Matcher, 0)
+	normalMatchers := make([]*labels.Matcher, 0)
+	for _, m := range ms {
+		if re.MatchString(m.Name) {
+			metaMatchers = append(metaMatchers, m)
+		} else {
+			normalMatchers = append(normalMatchers, m)
+		}
+	}
+	return metaMatchers, normalMatchers
+}
+
+func seperateMetaLabels(lbs labels.Labels) (labels.Labels, labels.Labels) {
+	// here we get the posting matches metadata
+	re := regexp.MustCompile(metaDataPrefix)
+
+	// get the label matchers related to metadata
+	metaLabels := []labels.Label{}
+	normalLabels := []labels.Label{}
+	lbs.Range(func(l labels.Label) {
+		if re.MatchString(l.Name) {
+			metaLabels = append(metaLabels, l)
+		} else {
+			normalLabels = append(normalLabels, l)
+		}
+	})
+	return labels.New(metaLabels...), labels.New(normalLabels...)
+}


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Separate metalabel filtering from the querier and head appender, placing it into its own file.