### PR TITLE
rules.NewGroup: Fix when no logger is passed

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -103,9 +103,13 @@ type GroupOptions struct {
 
 // NewGroup makes a new Group with the given name, options, and rules.
 func NewGroup(o GroupOptions) *Group {
-	metrics := o.Opts.Metrics
+	opts := o.Opts
+	if opts == nil {
+		opts = &ManagerOptions{}
+	}
+	metrics := opts.Metrics
 	if metrics == nil {
-		metrics = NewGroupMetrics(o.Opts.Registerer)
+		metrics = NewGroupMetrics(opts.Registerer)
 	}
 
 	key := GroupKey(o.File, o.Name)
@@ -124,13 +128,13 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc = DefaultEvalIterationFunc
 	}
 
-	concurrencyController := o.Opts.RuleConcurrencyController
+	concurrencyController := opts.RuleConcurrencyController
 	if concurrencyController == nil {
 		concurrencyController = sequentialRuleEvalController{}
 	}
 
-	if o.Opts.Logger == nil {
-		promslog.NewNopLogger()
+	if opts.Logger == nil {
+		opts.Logger = promslog.NewNopLogger()
 	}
 
 	return &Group{
@@ -141,13 +145,13 @@ func NewGroup(o GroupOptions) *Group {
 		limit:                         o.Limit,
 		rules:                         o.Rules,
 		shouldRestore:                 o.ShouldRestore,
-		opts:                          o.Opts,
+		opts:                          opts,
 		sourceTenants:                 o.SourceTenants,
 		seriesInPreviousEval:          make([]map[string]labels.Labels, len(o.Rules)),
 		done:                          make(chan struct{}),
 		managerDone:                   o.done,
 		terminated:                    make(chan struct{}),
-		logger:                        o.Opts.Logger.With("file", o.File, "group", o.Name),
+		logger:                        opts.Logger.With("file", o.File, "group", o.Name),
 		metrics:                       metrics,
 		evalIterationFunc:             evalIterationFunc,
 		concurrencyController:         concurrencyController,

--- a/rules/group_test.go
+++ b/rules/group_test.go
@@ -17,11 +17,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
+
+func TestNewGroup(t *testing.T) {
+	g := NewGroup(GroupOptions{
+		File: "test-file",
+		Name: "test-name",
+	})
+	require.Equal(t, promslog.NewNopLogger().With("file", "test-file", "group", "test-name"), g.logger)
+}
 
 func TestGroup_Equals(t *testing.T) {
 	testExpression, err := parser.ParseExpr("up")


### PR DESCRIPTION
Port Prometheus PR [rules.NewGroup: Fix when no logger is passed](https://github.com/prometheus/prometheus/pull/15356), to fix segfaults in Mimir.