### PR TITLE
OTLP: Add metadata labels for resource attributes

### DIFF
--- a/model/labels/meta.go
+++ b/model/labels/meta.go
@@ -1,0 +1,17 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+// MetadataPrefix is the prefix for metadata labels.
+const MetadataPrefix = `^__metadata__`

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -67,6 +67,30 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "metric_attr",
 					Value: "metric value",
 				},
+				{
+					Name:  "___metadata__otel_res_attr_metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_instance",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_instance_id",
+					Value: "service ID",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_name",
+					Value: "service name",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_job",
+					Value: "resource value",
+				},
 			},
 		},
 		{
@@ -91,6 +115,30 @@ func TestCreateAttributes(t *testing.T) {
 				},
 				{
 					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_instance",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_instance_id",
+					Value: "service ID",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_name",
+					Value: "service name",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_job",
 					Value: "resource value",
 				},
 			},
@@ -119,6 +167,30 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "metric_attr",
 					Value: "metric value",
 				},
+				{
+					Name:  "___metadata__otel_res_attr_metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_instance",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_instance_id",
+					Value: "service ID",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_name",
+					Value: "service name",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_job",
+					Value: "resource value",
+				},
 			},
 		},
 		{
@@ -144,6 +216,30 @@ func TestCreateAttributes(t *testing.T) {
 				{
 					Name:  "metric_attr",
 					Value: "metric value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_instance",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_instance_id",
+					Value: "service ID",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_service_name",
+					Value: "service name",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "___metadata__otel_res_attr_job",
+					Value: "resource value",
 				},
 			},
 		},

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -714,6 +714,7 @@ func TestRemoteWriteWithNewMetadata(t *testing.T) {
 
 	handler := NewWriteHandler(log.NewNopLogger(), nil, db.Head(), []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1})
 
+	// The same time series, but the __metadata__node__ip label changes for the second sample.
 	ts := []prompb.TimeSeries{
 		{
 			Labels: []prompb.Label{

--- a/tsdb/metadata.go
+++ b/tsdb/metadata.go
@@ -6,11 +6,9 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-const metaDataPrefix = `^__metadata__`
-
 func seperateMetaMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
 	// here we get the posting matches metadata
-	re := regexp.MustCompile(metaDataPrefix)
+	re := regexp.MustCompile(labels.MetadataPrefix)
 
 	// get the label matchers related to metadata
 	metaMatchers := make([]*labels.Matcher, 0)
@@ -27,7 +25,7 @@ func seperateMetaMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Ma
 
 func seperateMetaLabels(lbs labels.Labels) (labels.Labels, labels.Labels) {
 	// here we get the posting matches metadata
-	re := regexp.MustCompile(metaDataPrefix)
+	re := regexp.MustCompile(labels.MetadataPrefix)
 
 	// get the label matchers related to metadata
 	metaLabels := []labels.Label{}


### PR DESCRIPTION
In the OTLP endpoint, add metadata labels for OTel resource attributes.