### PR TITLE
OTLP: Convert Exponential histograms start timestamps into zero samples

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -617,7 +617,7 @@ func (c *PrometheusConverter) handleHistogramStartTime(startTs, sampleTs int64, 
 		return
 	}
 
-	ts.Histograms = append(ts.Histograms, prompb.Histogram{})
+	ts.Histograms = append(ts.Histograms, prompb.Histogram{Timestamp: startTs})
 }
 
 // addResourceTargetInfo converts the resource to the target info metric.

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -599,6 +599,27 @@ func (c *PrometheusConverter) handleStartTime(startTs, ts int64, labels []prompb
 	c.addSample(&prompb.Sample{Timestamp: startTs}, labels)
 }
 
+// handleHistogramStartTime similar to the method above but for native histograms..
+func (c *PrometheusConverter) handleHistogramStartTime(startTs, sampleTs int64, ts *prompb.TimeSeries, settings Settings) {
+	if !settings.EnableCreatedTimestampZeroIngestion {
+		return
+	}
+	// We want to ignore the write in three cases.
+	// - We've seen samples with the start timestamp set to epoch meaning it wasn't set by the sender so we skip those.
+	// - If StartTimestamp equals Timestamp ist means we don't know at which time the metric restarted according to the spec.
+	// - StartTimestamp can never be greater than the sample timestamp.
+	if startTs <= 0 || startTs == sampleTs || startTs > sampleTs {
+		return
+	}
+
+	// The difference between the start and the actual timestamp is more than a reasonable time, so we skip this sample.
+	if sampleTs-startTs > validIntervalForStartTimestamps {
+		return
+	}
+
+	ts.Histograms = append(ts.Histograms, prompb.Histogram{})
+}
+
 // addResourceTargetInfo converts the resource to the target info metric.
 func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *PrometheusConverter) {
 	if settings.DisableTargetInfo || timestamp == 0 {

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -43,6 +43,9 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 		}
 
 		pt := dataPoints.At(x)
+		timestamp := convertTimeStamp(pt.Timestamp())
+		startTimestampNs := pt.StartTimestamp()
+		startTimestampMs := convertTimeStamp(startTimestampNs)
 
 		histogram, ws, err := exponentialToNativeHistogram(pt)
 		annots.Merge(ws)
@@ -60,6 +63,8 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 			promName,
 		)
 		ts, _ := c.getOrCreateTimeSeries(lbls)
+
+		c.handleHistogramStartTime(startTimestampMs, timestamp, ts, settings)
 		ts.Histograms = append(ts.Histograms, histogram)
 
 		exemplars, err := getPromExemplars[pmetric.ExponentialHistogramDataPoint](ctx, &c.everyN, pt)


### PR DESCRIPTION
Follow up PR to https://github.com/grafana/mimir-prometheus/pull/684 and https://github.com/grafana/mimir-prometheus/pull/689 where we add the same logic but for exponential histograms.

Unit tests included.