### PR TITLE
Reduce PostingsForMatchersCache.expire() pressure on mutex

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -49,8 +50,9 @@ type IndexPostingsReader interface {
 // If `force` is true, then all requests go through cache, regardless of the `concurrent` param provided to the PostingsForMatchers method.
 func NewPostingsForMatchersCache(ttl time.Duration, maxItems int, maxBytes int64, force bool) *PostingsForMatchersCache {
 	b := &PostingsForMatchersCache{
-		calls:  &sync.Map{},
-		cached: list.New(),
+		calls:            &sync.Map{},
+		cached:           list.New(),
+		expireInProgress: atomic.NewBool(false),
 
 		ttl:      ttl,
 		maxItems: maxItems,
@@ -80,6 +82,10 @@ type PostingsForMatchersCache struct {
 	maxItems int
 	maxBytes int64
 	force    bool
+
+	// Signal whether there's already a call to expire() in progress, in order to avoid multiple goroutines
+	// cleaning up expired entries at the same time (1 at a time is enough).
+	expireInProgress *atomic.Bool
 
 	// timeNow is the time.Now that can be replaced for testing purposes
 	timeNow func() time.Time
@@ -247,6 +253,14 @@ func (c *PostingsForMatchersCache) expire() {
 	if c.ttl <= 0 {
 		return
 	}
+
+	// Ensure there's no other cleanup in progress. It's not a technical issue if there are two ongoing cleanups,
+	// but it's a waste of resources and it adds extra pressure to the mutex. One cleanup at a time is enough.
+	if !c.expireInProgress.CompareAndSwap(false, true) {
+		return
+	}
+
+	defer c.expireInProgress.Store(false)
 
 	c.cachedMtx.RLock()
 	if !c.shouldEvictHead() {


### PR DESCRIPTION
Currently, `PostingsForMatchersCache.expire()` is called for every single `PostingsForMatchers()` call. If the cache is full, it's expected that there's always something to expire from the cache (1 in, 1 out). However, in a high concurrency environment, there's no need to call `expire()` **concurrently**. We just need 1 goroutine to cleanup stale or over-the-capacity cached entries.

In this PR I propose a simple solution to only 1 `expire()` execution at a time.

I've added a new benchmark:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M3 Pro
                                                          │  before.txt  │              after.txt              │
                                                          │    sec/op    │   sec/op     vs base                │
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   1653.0n ± 4%   335.1n ± 8%  -79.73% (p=0.000 n=10)

                                                          │ before.txt  │              after.txt              │
                                                          │    B/op     │    B/op      vs base                │
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   1446.5 ± 0%   1004.0 ± 0%  -30.59% (p=0.000 n=10)

                                                          │ before.txt │             after.txt              │
                                                          │ allocs/op  │ allocs/op   vs base                │
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   29.00 ± 0%   20.00 ± 0%  -31.03% (p=0.000 n=10)
```