### PR TITLE
[weekly-r312] MemPostings.AddBatch per Appender

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1736,6 +1736,22 @@ func (h *Head) String() string {
 	return "head"
 }
 
+// getOrCreateWithoutIndexing assumes that the caller will do a h.postings.Add() call for created series later.
+func (h *Head) getOrCreateWithoutIndexing(hash uint64, lset labels.Labels) (_ *memSeries, created bool, _ error) {
+	// Just using `getOrCreateWithID` below would be semantically sufficient, but we'd create
+	// a new series on every sample inserted via Add(), which causes allocations
+	// and makes our series IDs rather random and harder to compress in postings.
+	s := h.series.getByHash(hash, lset)
+	if s != nil {
+		return s, false, nil
+	}
+
+	// Optimistically assume that we are the first one to create the series.
+	id := chunks.HeadSeriesRef(h.lastSeriesID.Inc())
+
+	return h.getOrCreateWithID(id, hash, lset, false)
+}
+
 func (h *Head) getOrCreate(hash uint64, lset labels.Labels) (*memSeries, bool, error) {
 	// Just using `getOrCreateWithID` below would be semantically sufficient, but we'd create
 	// a new series on every sample inserted via Add(), which causes allocations
@@ -1748,10 +1764,10 @@ func (h *Head) getOrCreate(hash uint64, lset labels.Labels) (*memSeries, bool, e
 	// Optimistically assume that we are the first one to create the series.
 	id := chunks.HeadSeriesRef(h.lastSeriesID.Inc())
 
-	return h.getOrCreateWithID(id, hash, lset)
+	return h.getOrCreateWithID(id, hash, lset, true)
 }
 
-func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labels.Labels) (*memSeries, bool, error) {
+func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labels.Labels, index bool) (*memSeries, bool, error) {
 	s, created, err := h.series.getOrSet(hash, lset, func() *memSeries {
 		shardHash := uint64(0)
 		if h.opts.EnableSharding {
@@ -1770,7 +1786,9 @@ func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labe
 	h.metrics.seriesCreated.Inc()
 	h.numSeries.Inc()
 
-	h.postings.Add(storage.SeriesRef(id), lset)
+	if index {
+		h.postings.Add(storage.SeriesRef(id), lset)
+	}
 	return s, true, nil
 }
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -236,7 +236,7 @@ Outer:
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels)
+				mSeries, created, err := h.getOrCreateWithID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, true)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -1526,7 +1526,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithID(csr.ref, csr.lset.Hash(), csr.lset)
+				series, _, err := h.getOrCreateWithID(csr.ref, csr.lset.Hash(), csr.lset, true)
 				if err != nil {
 					errChan <- err
 					return

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/record"
 )
 
 var allPostingsKey = labels.Label{}
@@ -343,6 +344,18 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.addFor(id, allPostingsKey)
 
 	p.mtx.Unlock()
+}
+
+func (p *MemPostings) AddBatch(series []record.RefSeries) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	for _, s := range series {
+		s.Labels.Range(func(l labels.Label) {
+			p.addFor(storage.SeriesRef(s.Ref), l)
+		})
+		p.addFor(storage.SeriesRef(s.Ref), allPostingsKey)
+	}
 }
 
 func appendWithExponentialGrowth[T any](a []T, v T) []T {


### PR DESCRIPTION
Instead of indexing each series separately, we can delay that until the commit (or rollback) phase of the append, in an attempt to reduce the lock contention on MemPostings.

(This is https://github.com/grafana/mimir-prometheus/pull/745 cherry-picked on top of weekly-r312)