### PR TITLE
Build 24h blocks for older OOO data

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1432,7 +1432,6 @@ func (db *DB) CompactOOOHead(ctx context.Context) error {
 // Callback for testing.
 var compactOOOHeadTestingCallback func()
 
-// firstBlockMint is in milliseconds.
 func (db *DB) compactOOOHead(ctx context.Context) error {
 	if !db.oooWasEnabled.Load() {
 		return nil

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1480,6 +1480,7 @@ func (db *DB) compactOOOHead(ctx context.Context) error {
 			return fmt.Errorf("truncate ooo wbl: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3772,7 +3772,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+		require.NoError(t, db.CompactOOOHead(ctx))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -3870,7 +3870,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting(t *testing.T) {
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+		require.NoError(t, db.CompactOOOHead(ctx))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -3961,7 +3961,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *te
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+		require.NoError(t, db.CompactOOOHead(ctx))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -4993,7 +4993,7 @@ func testOOOCompaction(t *testing.T, scenario sampleTypeScenario, addExtraSample
 	}
 
 	// OOO compaction happens here.
-	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+	require.NoError(t, db.CompactOOOHead(ctx))
 
 	// 3 blocks exist now. [0, 120), [120, 240), [240, 360)
 	require.Len(t, db.Blocks(), 3)
@@ -5399,7 +5399,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 
 	// Compaction should also work fine.
 	require.Empty(t, db.Blocks())
-	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+	require.NoError(t, db.CompactOOOHead(ctx))
 	require.Len(t, db.Blocks(), 1) // One block from OOO data.
 	require.Equal(t, int64(0), db.Blocks()[0].MinTime())
 	require.Equal(t, 120*time.Minute.Milliseconds(), db.Blocks()[0].MaxTime())
@@ -6907,7 +6907,7 @@ func TestOOOHistogramCompactionWithCounterResets(t *testing.T) {
 		require.Greater(t, f.Size(), int64(100))
 
 		// OOO compaction happens here.
-		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+		require.NoError(t, db.CompactOOOHead(ctx))
 
 		// Check that blocks are created after compaction.
 		require.Len(t, db.Blocks(), 5)
@@ -7097,7 +7097,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 	originalCompactor := db.compactor
 	db.compactor = &mockCompactorFailing{t: t}
 	for i := 0; i < 5; i++ {
-		require.Error(t, db.CompactOOOHead(ctx, time.Now()))
+		require.Error(t, db.CompactOOOHead(ctx))
 	}
 	require.Empty(t, db.Blocks())
 
@@ -7108,7 +7108,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 	verifyFirstWBLFileIs0(6)
 
 	db.compactor = originalCompactor
-	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+	require.NoError(t, db.CompactOOOHead(ctx))
 	oldBlocks := db.Blocks()
 	require.Len(t, db.Blocks(), 3)
 
@@ -7120,7 +7120,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 
 	// The failed compaction should not have left the ooo Head corrupted.
 	// Hence, expect no new blocks with another OOO compaction call.
-	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+	require.NoError(t, db.CompactOOOHead(ctx))
 	require.Len(t, db.Blocks(), 3)
 	require.Equal(t, oldBlocks, db.Blocks())
 
@@ -7528,7 +7528,7 @@ func testOutOfOrderRuntimeConfig(t *testing.T, scenario sampleTypeScenario) {
 		require.Positive(t, size)
 
 		require.Empty(t, db.Blocks())
-		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
+		require.NoError(t, db.CompactOOOHead(ctx))
 		require.NotEmpty(t, db.Blocks())
 
 		// WBL is empty.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9126,7 +9126,7 @@ func TestBiggerBlocksForOldOOOData(t *testing.T) {
 		expOOOSamples = append(expOOOSamples, sample{t: ts, f: float64(ts)})
 	}
 
-	require.Len(t, db.Blocks(), 0)
+	require.Empty(t, db.Blocks())
 	require.NoError(t, db.CompactOOOHead(ctx))
 	// 5 OOO blocks from the last 5 days + 3 OOO blocks for the 6h of curr day (2h blocks)
 	require.Len(t, db.Blocks(), 8)
@@ -9145,7 +9145,7 @@ func TestBiggerBlocksForOldOOOData(t *testing.T) {
 
 	require.NoError(t, db.reloadBlocks())
 	require.NoError(t, newDB.reloadBlocks())
-	require.Len(t, db.Blocks(), 0)
+	require.Empty(t, db.Blocks())
 	require.Len(t, newDB.Blocks(), 8)
 
 	// Only in-order sample in the old DB.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9087,3 +9087,76 @@ func TestBlockClosingBlockedDuringRemoteRead(t *testing.T) {
 	case <-blockClosed:
 	}
 }
+
+func TestBiggerBlocksForOldOOOData(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		lbls = labels.FromStrings("foo", "bar")
+
+		day  = 24 * time.Hour.Milliseconds()
+		hour = time.Hour.Milliseconds()
+
+		currTs       = time.Now().UnixMilli()
+		currDayStart = day * (currTs / day)
+
+		expOOOSamples []chunks.Sample
+	)
+
+	opts := DefaultOptions()
+	opts.OutOfOrderTimeWindow = 10 * day
+	db := openTestDB(t, opts, nil)
+	db.DisableCompactions()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	// 1 in-order sample.
+	app := db.Appender(ctx)
+	inOrderTs := currDayStart + (6 * hour)
+	ref, err := app.Append(0, lbls, inOrderTs, float64(inOrderTs))
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	// OOO samples till 5 days ago.
+	for ts := currDayStart - (5 * day); ts < inOrderTs; ts += hour {
+		app = db.Appender(ctx)
+		_, err := app.Append(ref, lbls, ts, float64(ts))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		expOOOSamples = append(expOOOSamples, sample{t: ts, f: float64(ts)})
+	}
+
+	require.Len(t, db.Blocks(), 0)
+	require.NoError(t, db.CompactOOOHead(ctx))
+	// 5 OOO blocks from the last 5 days + 3 OOO blocks for the 6h of curr day (2h blocks)
+	require.Len(t, db.Blocks(), 8)
+
+	// Check that blocks are alright.
+	// Move all the blocks to a new DB and check for all OOO samples
+	// getting into the new DB and the old DB only has the in-order sample.
+	newDB := openTestDB(t, opts, nil)
+	t.Cleanup(func() {
+		require.NoError(t, newDB.Close())
+	})
+	for _, b := range db.Blocks() {
+		err := os.Rename(b.Dir(), path.Join(newDB.Dir(), b.Meta().ULID.String()))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, db.reloadBlocks())
+	require.NoError(t, newDB.reloadBlocks())
+	require.Len(t, db.Blocks(), 0)
+	require.Len(t, newDB.Blocks(), 8)
+
+	// Only in-order sample in the old DB.
+	querier, err := db.Querier(inOrderTs-6*day, inOrderTs+1)
+	require.NoError(t, err)
+	seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {sample{t: inOrderTs, f: float64(inOrderTs)}}}, seriesSet)
+
+	// All OOO samples in the new DB.
+	querier, err = newDB.Querier(inOrderTs-6*day, inOrderTs+1)
+	require.NoError(t, err)
+	seriesSet = query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: expOOOSamples}, seriesSet)
+}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3772,7 +3772,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -3870,7 +3870,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting(t *testing.T) {
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -3961,7 +3961,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *te
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 	}()
 
@@ -4993,7 +4993,7 @@ func testOOOCompaction(t *testing.T, scenario sampleTypeScenario, addExtraSample
 	}
 
 	// OOO compaction happens here.
-	require.NoError(t, db.CompactOOOHead(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 
 	// 3 blocks exist now. [0, 120), [120, 240), [240, 360)
 	require.Len(t, db.Blocks(), 3)
@@ -5399,7 +5399,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 
 	// Compaction should also work fine.
 	require.Empty(t, db.Blocks())
-	require.NoError(t, db.CompactOOOHead(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 	require.Len(t, db.Blocks(), 1) // One block from OOO data.
 	require.Equal(t, int64(0), db.Blocks()[0].MinTime())
 	require.Equal(t, 120*time.Minute.Milliseconds(), db.Blocks()[0].MaxTime())
@@ -6907,7 +6907,7 @@ func TestOOOHistogramCompactionWithCounterResets(t *testing.T) {
 		require.Greater(t, f.Size(), int64(100))
 
 		// OOO compaction happens here.
-		require.NoError(t, db.CompactOOOHead(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 
 		// Check that blocks are created after compaction.
 		require.Len(t, db.Blocks(), 5)
@@ -7097,7 +7097,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 	originalCompactor := db.compactor
 	db.compactor = &mockCompactorFailing{t: t}
 	for i := 0; i < 5; i++ {
-		require.Error(t, db.CompactOOOHead(ctx))
+		require.Error(t, db.CompactOOOHead(ctx, time.Now()))
 	}
 	require.Empty(t, db.Blocks())
 
@@ -7108,7 +7108,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 	verifyFirstWBLFileIs0(6)
 
 	db.compactor = originalCompactor
-	require.NoError(t, db.CompactOOOHead(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 	oldBlocks := db.Blocks()
 	require.Len(t, db.Blocks(), 3)
 
@@ -7120,7 +7120,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 
 	// The failed compaction should not have left the ooo Head corrupted.
 	// Hence, expect no new blocks with another OOO compaction call.
-	require.NoError(t, db.CompactOOOHead(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 	require.Len(t, db.Blocks(), 3)
 	require.Equal(t, oldBlocks, db.Blocks())
 
@@ -7528,7 +7528,7 @@ func testOutOfOrderRuntimeConfig(t *testing.T, scenario sampleTypeScenario) {
 		require.Positive(t, size)
 
 		require.Empty(t, db.Blocks())
-		require.NoError(t, db.compactOOOHead(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx, time.Now()))
 		require.NotEmpty(t, db.Blocks())
 
 		// WBL is empty.


### PR DESCRIPTION
For https://github.com/grafana/mimir/issues/9911

In order to reduce the number of blocks when a long OOO window is configured.
