### PR TITLE
Metalabels working with stringlabels

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -204,7 +204,9 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 		h.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	builder.Assign(s.labels())
+	s.labels().Range(func(l labels.Label) {
+		builder.Add(l.Name, l.Value)
+	})
 
 	if chks == nil {
 		return nil
@@ -300,9 +302,9 @@ func (h *headMetaIndexReader) Series(ref storage.SeriesRef, builder *labels.Scra
 		h.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	for _, ss := range s.labels() {
-		builder.Add(ss.Name, ss.Value)
-	}
+	s.labels().Range(func(l labels.Label) {
+		builder.Add(l.Name, l.Value)
+	})
 	return nil
 }
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -649,6 +649,7 @@ func (b *blockBaseSeriesSet) Next() bool {
 	for b.p.Next() {
 		metaIdx := b.seriesMetaMappingIdx
 		b.seriesMetaMappingIdx++
+		b.builder.Reset()
 		if err := b.index.Series(b.p.At(), &b.builder, &b.bufChks); err != nil {
 			// Postings may be stale. Skip if no underlying series exists.
 			if errors.Is(err, storage.ErrNotFound) {
@@ -724,12 +725,12 @@ func (b *blockBaseSeriesSet) Next() bool {
 			_ = b.metaInfo.hmir.Series(b.metaInfo.seriesMetaMapping[metaIdx][1], &b.builder, nil)
 			lbls := b.builder.Labels()
 			b.builder.Reset()
-			for _, l := range lbls {
+			lbls.Range(func(l labels.Label) {
 				if strings.HasPrefix(l.Name, "__metalabel__") && !b.metaInfo.metaNames[l.Name] {
-					continue
+					return
 				}
 				b.builder.Add(l.Name, l.Value)
-			}
+			})
 			b.builder.Sort()
 		}
 		b.curr.labels = b.builder.Labels()


### PR DESCRIPTION
There is a slight difference in how the methods for normal and stringlabels work. This PR fixes queries when stringlabels is used.