### PR TITLE
Implement index.MaybeRecyclePostings (r313)

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -508,6 +508,7 @@ func analyzeBlock(ctx context.Context, path, blockID string, limit int, runExten
 
 	chks := []chunks.Meta{}
 	builder := labels.ScratchBuilder{}
+	defer index.MaybeRecyclePostings(p)
 	for p.Next() {
 		if err = ir.Series(p.At(), &builder, &chks); err != nil {
 			return err
@@ -636,6 +637,7 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 	histogramChunkSize := make([]int, 0)
 	histogramChunkBucketsCount := make([]int, 0)
 	var builder labels.ScratchBuilder
+	defer index.MaybeRecyclePostings(postingsr)
 	for postingsr.Next() {
 		var chks []chunks.Meta
 		if err := indexr.Series(postingsr.At(), &builder, &chks); err != nil {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -629,6 +629,7 @@ func (pb *Block) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Mat
 	if err != nil {
 		return fmt.Errorf("select series: %w", err)
 	}
+	defer index.MaybeRecyclePostings(p)
 
 	ir := pb.indexr
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1548,6 +1548,7 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	}
 
 	var stones []tombstones.Stone
+	defer index.MaybeRecyclePostings(p)
 	for p.Next() {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("select series: %w", err)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -133,6 +133,7 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 	series := make([]*memSeries, 0, 128)
 
 	// Fetch all the series only once.
+	defer index.MaybeRecyclePostings(p)
 	for p.Next() {
 		s := h.head.series.getByID(chunks.HeadSeriesRef(p.At()))
 		if s == nil {
@@ -165,7 +166,7 @@ func (h *headIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCou
 	}
 
 	out := make([]storage.SeriesRef, 0, 128)
-
+	defer index.MaybeRecyclePostings(p)
 	for p.Next() {
 		s := h.head.series.getByID(chunks.HeadSeriesRef(p.At()))
 		if s == nil {
@@ -299,6 +300,7 @@ func (h *headIndexReader) LabelValueFor(_ context.Context, id storage.SeriesRef,
 func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postings) ([]string, error) {
 	namesMap := make(map[string]struct{})
 	i := 0
+	defer index.MaybeRecyclePostings(series)
 	for series.Next() {
 		i++
 		if i%checkContextEveryNIterations == 0 && ctx.Err() != nil {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1575,6 +1575,7 @@ func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string
 	// Gather offsetsMap the name offsetsMap in the symbol table first
 	offsetsMap := make(map[uint32]struct{})
 	i := 0
+	defer MaybeRecyclePostings(postings)
 	for postings.Next() {
 		id := postings.At()
 		i++
@@ -1869,6 +1870,7 @@ func (r *Reader) ShardedPostings(p Postings, shardIndex, shardCount uint64) Post
 		seriesHashCache = r.cacheProvider.SeriesHashCache()
 	}
 
+	defer MaybeRecyclePostings(p)
 	for p.Next() {
 		id := p.At()
 

--- a/tsdb/index/labelvalues.go
+++ b/tsdb/index/labelvalues.go
@@ -270,6 +270,8 @@ func (p *MemPostings) labelValuesFor(postings Postings, name string, includeMatc
 
 // intersect returns whether p1 and p2 have at least one series in common.
 func intersect(p1, p2 Postings) bool {
+	defer MaybeRecyclePostings(p1)
+	defer MaybeRecyclePostings(p2)
 	if !p1.Next() || !p2.Next() {
 		return false
 	}
@@ -302,6 +304,8 @@ func intersect(p1, p2 Postings) bool {
 
 // contains returns whether subp is contained in p.
 func contains(p, subp Postings) bool {
+	defer MaybeRecyclePostings(p)
+	defer MaybeRecyclePostings(subp)
 	for subp.Next() {
 		if needle := subp.At(); !p.Seek(needle) || p.At() != needle {
 			return false

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -513,6 +513,7 @@ func Intersect(its ...Postings) Postings {
 	}
 	for _, p := range its {
 		if p == EmptyPostings() {
+			maybeRecycleAllPostings(its)
 			return EmptyPostings()
 		}
 	}
@@ -537,9 +538,7 @@ func newIntersectPostings(its ...Postings) *intersectPostings {
 }
 
 func (it *intersectPostings) Recycle() {
-	for _, p := range it.arr {
-		MaybeRecyclePostings(p)
-	}
+	maybeRecycleAllPostings(it.arr)
 	*it = intersectPostings{}
 	intersectPostingsPool.Put(it)
 }
@@ -627,9 +626,7 @@ func newMergedPostings(p []Postings) (m *mergedPostings, nonEmpty bool) {
 }
 
 func (it *mergedPostings) Recycle() {
-	for _, p := range it.p {
-		MaybeRecyclePostings(p)
-	}
+	maybeRecycleAllPostings(it.p)
 	*it = mergedPostings{}
 	mergedPostingsPool.Put(it)
 }
@@ -677,6 +674,7 @@ func (it mergedPostings) Err() error {
 // are not in the drop list.
 func Without(full, drop Postings) Postings {
 	if full == EmptyPostings() {
+		MaybeRecyclePostings(drop)
 		return EmptyPostings()
 	}
 
@@ -1074,6 +1072,12 @@ func (h *postingsWithIndexHeap) Pop() interface{} {
 	x := old[n-1]
 	*h = old[0 : n-1]
 	return x
+}
+
+func maybeRecycleAllPostings(ps []Postings) {
+	for _, p := range ps {
+		MaybeRecyclePostings(p)
+	}
 }
 
 func MaybeRecyclePostings(p Postings) {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -124,8 +124,8 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 }
 
 func TestIntersect(t *testing.T) {
-	a := newListPostings(1, 2, 3)
-	b := newListPostings(2, 3, 4)
+	a := func() Postings { return newListPostings(1, 2, 3) }
+	b := func() Postings { return newListPostings(2, 3, 4) }
 
 	cases := []struct {
 		in []Postings
@@ -137,31 +137,31 @@ func TestIntersect(t *testing.T) {
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{a, b, EmptyPostings()},
+			in:  []Postings{a(), b(), EmptyPostings()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{b, a, EmptyPostings()},
+			in:  []Postings{b(), a(), EmptyPostings()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{EmptyPostings(), b, a},
+			in:  []Postings{EmptyPostings(), b(), a()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{EmptyPostings(), a, b},
+			in:  []Postings{EmptyPostings(), a(), b()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{a, EmptyPostings(), b},
+			in:  []Postings{a(), EmptyPostings(), b()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{b, EmptyPostings(), a},
+			in:  []Postings{b(), EmptyPostings(), a()},
 			res: EmptyPostings(),
 		},
 		{
-			in:  []Postings{b, EmptyPostings(), a, a, b, a, a, a},
+			in:  []Postings{b(), EmptyPostings(), a(), a(), b(), a(), a(), a()},
 			res: EmptyPostings(),
 		},
 		{

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -335,6 +335,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 	p = hr.SortedPostings(p)
 
 	var lastSeq, lastOff int
+	defer index.MaybeRecyclePostings(p)
 	for p.Next() {
 		seriesRef := p.At()
 		ms := head.series.getByID(chunks.HeadSeriesRef(seriesRef))

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -426,6 +426,7 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, ma
 		return allValues, nil
 	}
 
+	// p will be recycled by the FindIntersectingPostings call below.
 	p, err := r.PostingsForMatchers(ctx, false, matchers...)
 	if err != nil {
 		return nil, fmt.Errorf("fetching postings for matchers: %w", err)
@@ -456,11 +457,13 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, ma
 		}
 
 		// If we haven't reached end of postings, we prepend our expanded postings to "p", and continue.
+		// p will be recycled by the FindIntersectingPostings call below.
 		p = newPrependPostings(expanded, p)
 	}
 
 	valuesPostings := make([]index.Postings, len(allValues))
 	for i, value := range allValues {
+		// valuesPostings[i], will be recycled by the FindIntersectingPostings call below.
 		valuesPostings[i], err = r.Postings(ctx, name, value)
 		if err != nil {
 			return nil, fmt.Errorf("fetching postings for %s=%q: %w", name, value, err)


### PR DESCRIPTION
This method would call an optional Recycle() method on the postings, that would reuse the reference by putting it into a pool.

The heuristic I've followed is that it should be called by the method that performs the Next() check, as it's that method who knows that postings can't be used anymore.

