### PR TITLE
MemPostings: abuse of append-only slices

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -1123,20 +1123,3 @@ func (h *postingsWithIndexHeap) Pop() interface{} {
 	*h = old[0 : n-1]
 	return x
 }
-
-type atomicishValue[T any] struct {
-	mtx      sync.RWMutex
-	elements T
-}
-
-func (a *atomicishValue[T]) Load() T {
-	a.mtx.RLock()
-	defer a.mtx.RUnlock()
-	return a.elements
-}
-
-func (a *atomicishValue[T]) Store(v T) {
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
-	a.elements = v
-}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -431,7 +431,9 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 		}
 
 		repl := make([]*labelValuePostings, 0, len(nameValues.index))
-		for _, i := range nameValues.index {
+		for k, i := range nameValues.index {
+			// Update the index.
+			nameValues.index[k] = len(repl)
 			// Yes, this copies a mutex. We don't care.
 			repl = append(repl, nameValues.valuesSlice[i])
 		}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -543,8 +543,11 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	// We just need to make sure we don't modify the slice we took,
 	// so we'll append matching values to a different one.
 	p.mtx.RLock()
-	nameValues := p.m[name]
+	nameValues, ok := p.m[name]
 	p.mtx.RUnlock()
+	if !ok {
+		return EmptyPostings()
+	}
 	values := nameValues.values()
 
 	its := make([]Postings, 0, len(values))


### PR DESCRIPTION
Lots of short locks instead of longer ones while we're reading data. Read path only needs to hold mutex on the indexes, but not on the iterating operations.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
