### PR TITLE
Fix round function not honoring delayed name removal flag

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3928,3 +3928,65 @@ func (s mockSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	}
 	return storage.ChainSampleIteratorFromIterators(it, iterables)
 }
+
+func TestEvaluationWithDelayedNameRemovalDisabled(t *testing.T) {
+	opts := promql.EngineOpts{
+		Logger:                   nil,
+		Reg:                      nil,
+		EnableAtModifier:         true,
+		MaxSamples:               10000,
+		Timeout:                  10 * time.Second,
+		EnableDelayedNameRemoval: false,
+	}
+	engine := promqltest.NewTestEngineWithOpts(t, opts)
+
+	promqltest.RunTest(t, `
+load 5m
+	metric{env="1"}	0 60 120
+	another_metric{env="1"}	60 120 180
+
+# Does not drop __name__ for vector selector
+eval instant at 15m metric{env="1"}
+	metric{env="1"} 120
+
+# Drops __name__ for unary operators
+eval instant at 15m -metric
+	{env="1"} -120
+
+# Drops __name__ for binary operators
+eval instant at 15m metric + another_metric
+	{env="1"} 300
+
+# Does not drop __name__ for binary comparison operators
+eval instant at 15m metric <= another_metric
+	metric{env="1"} 120
+
+# Drops __name__ for binary comparison operators with "bool" modifier
+eval instant at 15m metric <= bool another_metric
+	{env="1"} 1
+
+# Drops __name__ for vector-scalar operations
+eval instant at 15m metric * 2
+	{env="1"} 240
+
+# Drops __name__ for instant-vector functions
+eval instant at 15m clamp(metric, 0, 100)
+	{env="1"} 100
+
+# Drops __name__ for round function
+eval instant at 15m round(metric)
+	{env="1"} 120
+
+# Drops __name__ for range-vector functions
+eval instant at 15m rate(metric{env="1"}[10m])
+	{env="1"} 0.2
+
+# Does not drop __name__ for last_over_time function
+eval instant at 15m last_over_time(metric{env="1"}[10m])
+	metric{env="1"} 120
+
+# Drops name for other _over_time functions
+eval instant at 15m max_over_time(metric{env="1"}[10m])
+	{env="1"} 120
+`, engine)
+}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3946,47 +3946,47 @@ load 5m
 	another_metric{env="1"}	60 120 180
 
 # Does not drop __name__ for vector selector
-eval instant at 15m metric{env="1"}
+eval instant at 10m metric{env="1"}
 	metric{env="1"} 120
 
 # Drops __name__ for unary operators
-eval instant at 15m -metric
+eval instant at 10m -metric
 	{env="1"} -120
 
 # Drops __name__ for binary operators
-eval instant at 15m metric + another_metric
+eval instant at 10m metric + another_metric
 	{env="1"} 300
 
 # Does not drop __name__ for binary comparison operators
-eval instant at 15m metric <= another_metric
+eval instant at 10m metric <= another_metric
 	metric{env="1"} 120
 
 # Drops __name__ for binary comparison operators with "bool" modifier
-eval instant at 15m metric <= bool another_metric
+eval instant at 10m metric <= bool another_metric
 	{env="1"} 1
 
 # Drops __name__ for vector-scalar operations
-eval instant at 15m metric * 2
+eval instant at 10m metric * 2
 	{env="1"} 240
 
 # Drops __name__ for instant-vector functions
-eval instant at 15m clamp(metric, 0, 100)
+eval instant at 10m clamp(metric, 0, 100)
 	{env="1"} 100
 
 # Drops __name__ for round function
-eval instant at 15m round(metric)
+eval instant at 10m round(metric)
 	{env="1"} 120
 
 # Drops __name__ for range-vector functions
-eval instant at 15m rate(metric{env="1"}[10m])
+eval instant at 10m rate(metric{env="1"}[10m])
 	{env="1"} 0.2
 
 # Does not drop __name__ for last_over_time function
-eval instant at 15m last_over_time(metric{env="1"}[10m])
+eval instant at 10m last_over_time(metric{env="1"}[10m])
 	metric{env="1"} 120
 
 # Drops name for other _over_time functions
-eval instant at 15m max_over_time(metric{env="1"}[10m])
+eval instant at 10m max_over_time(metric{env="1"}[10m])
 	{env="1"} 120
 `, engine)
 }

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -538,6 +538,9 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 			continue
 		}
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
+		if !enh.enableDelayedNameRemoval {
+			el.Metric = el.Metric.DropMetricName()
+		}
 		enh.Out = append(enh.Out, Sample{
 			Metric:   el.Metric,
 			F:        f,

--- a/promql/promqltest/testdata/name_label_dropping.test
+++ b/promql/promqltest/testdata/name_label_dropping.test
@@ -31,6 +31,10 @@ eval instant at 10m metric * 2
 eval instant at 10m clamp(metric, 0, 100)
 	{env="1"} 100
 
+# Drops __name__ for round function
+eval instant at 15m round(metric)
+	{env="1"} 120
+
 # Drops __name__ for range-vector functions
 eval instant at 10m rate(metric{env="1"}[10m])
 	{env="1"} 0.2

--- a/promql/promqltest/testdata/name_label_dropping.test
+++ b/promql/promqltest/testdata/name_label_dropping.test
@@ -32,7 +32,7 @@ eval instant at 10m clamp(metric, 0, 100)
 	{env="1"} 100
 
 # Drops __name__ for round function
-eval instant at 15m round(metric)
+eval instant at 10m round(metric)
 	{env="1"} 120
 
 # Drops __name__ for range-vector functions


### PR DESCRIPTION
Cherry-pick PR [Fix round function not honoring delayed name removal flag](https://github.com/prometheus/prometheus/pull/15250), on request from @charleskorn. This harmonizes with v2.55.1, which Mimir is now based on, so that the `round` function drops the metric name.