### PR TITLE
OTLP: Insert created timestamp if starttimestamp is within interval

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -21,7 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
@@ -42,6 +45,12 @@ type Settings struct {
 	EnableCreatedTimestampZeroIngestion bool
 }
 
+type StartTsAndTs struct {
+	StartTs int64
+	Ts      int64
+	Labels  []prompb.Label
+}
+
 // PrometheusConverter converts from OTel write format to Prometheus remote write format.
 type PrometheusConverter struct {
 	unique    map[uint64]*prompb.TimeSeries
@@ -57,7 +66,7 @@ func NewPrometheusConverter() *PrometheusConverter {
 }
 
 // FromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metrics, settings Settings) (annots annotations.Annotations, errs error) {
+func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metrics, settings Settings, logger log.Logger) (annots annotations.Annotations, errs error) {
 	c.everyN = everyNTimes{n: 128}
 	resourceMetricsSlice := md.ResourceMetrics()
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
@@ -108,7 +117,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
 						break
 					}
-					if err := c.addSumNumberDataPoints(ctx, dataPoints, resource, metric, settings, promName); err != nil {
+					if err := c.addSumNumberDataPoints(ctx, dataPoints, resource, metric, settings, promName, logger); err != nil {
 						errs = multierr.Append(errs, err)
 						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 							return
@@ -225,4 +234,23 @@ func (c *PrometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Lab
 	ts, _ := c.getOrCreateTimeSeries(lbls)
 	ts.Samples = append(ts.Samples, *sample)
 	return ts
+}
+
+// TODO(jesus.vazquez) This method is for debugging only and its meant to be removed soon.
+// trackStartTimestampForSeries logs the start timestamp for a series if it has been seen before.
+func (c *PrometheusConverter) trackStartTimestampForSeries(startTs, ts int64, lbls []prompb.Label, logger log.Logger) {
+	h := timeSeriesSignature(lbls)
+	if _, ok := c.unique[h]; ok {
+		var seriesBuilder strings.Builder
+		seriesBuilder.WriteString("{")
+		for i, l := range lbls {
+			if i > 0 {
+				seriesBuilder.WriteString(",")
+			}
+			seriesBuilder.WriteString(fmt.Sprintf("%s=%s", l.Name, l.Value))
+
+		}
+		seriesBuilder.WriteString("}")
+		level.Debug(logger).Log("labels", seriesBuilder.String(), "start_ts", startTs, "ts", ts)
+	}
 }

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -36,7 +37,7 @@ func TestFromMetrics(t *testing.T) {
 		cancel()
 		payload := createExportRequest(5, 128, 128, 2, 0)
 
-		_, err := converter.FromMetrics(ctx, payload.Metrics(), Settings{})
+		_, err := converter.FromMetrics(ctx, payload.Metrics(), Settings{}, log.NewNopLogger())
 		require.ErrorIs(t, err, context.Canceled)
 	})
 
@@ -47,7 +48,7 @@ func TestFromMetrics(t *testing.T) {
 		t.Cleanup(cancel)
 		payload := createExportRequest(5, 128, 128, 2, 0)
 
-		_, err := converter.FromMetrics(ctx, payload.Metrics(), Settings{})
+		_, err := converter.FromMetrics(ctx, payload.Metrics(), Settings{}, log.NewNopLogger())
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
@@ -74,7 +75,7 @@ func TestFromMetrics(t *testing.T) {
 		}
 
 		converter := NewPrometheusConverter()
-		annots, err := converter.FromMetrics(context.Background(), request.Metrics(), Settings{})
+		annots, err := converter.FromMetrics(context.Background(), request.Metrics(), Settings{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.NotEmpty(t, annots)
 		ws, infos := annots.AsStrings("", 0, 0)
@@ -107,7 +108,7 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 
 											for i := 0; i < b.N; i++ {
 												converter := NewPrometheusConverter()
-												annots, err := converter.FromMetrics(context.Background(), payload.Metrics(), Settings{})
+												annots, err := converter.FromMetrics(context.Background(), payload.Metrics(), Settings{}, log.NewNopLogger())
 												require.NoError(b, err)
 												require.Empty(b, annots)
 												require.NotNil(b, converter.TimeSeries())

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -73,6 +73,7 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 
 		pt := dataPoints.At(x)
 		startTimestampNs := pt.StartTimestamp()
+		startTimestampMs := convertTimeStamp(pt.StartTimestamp())
 		lbls := createAttributes(
 			resource,
 			pt.Attributes(),
@@ -97,7 +98,7 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 		}
 		isMonotonic := metric.Sum().IsMonotonic()
 		if isMonotonic {
-			c.handleStartTime(convertTimeStamp(startTimestampNs), timestamp, sample.Value, lbls, settings)
+			c.handleStartTime(startTimestampMs, timestamp, lbls, settings)
 		}
 		ts := c.addSample(sample, lbls)
 		if ts != nil {
@@ -122,7 +123,7 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 					break
 				}
 			}
-			c.addTimeSeriesIfNeeded(createdLabels, startTimestampNs, pt.Timestamp())
+			c.addTimeSeriesIfNeeded(createdLabels, startTimestampMs, pt.Timestamp())
 		}
 	}
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -255,6 +256,7 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 					EnableCreatedTimestampZeroIngestion: true,
 				},
 				metric.Name(),
+				log.NewNopLogger(),
 			)
 
 			assert.Equal(t, tt.want(), converter.unique)

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
@@ -22,10 +22,11 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/prometheus/prometheus/prompb"
 )
 
 func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
@@ -172,7 +173,6 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 					timeSeriesSignature(labels): {
 						Labels: labels,
 						Samples: []prompb.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts) - 1},
 							{Value: 1, Timestamp: convertTimeStamp(ts)},
 						},
 					},

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -518,7 +518,7 @@ func (h *otlpWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AddMetricSuffixes:                   true,
 		PromoteResourceAttributes:           otlpCfg.PromoteResourceAttributes,
 		EnableCreatedTimestampZeroIngestion: h.enableCTZeroIngestion,
-	})
+	}, h.logger)
 	if err != nil {
 		level.Warn(h.logger).Log("msg", "Error translating OTLP metrics to Prometheus write request", "err", err)
 	}

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -379,7 +380,7 @@ func TestOTLPWriteHandler(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
 	appendable := &mockAppendable{}
-	handler := NewOTLPWriteHandler(nil, appendable, func() config.Config {
+	handler := NewOTLPWriteHandler(log.NewNopLogger(), appendable, func() config.Config {
 		return config.Config{
 			OTLPConfig: config.DefaultOTLPConfig,
 		}


### PR DESCRIPTION
Relates to https://opentelemetry.io/docs/specs/otel/metrics/data-model/#resets-and-gaps and https://github.com/open-telemetry/opentelemetry-specification/issues/4184

While testing [our previously introduced feature](https://github.com/grafana/mimir-prometheus/pull/684) to introduce 0's at `ts-1` when an OTLP sample had `StartTimeUnixNano == sample.timestamp` we noticed that it was not working for some usages of the OTel SDK and connectors like the spanmetrics connector.

Later we found out the reason is that it's unclear to what value `StartTImeUnixNano` should be set to when there is a reset in a cumulative stream. The links at the beginning give you more context on what the spec says and then a reasonable ask by Arthur asking to have a StartTimeUnixNano initialized per series and to the first observation.

Unfortunately it will take time to get there.

So what this PR does is to slightly modify our existing workaround of adding those zeros. Instead of writing the zero if the sample had `StartTimeUnixNano == sample.timestamp`, now it will only insert the zero if `the sample's StartTimeUnixNano is within 2 minutes of sample.Timestamp`

The downside of this approach is that we can't know the scrape interval of samples so in the case of more than 1 sample sent per minute, this workaround could lead to duplicate zero's for the same timestamp until that minute has passed. This incurs an increase of duplicate data in memory and an increase of DPM per series.
- This duplicate data in memory should be removed during compaction.