### PR TITLE
Wrap ErrNotFound in some cases to get more information

### DIFF
--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -580,7 +580,7 @@ func createChunkDiskMapper(t *testing.T, dir string) *ChunkDiskMapper {
 		dir = t.TempDir()
 	}
 
-	hrw, err := NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, writeQueueSize)
+	hrw, err := NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, writeQueueSize, nil)
 	require.NoError(t, err)
 	require.False(t, hrw.fileMaxtSet)
 	require.NoError(t, hrw.IterateAllChunks(func(_ HeadSeriesRef, _ ChunkDiskMapperRef, _, _ int64, _ uint16, _ chunkenc.Encoding, _ bool) error {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2163,7 +2163,9 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 
 	if overlapsOOO {
 		// We need to fetch from in-order and out-of-order chunks: wrap the headQuerier.
-		isoState := db.head.oooIso.TrackReadAfter(db.lastGarbageCollectedMmapRef)
+		lastGarbageCollectedMmapRef := db.lastGarbageCollectedMmapRef
+		isoState := db.head.oooIso.TrackReadAfter(lastGarbageCollectedMmapRef)
+		level.Info(db.logger).Log("tag", "missing_chunks", "msg", "got iso state for ooo head", "mint", mint, "maxt", maxt, "lastGarbageCollectedMmapRef", lastGarbageCollectedMmapRef)
 		headQuerier = NewHeadAndOOOQuerier(inoMint, mint, maxt, db.head, isoState, headQuerier)
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2132,7 +2132,7 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 
 	overlapsOOO := overlapsClosedInterval(mint, maxt, db.head.MinOOOTime(), db.head.MaxOOOTime())
 	var headQuerier storage.Querier
-	inoMint := mint
+	inoMint := max(db.head.MinTime(), mint)
 	if maxt >= db.head.MinTime() || overlapsOOO {
 		rh := NewRangeHead(db.head, mint, maxt)
 		var err error
@@ -2213,7 +2213,7 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 
 	overlapsOOO := overlapsClosedInterval(mint, maxt, db.head.MinOOOTime(), db.head.MaxOOOTime())
 	var headQuerier storage.ChunkQuerier
-	inoMint := mint
+	inoMint := max(db.head.MinTime(), mint)
 	if maxt >= db.head.MinTime() || overlapsOOO {
 		rh := NewRangeHead(db.head, mint, maxt)
 		headQuerier, err = db.blockChunkQuerierFunc(rh, mint, maxt)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -423,6 +423,7 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 	// This means that the chunk is outside the specified range.
 	if !c.OverlapsClosedInterval(mint, maxt) {
 		truncateTime := h.lastMemoryTruncationTime.Load()
+		level.Info(h.logger).Log("tag", "missing_chunks", "msg", "chunk is outside the range", "minT", mint, "maxT", maxt, "lastTruncT", truncateTime)
 		return nil, 0, fmt.Errorf("%w error: chunk is outside the range minT=%d, maxT=%d, lastTruncT=%d", storage.ErrNotFound, mint, maxt, truncateTime)
 	}
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -389,7 +389,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				tc.setup(t, series, chunkDiskMapper)
 			}
 
-			chk, headChunk, isOpen, err := series.chunk(tc.inputID, chunkDiskMapper, memChunkPool)
+			chk, headChunk, isOpen, err := series.chunk(tc.inputID, chunkDiskMapper, memChunkPool, 0, 0, 0)
 			switch tc.expected {
 			case outOpenHeadChunk:
 				require.NoError(t, err, "unexpected error")

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -377,7 +377,7 @@ func TestMemSeries_chunk(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+			chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, chunkDiskMapper.Close())

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1047,7 +1047,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 
 	require.Equal(t, int64(2000), s.mmappedChunks[0].minTime)
 	_, _, _, err = s.chunk(0, chunkDiskMapper, &memChunkPool)
-	require.Equal(t, storage.ErrNotFound, err, "first chunks not gone")
+	require.ErrorIs(t, err, storage.ErrNotFound, "first chunks not gone")
 	require.Equal(t, countBefore/2, len(s.mmappedChunks)+1) // +1 for the head chunk.
 	chk, _, _, err = s.chunk(lastID, chunkDiskMapper, &memChunkPool)
 	require.NoError(t, err)
@@ -1950,7 +1950,7 @@ func TestGCChunkAccess(t *testing.T) {
 	require.NoError(t, h.Truncate(1500)) // Remove a chunk.
 
 	_, _, err = cr.ChunkOrIterable(chunks[0])
-	require.Equal(t, storage.ErrNotFound, err)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 	_, _, err = cr.ChunkOrIterable(chunks[1])
 	require.NoError(t, err)
 }
@@ -2011,9 +2011,9 @@ func TestGCSeriesAccess(t *testing.T) {
 	require.Equal(t, (*memSeries)(nil), h.series.getByID(1))
 
 	_, _, err = cr.ChunkOrIterable(chunks[0])
-	require.Equal(t, storage.ErrNotFound, err)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 	_, _, err = cr.ChunkOrIterable(chunks[1])
-	require.Equal(t, storage.ErrNotFound, err)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 }
 
 func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
@@ -5691,7 +5691,7 @@ func TestSnapshotAheadOfWALError(t *testing.T) {
 
 	// Verify that snapshot directory does not exist anymore.
 	_, _, _, err = LastChunkSnapshot(head.opts.ChunkDirRoot)
-	require.Equal(t, record.ErrNotFound, err)
+	require.ErrorIs(t, err, record.ErrNotFound)
 
 	require.NoError(t, head.Close())
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -344,7 +344,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 
 					// Write mmapped chunks.
 					if c.mmappedChunkT != 0 {
-						chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, mmappedChunksDir(dir), chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+						chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, mmappedChunksDir(dir), chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 						require.NoError(b, err)
 						cOpts := chunkOpts{
 							chunkDiskMapper: chunkDiskMapper,
@@ -1006,7 +1006,7 @@ func TestHead_Truncate(t *testing.T) {
 func TestMemSeries_truncateChunks(t *testing.T) {
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
-	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, chunkDiskMapper.Close())
@@ -1158,7 +1158,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+			chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, chunkDiskMapper.Close())
@@ -1727,7 +1727,7 @@ func TestComputeChunkEndTime(t *testing.T) {
 func TestMemSeries_append(t *testing.T) {
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
-	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, chunkDiskMapper.Close())
@@ -1788,7 +1788,7 @@ func TestMemSeries_append(t *testing.T) {
 func TestMemSeries_appendHistogram(t *testing.T) {
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
-	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, chunkDiskMapper.Close())
@@ -1850,7 +1850,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	const samplesPerChunk = 120
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
-	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, chunkDiskMapper.Close())
@@ -3283,7 +3283,7 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 func TestIteratorSeekIntoBuffer(t *testing.T) {
 	dir := t.TempDir()
 	// This is usually taken from the Head, but passing manually here.
-	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, chunkDiskMapper.Close())

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -28,7 +28,7 @@ func TestIsolation(t *testing.T) {
 		lowWatermark uint64
 	}
 	var appendA, appendB result
-	iso := newIsolation(false)
+	iso := newIsolation(false, nil)
 
 	// Low watermark starts at 1.
 	require.Equal(t, uint64(0), iso.lowWatermark())
@@ -82,7 +82,7 @@ func countOpenReads(iso *isolation) int {
 func BenchmarkIsolation(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
-			iso := newIsolation(false)
+			iso := newIsolation(false, nil)
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})
@@ -112,7 +112,7 @@ func BenchmarkIsolation(b *testing.B) {
 func BenchmarkIsolationWithState(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
-			iso := newIsolation(false)
+			iso := newIsolation(false, nil)
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -64,7 +64,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 
 	if s == nil {
 		oh.head.metrics.seriesNotFound.Inc()
-		return storage.ErrNotFound
+		return fmt.Errorf("%w error: ooo series is missing", storage.ErrNotFound)
 	}
 	builder.Assign(s.labels())
 
@@ -247,7 +247,7 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 	s := cr.head.series.getByID(sid)
 	// This means that the series has been garbage collected.
 	if s == nil {
-		return nil, nil, 0, storage.ErrNotFound
+		return nil, nil, 0, fmt.Errorf("%w error: ooo series was garbage collected", storage.ErrNotFound)
 	}
 	var isoState *isolationState
 	if cr.cr != nil {
@@ -481,7 +481,7 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 
 	if s == nil {
 		ir.ch.head.metrics.seriesNotFound.Inc()
-		return storage.ErrNotFound
+		return fmt.Errorf("%w error: ooo series is missing in compaction head", storage.ErrNotFound)
 	}
 	builder.Assign(s.labels())
 

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -64,7 +64,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 
 	if s == nil {
 		oh.head.metrics.seriesNotFound.Inc()
-		return fmt.Errorf("%w error: ooo series is missing", storage.ErrNotFound)
+		return fmt.Errorf("%w error: ooo series is missing minT=%d, maxT=%d, lastTruncT=%d", storage.ErrNotFound, oh.mint, oh.maxt, oh.head.lastMemoryTruncationTime.Load())
 	}
 	builder.Assign(s.labels())
 
@@ -247,7 +247,7 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 	s := cr.head.series.getByID(sid)
 	// This means that the series has been garbage collected.
 	if s == nil {
-		return nil, nil, 0, fmt.Errorf("%w error: ooo series was garbage collected", storage.ErrNotFound)
+		return nil, nil, 0, fmt.Errorf("%w error: ooo series was garbage collected minT=%d, maxT=%d, lastTruncT=%d", storage.ErrNotFound, cr.mint, cr.maxt, cr.head.lastMemoryTruncationTime.Load())
 	}
 	var isoState *isolationState
 	if cr.cr != nil {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -370,7 +370,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 					require.Equal(t, expChunks, chks)
 
 					err = ir.Series(storage.SeriesRef(s1ID+1), &b, &chks)
-					require.Equal(t, storage.ErrNotFound, err)
+					require.ErrorIs(t, err, storage.ErrNotFound)
 				})
 			}
 		}
@@ -506,7 +506,7 @@ func testOOOHeadChunkReader_Chunk(t *testing.T, scenario sampleTypeScenario) {
 			Ref: 0x1800000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 300,
 		})
 		require.Nil(t, iterable)
-		require.Equal(t, err, fmt.Errorf("not found"))
+		require.ErrorIs(t, err, storage.ErrNotFound)
 		require.Nil(t, c)
 	})
 

--- a/tsdb/ooo_isolation.go
+++ b/tsdb/ooo_isolation.go
@@ -69,7 +69,7 @@ func (i *oooIsolation) HasOpenReadsAtOrBefore(ref chunks.ChunkDiskMapperRef) boo
 //
 // The caller must ensure that the returned oooIsolationState is eventually closed when
 // the read is complete.
-func (i *oooIsolation) TrackReadAfter(minRef chunks.ChunkDiskMapperRef) *oooIsolationState {
+func (i *oooIsolation) TrackReadAfter(minRef chunks.ChunkDiskMapperRef, mint int64, maxt int64) *oooIsolationState {
 	s := &oooIsolationState{
 		i:      i,
 		minRef: minRef,
@@ -77,7 +77,7 @@ func (i *oooIsolation) TrackReadAfter(minRef chunks.ChunkDiskMapperRef) *oooIsol
 
 	i.mtx.Lock()
 	s.e = i.openReads.PushBack(s)
-	level.Info(s.i.logger).Log("tag", "missing_chunks", "msg", "appended to ooo isolation state", "minRef", minRef)
+	level.Info(s.i.logger).Log("tag", "missing_chunks", "msg", "appended to ooo isolation state", "minRef", minRef, "mint", mint, "maxt", maxt)
 	i.mtx.Unlock()
 
 	return s

--- a/tsdb/ooo_isolation_test.go
+++ b/tsdb/ooo_isolation_test.go
@@ -29,13 +29,13 @@ func TestOOOIsolation(t *testing.T) {
 	require.False(t, i.HasOpenReadsAtOrBefore(3))
 
 	// Add a read.
-	read1 := i.TrackReadAfter(1)
+	read1 := i.TrackReadAfter(1, 0, 0)
 	require.False(t, i.HasOpenReadsAtOrBefore(0))
 	require.False(t, i.HasOpenReadsAtOrBefore(1))
 	require.True(t, i.HasOpenReadsAtOrBefore(2))
 
 	// Add another overlapping read.
-	read2 := i.TrackReadAfter(0)
+	read2 := i.TrackReadAfter(0, 0, 0)
 	require.False(t, i.HasOpenReadsAtOrBefore(0))
 	require.True(t, i.HasOpenReadsAtOrBefore(1))
 	require.True(t, i.HasOpenReadsAtOrBefore(2))

--- a/tsdb/ooo_isolation_test.go
+++ b/tsdb/ooo_isolation_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestOOOIsolation(t *testing.T) {
-	i := newOOOIsolation()
+	i := newOOOIsolation(nil)
 
 	// Empty state shouldn't have any open reads.
 	require.False(t, i.HasOpenReadsAtOrBefore(0))

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3238,7 +3238,7 @@ func BenchmarkQueries(b *testing.B) {
 
 					qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
 					require.NoError(b, err)
-					isoState := head.oooIso.TrackReadAfter(0)
+					isoState := head.oooIso.TrackReadAfter(0, 0, 0)
 					qOOOHead := NewHeadAndOOOQuerier(1, 1, nSamples, head, isoState, qHead)
 
 					queryTypes = append(queryTypes, qt{


### PR DESCRIPTION
Update tests to use ErrorIs and not equal. This could go upstream as the query code uses ErrorIs anyway so the tests are inconsistent with the production code.
