### PR TITLE
OTLP: Disable handle starttime samples for Exponential Histograms

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -564,8 +564,8 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 func TestPrometheusConverter_AddExponentialHistogramDataPoints(t *testing.T) {
 	now := time.Now()
 	nowUnixNano := pcommon.Timestamp(now.UnixNano())
-	nowMinus2m30s := pcommon.Timestamp(now.Add(-2 * time.Minute).Add(-30 * time.Second).UnixNano())
-	nowMinus6m := pcommon.Timestamp(now.Add(-6 * time.Minute).UnixNano())
+	// nowMinus2m30s := pcommon.Timestamp(now.Add(-2 * time.Minute).Add(-30 * time.Second).UnixNano())
+	// nowMinus6m := pcommon.Timestamp(now.Add(-6 * time.Minute).UnixNano())
 	nowMinus1h := pcommon.Timestamp(now.Add(-1 * time.Hour).UnixNano())
 	tests := []struct {
 		overrideValidInterval time.Duration
@@ -644,85 +644,86 @@ func TestPrometheusConverter_AddExponentialHistogramDataPoints(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "histogram with start time within default valid interval to sample timestamp",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_exponential_hist")
-				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		//  TODO(@jesusvazquez) Reenable after OOO NH is stable
+		// {
+		// 	name: "histogram with start time within default valid interval to sample timestamp",
+		// 	metric: func() pmetric.Metric {
+		// 		metric := pmetric.NewMetric()
+		// 		metric.SetName("test_exponential_hist")
+		// 		metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
-				pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
-				pt.SetTimestamp(nowUnixNano)
-				pt.SetStartTimestamp(nowMinus2m30s)
+		// 		pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+		// 		pt.SetTimestamp(nowUnixNano)
+		// 		pt.SetStartTimestamp(nowMinus2m30s)
 
-				return metric
-			},
-			want: func() map[uint64]*prompb.TimeSeries {
-				labels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_exponential_hist"},
-				}
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(labels): {
-						Labels: labels,
-						Histograms: []prompb.Histogram{
-							{
-								Timestamp: convertTimeStamp(nowMinus2m30s),
-							},
-							{
-								Timestamp: convertTimeStamp(nowUnixNano),
-								Count: &prompb.Histogram_CountInt{
-									CountInt: 0,
-								},
-								ZeroCount: &prompb.Histogram_ZeroCountInt{
-									ZeroCountInt: 0,
-								},
-								ZeroThreshold: defaultZeroThreshold,
-							},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "histogram with start time within overiden valid interval to sample timestamp",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_exponential_hist")
-				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		// 		return metric
+		// 	},
+		// 	want: func() map[uint64]*prompb.TimeSeries {
+		// 		labels := []prompb.Label{
+		// 			{Name: model.MetricNameLabel, Value: "test_exponential_hist"},
+		// 		}
+		// 		return map[uint64]*prompb.TimeSeries{
+		// 			timeSeriesSignature(labels): {
+		// 				Labels: labels,
+		// 				Histograms: []prompb.Histogram{
+		// 					{
+		// 						Timestamp: convertTimeStamp(nowMinus2m30s),
+		// 					},
+		// 					{
+		// 						Timestamp: convertTimeStamp(nowUnixNano),
+		// 						Count: &prompb.Histogram_CountInt{
+		// 							CountInt: 0,
+		// 						},
+		// 						ZeroCount: &prompb.Histogram_ZeroCountInt{
+		// 							ZeroCountInt: 0,
+		// 						},
+		// 						ZeroThreshold: defaultZeroThreshold,
+		// 					},
+		// 				},
+		// 			},
+		// 		}
+		// 	},
+		// },
+		// {
+		// 	name: "histogram with start time within overiden valid interval to sample timestamp",
+		// 	metric: func() pmetric.Metric {
+		// 		metric := pmetric.NewMetric()
+		// 		metric.SetName("test_exponential_hist")
+		// 		metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
-				pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
-				pt.SetTimestamp(nowUnixNano)
-				pt.SetStartTimestamp(nowMinus6m)
+		// 		pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+		// 		pt.SetTimestamp(nowUnixNano)
+		// 		pt.SetStartTimestamp(nowMinus6m)
 
-				return metric
-			},
-			want: func() map[uint64]*prompb.TimeSeries {
-				labels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_exponential_hist"},
-				}
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(labels): {
-						Labels: labels,
-						Histograms: []prompb.Histogram{
-							{
-								Timestamp: convertTimeStamp(nowMinus6m),
-							},
-							{
-								Timestamp: convertTimeStamp(nowUnixNano),
-								Count: &prompb.Histogram_CountInt{
-									CountInt: 0,
-								},
-								ZeroCount: &prompb.Histogram_ZeroCountInt{
-									ZeroCountInt: 0,
-								},
-								ZeroThreshold: defaultZeroThreshold,
-							},
-						},
-					},
-				}
-			},
-			overrideValidInterval: 10 * time.Minute,
-		},
+		// 		return metric
+		// 	},
+		// 	want: func() map[uint64]*prompb.TimeSeries {
+		// 		labels := []prompb.Label{
+		// 			{Name: model.MetricNameLabel, Value: "test_exponential_hist"},
+		// 		}
+		// 		return map[uint64]*prompb.TimeSeries{
+		// 			timeSeriesSignature(labels): {
+		// 				Labels: labels,
+		// 				Histograms: []prompb.Histogram{
+		// 					{
+		// 						Timestamp: convertTimeStamp(nowMinus6m),
+		// 					},
+		// 					{
+		// 						Timestamp: convertTimeStamp(nowUnixNano),
+		// 						Count: &prompb.Histogram_CountInt{
+		// 							CountInt: 0,
+		// 						},
+		// 						ZeroCount: &prompb.Histogram_ZeroCountInt{
+		// 							ZeroCountInt: 0,
+		// 						},
+		// 						ZeroThreshold: defaultZeroThreshold,
+		// 					},
+		// 				},
+		// 			},
+		// 		}
+		// 	},
+		// 	overrideValidInterval: 10 * time.Minute,
+		// },
 		{
 			name: "histogram with start time older than default valid interval to sample timestamp",
 			metric: func() pmetric.Metric {

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -43,9 +43,6 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 		}
 
 		pt := dataPoints.At(x)
-		timestamp := convertTimeStamp(pt.Timestamp())
-		startTimestampNs := pt.StartTimestamp()
-		startTimestampMs := convertTimeStamp(startTimestampNs)
 
 		histogram, ws, err := exponentialToNativeHistogram(pt)
 		annots.Merge(ws)
@@ -64,7 +61,6 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 		)
 		ts, _ := c.getOrCreateTimeSeries(lbls)
 
-		c.handleHistogramStartTime(startTimestampMs, timestamp, ts, settings)
 		ts.Histograms = append(ts.Histograms, histogram)
 
 		exemplars, err := getPromExemplars[pmetric.ExponentialHistogramDataPoint](ctx, &c.everyN, pt)


### PR DESCRIPTION
This PR undoes https://github.com/grafana/mimir-prometheus/pull/699 because OOO for NH is still WIP and this causes a lot of out of order errors. 

We can revert this PR when OOO NH is production ready again,

cc @lamida @krajorama @fionaliao 