### PR TITLE
Faster regexp prefixes

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -106,6 +107,7 @@ func newFastRegexMatcherWithoutCache(v string) (*FastRegexMatcher, error) {
 		}
 		// Simplify the syntax tree to run faster.
 		parsed = parsed.Simplify()
+		//fmt.Printf("%s\n", parsed.String())
 		m.re, err = regexp.Compile("^(?:" + parsed.String() + ")$")
 		if err != nil {
 			return nil, err
@@ -113,10 +115,16 @@ func newFastRegexMatcherWithoutCache(v string) (*FastRegexMatcher, error) {
 		if parsed.Op == syntax.OpConcat {
 			m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
 		}
-		if matches, caseSensitive := findSetMatches(parsed); caseSensitive {
+		matches, prefixes, caseSensitive := findSetMatches(parsed)
+		switch {
+		case len(matches) == 0 && len(prefixes) > minEqualMultiStringMatcherMapThreshold:
+			m.stringMatcher = newMatcherFromPrefixMatchers(caseSensitive, prefixes)
+		case len(matches) > 0 && caseSensitive:
 			m.setMatches = matches
+			m.stringMatcher = stringMatcherFromRegexp(parsed)
+		default:
+			m.stringMatcher = stringMatcherFromRegexp(parsed)
 		}
-		m.stringMatcher = stringMatcherFromRegexp(parsed)
 		m.matchString = m.compileMatchStringFunction()
 	}
 
@@ -164,27 +172,27 @@ func (m *FastRegexMatcher) IsOptimized() bool {
 // findSetMatches extract equality matches from a regexp.
 // Returns nil if we can't replace the regexp by only equality matchers or the regexp contains
 // a mix of case sensitive and case insensitive matchers.
-func findSetMatches(re *syntax.Regexp) (matches []string, caseSensitive bool) {
+func findSetMatches(re *syntax.Regexp) (matches []string, prefixes []prefixMatcher, caseSensitive bool) {
 	clearBeginEndText(re)
 
 	return findSetMatchesInternal(re, "")
 }
 
-func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, caseSensitive bool) {
+func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, prefixes []prefixMatcher, matchesCaseSensitive bool) {
 	switch re.Op {
 	case syntax.OpBeginText:
 		// Correctly handling the begin text operator inside a regex is tricky,
 		// so in this case we fallback to the regex engine.
-		return nil, false
+		return nil, nil, false
 	case syntax.OpEndText:
 		// Correctly handling the end text operator inside a regex is tricky,
 		// so in this case we fallback to the regex engine.
-		return nil, false
+		return nil, nil, false
 	case syntax.OpLiteral:
-		return []string{base + string(re.Rune)}, isCaseSensitive(re)
+		return []string{base + string(re.Rune)}, nil, isCaseSensitive(re)
 	case syntax.OpEmptyMatch:
 		if base != "" {
-			return []string{base}, isCaseSensitive(re)
+			return []string{base}, nil, isCaseSensitive(re)
 		}
 	case syntax.OpAlternate:
 		return findSetMatchesFromAlternate(re, base)
@@ -195,7 +203,7 @@ func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, c
 		return findSetMatchesFromConcat(re, base)
 	case syntax.OpCharClass:
 		if len(re.Rune)%2 != 0 {
-			return nil, false
+			return nil, nil, false
 		}
 		var matches []string
 		var totalSet int
@@ -206,7 +214,7 @@ func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, c
 		// In some case like negation [^0-9] a lot of possibilities exists and that
 		// can create thousands of possible matches at which points we're better off using regexp.
 		if totalSet > maxSetMatches {
-			return nil, false
+			return nil, nil, false
 		}
 		for i := 0; i+1 < len(re.Rune); i += 2 {
 			lo, hi := re.Rune[i], re.Rune[i+1]
@@ -214,30 +222,40 @@ func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, c
 				matches = append(matches, base+string(c))
 			}
 		}
-		return matches, isCaseSensitive(re)
+		return matches, nil, isCaseSensitive(re)
 	default:
-		return nil, false
+		return nil, nil, false
 	}
-	return nil, false
+	return nil, nil, false
 }
 
-func findSetMatchesFromConcat(re *syntax.Regexp, base string) (matches []string, matchesCaseSensitive bool) {
+func findSetMatchesFromConcat(re *syntax.Regexp, base string) (matches []string, prefixes []prefixMatcher, matchesCaseSensitive bool) {
 	if len(re.Sub) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 	clearCapture(re.Sub...)
 
 	matches = []string{base}
 
 	for i := 0; i < len(re.Sub); i++ {
-		var newMatches []string
+		// An OpStar at the end of the sequence of concats makes the matches so far into prefixes.
+		if i > 0 && i == len(re.Sub)-1 && re.Sub[i].Op == syntax.OpStar {
+			prefixes = make([]prefixMatcher, 0, len(matches))
+			for _, prefix := range matches {
+				right := stringMatcherFromRegexpInternal(re.Sub[i])
+				prefixes = append(prefixes, newLiteralPrefixStringMatcher(prefix, matchesCaseSensitive, right))
+			}
+			return []string{}, prefixes, matchesCaseSensitive
+		}
+
+		newMatches := []string{}
 		for j, b := range matches {
-			m, caseSensitive := findSetMatchesInternal(re.Sub[i], b)
+			m, p, caseSensitive := findSetMatchesInternal(re.Sub[i], b)
 			if m == nil {
-				return nil, false
+				return nil, nil, false
 			}
 			if tooManyMatches(newMatches, m...) {
-				return nil, false
+				return nil, nil, false
 			}
 
 			// All matches must have the same case sensitivity. If it's the first set of matches
@@ -247,25 +265,29 @@ func findSetMatchesFromConcat(re *syntax.Regexp, base string) (matches []string,
 				matchesCaseSensitive = caseSensitive
 			}
 			if matchesCaseSensitive != caseSensitive {
-				return nil, false
+				return nil, nil, false
 			}
 
 			newMatches = append(newMatches, m...)
+			if i == len(re.Sub)-1 && len(p) > 0 {
+				prefixes = append(prefixes, p...)
+			}
 		}
 		matches = newMatches
 	}
 
-	return matches, matchesCaseSensitive
+	return matches, prefixes, matchesCaseSensitive
 }
 
-func findSetMatchesFromAlternate(re *syntax.Regexp, base string) (matches []string, matchesCaseSensitive bool) {
+func findSetMatchesFromAlternate(re *syntax.Regexp, base string) (matches []string, prefixes []prefixMatcher, matchesCaseSensitive bool) {
+	matches = []string{}
 	for i, sub := range re.Sub {
-		found, caseSensitive := findSetMatchesInternal(sub, base)
+		found, foundPrefixes, caseSensitive := findSetMatchesInternal(sub, base)
 		if found == nil {
-			return nil, false
+			return nil, nil, false
 		}
 		if tooManyMatches(matches, found...) {
-			return nil, false
+			return nil, nil, false
 		}
 
 		// All matches must have the same case sensitivity. If it's the first set of matches
@@ -275,13 +297,14 @@ func findSetMatchesFromAlternate(re *syntax.Regexp, base string) (matches []stri
 			matchesCaseSensitive = caseSensitive
 		}
 		if matchesCaseSensitive != caseSensitive {
-			return nil, false
+			return nil, nil, false
 		}
 
 		matches = append(matches, found...)
+		prefixes = append(prefixes, foundPrefixes...)
 	}
 
-	return matches, matchesCaseSensitive
+	return matches, prefixes, matchesCaseSensitive
 }
 
 // clearCapture removes capture operation as they are not used for matching.
@@ -451,6 +474,11 @@ type StringMatcher interface {
 	Matches(s string) bool
 }
 
+type prefixMatcher interface {
+	StringMatcher
+	Prefix() string
+}
+
 // stringMatcherFromRegexp attempts to replace a common regexp with a string matcher.
 // It returns nil if the regexp is not supported.
 func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
@@ -549,7 +577,11 @@ func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
 			re.Sub = re.Sub[:len(re.Sub)-1]
 		}
 
-		matches, matchesCaseSensitive := findSetMatchesInternal(re, "")
+		matches, prefixes, matchesCaseSensitive := findSetMatchesInternal(re, "")
+
+		if left == nil && right == nil && len(matches) == 0 && len(prefixes) > minEqualMultiStringMatcherMapThreshold {
+			return newMatcherFromPrefixMatchers(matchesCaseSensitive, prefixes)
+		}
 
 		if len(matches) == 0 && len(re.Sub) == 2 {
 			// We have not find fixed set matches. We look for other known cases that
@@ -590,6 +622,9 @@ func stringMatcherFromRegexpInternal(re *syntax.Regexp) StringMatcher {
 					s:             match,
 					caseSensitive: matchesCaseSensitive,
 				})
+			}
+			for _, prefix := range prefixes {
+				or = append(or, prefix)
 			}
 			return orStringMatcher(or)
 
@@ -673,7 +708,7 @@ func (m *containsStringMatcher) Matches(s string) bool {
 	return false
 }
 
-func newLiteralPrefixStringMatcher(prefix string, prefixCaseSensitive bool, right StringMatcher) StringMatcher {
+func newLiteralPrefixStringMatcher(prefix string, prefixCaseSensitive bool, right StringMatcher) prefixMatcher {
 	if prefixCaseSensitive {
 		return &literalPrefixSensitiveStringMatcher{
 			prefix: prefix,
@@ -704,6 +739,10 @@ func (m *literalPrefixSensitiveStringMatcher) Matches(s string) bool {
 	return m.right.Matches(s[len(m.prefix):])
 }
 
+func (m *literalPrefixSensitiveStringMatcher) Prefix() string {
+	return m.prefix
+}
+
 // literalPrefixInsensitiveStringMatcher matches a string with the given literal case-insensitive prefix and right side matcher.
 type literalPrefixInsensitiveStringMatcher struct {
 	prefix string
@@ -719,6 +758,10 @@ func (m *literalPrefixInsensitiveStringMatcher) Matches(s string) bool {
 
 	// Ensure the right side matches.
 	return m.right.Matches(s[len(m.prefix):])
+}
+
+func (m *literalPrefixInsensitiveStringMatcher) Prefix() string {
+	return m.prefix
 }
 
 // literalSuffixStringMatcher matches a string with the given literal suffix and left side matcher.
@@ -773,6 +816,18 @@ func (m *equalStringMatcher) Matches(s string) bool {
 		return m.s == s
 	}
 	return strings.EqualFold(m.s, s)
+}
+
+func newMatcherFromPrefixMatchers(caseSensitive bool, matchers []prefixMatcher) StringMatcher {
+	minPrefixLength := math.MaxInt
+	for _, m := range matchers {
+		minPrefixLength = min(minPrefixLength, len(m.Prefix()))
+	}
+	multiMatcher := newEqualMultiStringMatcher(caseSensitive, 0, len(matchers), minPrefixLength)
+	for _, m := range matchers {
+		multiMatcher.addPrefix(m.Prefix(), caseSensitive, m)
+	}
+	return multiMatcher
 }
 
 type multiStringMatcherBuilder interface {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -887,17 +887,24 @@ func (m *equalMultiStringMapMatcher) setMatches() []string {
 }
 
 func (m *equalMultiStringMapMatcher) Matches(s string) bool {
-	s2 := s
-	if !m.caseSensitive {
-		var a [256]byte
-		s2 = toNormalisedLower(s, a[:])
+	if len(m.values) > 0 {
+		s2 := s
+		if !m.caseSensitive {
+			var a [256]byte
+			s2 = toNormalisedLower(s, a[:])
+		}
+		if _, ok := m.values[s2]; ok {
+			return true
+		}
 	}
 
-	if _, ok := m.values[s2]; ok {
-		return true
-	}
-	if m.minPrefixLen > 0 && len(s2) >= m.minPrefixLen {
-		for _, matcher := range m.prefixes[s2[:m.minPrefixLen]] {
+	if m.minPrefixLen > 0 && len(s) >= m.minPrefixLen {
+		s2 := s[:m.minPrefixLen]
+		if !m.caseSensitive {
+			var a [256]byte
+			s2 = toNormalisedLower(s[:m.minPrefixLen], a[:])
+		}
+		for _, matcher := range m.prefixes[s2] {
 			if matcher.Matches(s) {
 				return true
 			}

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -453,7 +453,8 @@ func BenchmarkToNormalizedLower(b *testing.B) {
 							}
 							b.ResetTimer()
 							for n := 0; n < b.N; n++ {
-								toNormalisedLower(inputs[n%len(inputs)])
+								var a [256]byte
+								toNormalisedLower(inputs[n%len(inputs)], a[:])
 							}
 						})
 					}
@@ -1758,6 +1759,6 @@ func TestToNormalisedLower(t *testing.T) {
 		"ſſAſſa": "ssassa",
 	}
 	for input, expectedOutput := range testCases {
-		require.Equal(t, expectedOutput, toNormalisedLower(input))
+		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
 	}
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -370,9 +370,10 @@ func TestFindSetMatches(t *testing.T) {
 			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl)
 			require.NoError(t, err)
-			matches, actualCaseSensitive := findSetMatches(parsed)
+			matches, prefixes, actualCaseSensitive := findSetMatches(parsed)
 			require.ElementsMatch(t, c.expMatches, matches)
 			require.Equal(t, c.expCaseSensitive, actualCaseSensitive)
+			require.Empty(t, prefixes)
 
 			if c.expCaseSensitive {
 				// When the regexp is case sensitive, we want to ensure that the
@@ -520,7 +521,7 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{".*foo.*bar.*", nil},
 		{`\d*`, nil},
 		{".", nil},
-		{"/|/bar.*", &literalPrefixSensitiveStringMatcher{prefix: "/", right: orStringMatcher{emptyStringMatcher{}, &literalPrefixSensitiveStringMatcher{prefix: "bar", right: anyStringWithoutNewlineMatcher{}}}}},
+		{"/|/bar.*", orStringMatcher{&equalStringMatcher{s: "/", caseSensitive: true}, &literalPrefixSensitiveStringMatcher{prefix: "/bar", right: anyStringWithoutNewlineMatcher{}}}},
 		// This one is not supported because  `stringMatcherFromRegexp` is not reentrant for syntax.OpConcat.
 		// It would make the code too complex to handle it.
 		{"(.+)/(foo.*|bar$)", nil},


### PR DESCRIPTION
Do a better job of regexps with a long series of choices followed by `.*`, like:
```
		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*|qbvKMimS.*|IecrXtPa.*|seTckYqt.*|NxnyHkgB.*|fIDlOgKb.*|UhlWIygH.*|OtNoJxHG.*|cUTkFVIV.*|mTgFIHjr.*|jQkoIDtE.*|PPMKxRXl.*|AwMfwVkQ.*|CQyMrTQJ.*|BzrqxVSi.*|nTpcWuhF.*|PertdywG.*|ZZDgCtXN.*|WWdDPyyE.*|uVtNQsKk.*|BdeCHvPZ.*|wshRnFlH.*|aOUIitIp.*|RxZeCdXT.*|CFZMslCj.*|AVBZRDxl.*|IzIGCnhw.*|ythYuWiz.*|oztXVXhl.*|VbLkwqQx.*|qvaUgyVC.*|VawUjPWC.*|ecloYJuj.*|boCLTdSU.*|uPrKeAZx.*|hrMWLWBq.*|JOnUNHRM.*|rYnujkPq.*|dDEdZhIj.*|DRrfvugG.*|yEGfDxVV.*|YMYdJWuP.*|PHUQZNWM.*|AmKNrLis.*|zTxndVfn.*|FPsHoJnc.*|EIulZTua.*|KlAPhdzg.*|ScHJJCLt.*|NtTfMzME.*|eMCwuFdo.*|SEpJVJbR.*|cdhXZeCx.*|sAVtBwRh.*|kVFEVcMI.*|jzJrxraA.*|tGLHTell.*|NNWoeSaw.*|DcOKSetX.*|UXZAJyka.*|THpMphDP.*|rizheevl.*|kDCBRidd.*|pCZZRqyu.*|pSygkitl.*|SwZGkAaW.*|wILOrfNX.*|QkwVOerj.*|kHOMxPDr.*|EwOVycJv.*|AJvtzQFS.*|yEOjKYYB.*|LizIINLL.*|JBRSsfcG.*|YPiUqqNl.*|IsdEbvee.*|MjEpGcBm.*|OxXZVgEQ.*|xClXGuxa.*|UzRCGFEb.*|buJbvfvA.*|IPZQxRet.*|oFYShsMc.*|oBHffuHO.*|bzzKrcBR.*|KAjzrGCl.*|IPUsAVls.*|OGMUMbIU.*|gyDccHuR.*|bjlalnDd.*|ZLWjeMna.*|fdsuIlxQ.*|dVXtiomV.*|XxedTjNg.*|XWMHlNoA.*|nnyqArQX.*|opfkWGhb.*|wYtnhdYb.*))",
```