### PR TITLE
Pause more frequently and less time

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -321,7 +321,7 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 		// From time to time want some readers to go through and read their postings.
 		// It takes around 50ms to process a 1K series batch, and 120ms to process a 10K series batch (local benchmarks on an M3).
 		// It seems that a number between that 1K and 10K should be a good balance between speed and amount of pauses.
-		if i%4096 == 0 {
+		if i%512 == 0 {
 			p.mtx.Unlock()
 			// While it's tempting to just do a `time.Sleep(time.Millisecond)` here,
 			// it wouldn't ensure use that readers actually were able to get the read lock,
@@ -333,7 +333,7 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 			p.mtx.RUnlock() //nolint:staticcheck // SA2001: this is an intentionally empty critical section.
 			// Now we can wait a little bit just to increase the chance of a reader getting the lock.
 			// If we were deleting 100M series here, pausing every 4096 with 10ms sleeps would be an extra of 240s, which is negligible.
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(time.Millisecond)
 			p.mtx.Lock()
 		}
 	}


### PR DESCRIPTION
8x more frequency, 10x less time (just enough to let the scheduler run all the goroutines that are currently waiting on the mutex.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
