### PR TITLE
MemPostings.AddBatch per Appender

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -461,7 +461,7 @@ func (a *headAppender) getOrCreate(lset labels.Labels) (s *memSeries, created bo
 	if l, dup := lset.HasDuplicateLabelNames(); dup {
 		return nil, false, fmt.Errorf(`label name "%s" is not unique: %w`, l, ErrInvalidSample)
 	}
-	s, created, err = a.head.getOrCreate(lset.Hash(), lset)
+	s, created, err = a.head.getOrCreateWithoutIndexing(lset.Hash(), lset)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1405,6 +1405,10 @@ func (a *headAppender) commitMetadata() {
 	}
 }
 
+func (a *headAppender) indexSeries() {
+	a.head.postings.AddBatch(a.series)
+}
+
 // Commit writes to the WAL and adds the data to the Head.
 // TODO(codesome): Refactor this method to reduce indentation and make it more readable.
 func (a *headAppender) Commit() (err error) {
@@ -1417,6 +1421,9 @@ func (a *headAppender) Commit() (err error) {
 		_ = a.Rollback() // Most likely the same error will happen again.
 		return fmt.Errorf("write to WAL: %w", err)
 	}
+
+	// Index series after we know we won't rollback, because rollback would also index the series.
+	a.indexSeries()
 
 	if a.head.writeNotified != nil {
 		a.head.writeNotified.Notify()
@@ -1984,7 +1991,8 @@ func (a *headAppender) Rollback() (err error) {
 	a.histograms = nil
 	a.metadata = nil
 
-	// Series are created in the head memory regardless of rollback. Thus we have
-	// to log them to the WAL in any case.
+	// Series are created in the head memory regardless of rollback.
+	// Thus we have to index them and log them to the WAL in any case.
+	a.indexSeries()
 	return a.log()
 }

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -235,7 +235,7 @@ Outer:
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels)
+				mSeries, created, err := h.getOrCreateWithID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, true)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -1525,7 +1525,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithID(csr.ref, csr.lset.Hash(), csr.lset)
+				series, _, err := h.getOrCreateWithID(csr.ref, csr.lset.Hash(), csr.lset, true)
 				if err != nil {
 					errChan <- err
 					return


### PR DESCRIPTION
Instead of indexing each series separately, we can delay that until the commit (or rollback) phase of the append, in an attempt to reduce the lock contention on MemPostings.