### PR TITLE
Cherry-pick native histograms fixes

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2794,77 +2794,84 @@ func scalarBinop(op parser.ItemType, lhs, rhs float64) float64 {
 
 // vectorElemBinop evaluates a binary operation between two Vector elements.
 func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram.FloatHistogram, pos posrange.PositionRange) (float64, *histogram.FloatHistogram, bool, error) {
-	switch op {
-	case parser.ADD:
-		if hlhs != nil && hrhs != nil {
-			res, err := hlhs.Copy().Add(hrhs)
-			if err != nil {
-				return 0, nil, false, err
+	opName := parser.ItemTypeStr[op]
+	switch {
+	case hlhs == nil && hrhs == nil:
+		{
+			switch op {
+			case parser.ADD:
+				return lhs + rhs, nil, true, nil
+			case parser.SUB:
+				return lhs - rhs, nil, true, nil
+			case parser.MUL:
+				return lhs * rhs, nil, true, nil
+			case parser.DIV:
+				return lhs / rhs, nil, true, nil
+			case parser.POW:
+				return math.Pow(lhs, rhs), nil, true, nil
+			case parser.MOD:
+				return math.Mod(lhs, rhs), nil, true, nil
+			case parser.EQLC:
+				return lhs, nil, lhs == rhs, nil
+			case parser.NEQ:
+				return lhs, nil, lhs != rhs, nil
+			case parser.GTR:
+				return lhs, nil, lhs > rhs, nil
+			case parser.LSS:
+				return lhs, nil, lhs < rhs, nil
+			case parser.GTE:
+				return lhs, nil, lhs >= rhs, nil
+			case parser.LTE:
+				return lhs, nil, lhs <= rhs, nil
+			case parser.ATAN2:
+				return math.Atan2(lhs, rhs), nil, true, nil
 			}
-			return 0, res.Compact(0), true, nil
 		}
-		if hlhs == nil && hrhs == nil {
-			return lhs + rhs, nil, true, nil
-		}
-		if hlhs != nil {
-			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "+", "float", pos)
-		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "+", "histogram", pos)
-	case parser.SUB:
-		if hlhs != nil && hrhs != nil {
-			res, err := hlhs.Copy().Sub(hrhs)
-			if err != nil {
-				return 0, nil, false, err
+	case hlhs == nil && hrhs != nil:
+		{
+			switch op {
+			case parser.MUL:
+				return 0, hrhs.Copy().Mul(lhs).Compact(0), true, nil
+			case parser.ADD, parser.SUB, parser.DIV, parser.POW, parser.MOD, parser.EQLC, parser.NEQ, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", opName, "histogram", pos)
 			}
-			return 0, res.Compact(0), true, nil
 		}
-		if hlhs == nil && hrhs == nil {
-			return lhs - rhs, nil, true, nil
-		}
-		if hlhs != nil {
-			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "-", "float", pos)
-		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "-", "histogram", pos)
-	case parser.MUL:
-		if hlhs != nil && hrhs == nil {
-			return 0, hlhs.Copy().Mul(rhs), true, nil
-		}
-		if hlhs == nil && hrhs != nil {
-			return 0, hrhs.Copy().Mul(lhs), true, nil
-		}
-		if hlhs != nil && hrhs != nil {
-			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "*", "histogram", pos)
-		}
-		return lhs * rhs, nil, true, nil
-	case parser.DIV:
-		if hlhs != nil && hrhs == nil {
-			return 0, hlhs.Copy().Div(rhs), true, nil
-		}
-		if hrhs != nil {
-			if hlhs != nil {
-				return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "/", "histogram", pos)
+	case hlhs != nil && hrhs == nil:
+		{
+			switch op {
+			case parser.MUL:
+				return 0, hlhs.Copy().Mul(rhs).Compact(0), true, nil
+			case parser.DIV:
+				return 0, hlhs.Copy().Div(rhs).Compact(0), true, nil
+			case parser.ADD, parser.SUB, parser.POW, parser.MOD, parser.EQLC, parser.NEQ, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", opName, "float", pos)
 			}
-			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "/", "histogram", pos)
 		}
-		return lhs / rhs, nil, true, nil
-	case parser.POW:
-		return math.Pow(lhs, rhs), nil, true, nil
-	case parser.MOD:
-		return math.Mod(lhs, rhs), nil, true, nil
-	case parser.EQLC:
-		return lhs, nil, lhs == rhs, nil
-	case parser.NEQ:
-		return lhs, nil, lhs != rhs, nil
-	case parser.GTR:
-		return lhs, nil, lhs > rhs, nil
-	case parser.LSS:
-		return lhs, nil, lhs < rhs, nil
-	case parser.GTE:
-		return lhs, nil, lhs >= rhs, nil
-	case parser.LTE:
-		return lhs, nil, lhs <= rhs, nil
-	case parser.ATAN2:
-		return math.Atan2(lhs, rhs), nil, true, nil
+	case hlhs != nil && hrhs != nil:
+		{
+			switch op {
+			case parser.ADD:
+				res, err := hlhs.Copy().Add(hrhs)
+				if err != nil {
+					return 0, nil, false, err
+				}
+				return 0, res.Compact(0), true, nil
+			case parser.SUB:
+				res, err := hlhs.Copy().Sub(hrhs)
+				if err != nil {
+					return 0, nil, false, err
+				}
+				return 0, res.Compact(0), true, nil
+			case parser.EQLC:
+				// This operation expects that both histograms are compacted.
+				return 0, hlhs, hlhs.Equals(hrhs), nil
+			case parser.NEQ:
+				// This operation expects that both histograms are compacted.
+				return 0, hlhs, !hlhs.Equals(hrhs), nil
+			case parser.MUL, parser.DIV, parser.POW, parser.MOD, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", opName, "histogram", pos)
+			}
+		}
 	}
 	panic(fmt.Errorf("operator %q not allowed for operations between Vectors", op))
 }
@@ -2926,16 +2933,34 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 				case h != nil:
 					// Ignore histograms for STDVAR and STDDEV.
 					group.seen = false
+					if op == parser.STDVAR {
+						annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stdvar", e.Expr.PositionRange()))
+					} else {
+						annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stddev", e.Expr.PositionRange()))
+					}
 				case math.IsNaN(f), math.IsInf(f, 0):
 					group.floatValue = math.NaN()
 				default:
 					group.floatValue = 0
 				}
 			case parser.QUANTILE:
+				if h != nil {
+					group.seen = false
+					annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("quantile", e.Expr.PositionRange()))
+				}
 				group.heap = make(vectorByValueHeap, 1)
 				group.heap[0] = Sample{F: f}
 			case parser.GROUP:
 				group.floatValue = 1
+			case parser.MIN, parser.MAX:
+				if h != nil {
+					group.seen = false
+					if op == parser.MIN {
+						annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
+					} else {
+						annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
+					}
+				}
 			}
 			continue
 		}
@@ -3034,11 +3059,19 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 			// Do nothing. Required to avoid the panic in `default:` below.
 
 		case parser.MAX:
+			if h != nil {
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
+				continue
+			}
 			if group.floatValue < f || math.IsNaN(group.floatValue) {
 				group.floatValue = f
 			}
 
 		case parser.MIN:
+			if h != nil {
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
+				continue
+			}
 			if group.floatValue > f || math.IsNaN(group.floatValue) {
 				group.floatValue = f
 			}
@@ -3052,9 +3085,18 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 				delta := f - group.floatMean
 				group.floatMean += delta / group.groupCount
 				group.floatValue += delta * (f - group.floatMean)
+				if op == parser.STDVAR {
+					annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stdvar", e.Expr.PositionRange()))
+				} else {
+					annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stddev", e.Expr.PositionRange()))
+				}
 			}
 
 		case parser.QUANTILE:
+			if h != nil {
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("quantile", e.Expr.PositionRange()))
+				continue
+			}
 			group.heap = append(group.heap, Sample{F: f})
 
 		default:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3060,7 +3060,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 
 		case parser.MAX:
 			if h != nil {
-				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
 				continue
 			}
 			if group.floatValue < f || math.IsNaN(group.floatValue) {
@@ -3069,7 +3069,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 
 		case parser.MIN:
 			if h != nil {
-				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
 				continue
 			}
 			if group.floatValue > f || math.IsNaN(group.floatValue) {
@@ -3085,6 +3085,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 				delta := f - group.floatMean
 				group.floatMean += delta / group.groupCount
 				group.floatValue += delta * (f - group.floatMean)
+			} else {
 				if op == parser.STDVAR {
 					annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stdvar", e.Expr.PositionRange()))
 				} else {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2608,9 +2608,11 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		floatValue, histogramValue, keep, err := vectorElemBinop(op, fl, fr, hl, hr, pos)
 		if err != nil {
 			lastErr = err
+			continue
 		}
 		switch {
 		case returnBool:
+			histogramValue = nil
 			if keep {
 				floatValue = 1.0
 			} else {
@@ -2729,6 +2731,7 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 		float, histogram, keep, err := vectorElemBinop(op, lf, rf, lh, rh, pos)
 		if err != nil {
 			lastErr = err
+			continue
 		}
 		// Catch cases where the scalar is the LHS in a scalar-vector comparison operation.
 		// We want to always keep the vector element value as the output value, even if it's on the RHS.

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -229,12 +229,27 @@ load 5m
   http_requests{job="api-server", instance="0", group="canary"}		NaN
   http_requests{job="api-server", instance="1", group="canary"}		3
   http_requests{job="api-server", instance="2", group="canary"}		4
+  http_requests_histogram{job="api-server", instance="3", group="canary"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
 
 eval instant at 0m max(http_requests)
   {} 4
 
+# The histogram is ignored here so the result doesn't change but it has an info annotation now.
+eval_info instant at 0m max({job="api-server"})
+  {} 4
+
+# The histogram is ignored here so there is no result but it has an info annotation now.
+eval_info instant at 0m max(http_requests_histogram)
+
 eval instant at 0m min(http_requests)
   {} 1
+
+# The histogram is ignored here so the result doesn't change but it has an info annotation now.
+eval_info instant at 0m min({job="api-server"})
+  {} 1
+
+# The histogram is ignored here so there is no result but it has an info annotation now.
+eval_info instant at 0m min(http_requests_histogram)
 
 eval instant at 0m max by (group) (http_requests)
   {group="production"} 2
@@ -380,12 +395,22 @@ load 10s
 	data{test="uneven samples",point="a"} 0
 	data{test="uneven samples",point="b"} 1
 	data{test="uneven samples",point="c"} 4
+	data_histogram{test="histogram sample", point="c"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
 	foo .8
 
 eval instant at 1m quantile without(point)(0.8, data)
 	{test="two samples"} 0.8
 	{test="three samples"} 1.6
 	{test="uneven samples"} 2.8
+
+# The histogram is ignored here so the result doesn't change but it has an info annotation now.
+eval_info instant at 1m quantile without(point)(0.8, {__name__=~"data(_histogram)?"})
+	{test="two samples"} 0.8
+	{test="three samples"} 1.6
+	{test="uneven samples"} 2.8
+
+# The histogram is ignored here so there is no result but it has an info annotation now.
+eval_info instant at 1m quantile(0.8, data_histogram)
 
 # Bug #5276.
 eval instant at 1m quantile without(point)(scalar(foo), data)
@@ -581,11 +606,17 @@ load 5m
 	series{label="b"} 2
 	series{label="c"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}
 
-eval instant at 0m stddev(series)
+# The histogram is ignored here so the result doesn't change but it has an info annotation now.
+eval_info instant at 0m stddev(series)
 	{} 0.5
 
-eval instant at 0m stdvar(series)
+eval_info instant at 0m stdvar(series)
 	{} 0.25
+
+# The histogram is ignored here so there is no result but it has an info annotation now.
+eval_info instant at 0m stddev({label="c"})
+
+eval_info instant at 0m stdvar({label="c"})
 
 eval instant at 0m stddev by (label) (series)
 	{label="a"} 0

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1184,3 +1184,5 @@ eval instant at 3m sum_over_time(histogram_sum_over_time[4m:1m])
 
 eval instant at 3m avg_over_time(histogram_sum_over_time[4m:1m])
     {} {{schema:0 count:26.75 sum:1172.8 z_bucket:3.5 z_bucket_w:0.001 buckets:[0.75 2 0.5 1.25 0.75 0.5 0.5] n_buckets:[0.5 1.5 2 1 3.75 2.25 0 0 0 2.5 2.5 1]}}
+
+clear

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -7,6 +7,7 @@ load 5m
 	http_requests{job="app-server", instance="1", group="production"}	0+60x10
 	http_requests{job="app-server", instance="0", group="canary"}		0+70x10
 	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
+    http_requests_histogram{job="app-server", instance="1", group="production"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}x11
 
 load 5m
 	vector_matching_a{l="x"} 0+1x100
@@ -286,6 +287,26 @@ eval instant at 50m 1 == bool 1
 
 eval instant at 50m http_requests{job="api-server", instance="0", group="production"} == bool 100
 	{job="api-server", instance="0", group="production"} 1
+
+# The histogram is ignored here so the result doesn't change but it has an info annotation now.
+eval_info instant at 5m {job="app-server"} == 80
+    http_requests{group="canary", instance="1", job="app-server"} 80
+
+eval_info instant at 5m http_requests_histogram != 80
+
+eval_info instant at 5m http_requests_histogram > 80
+
+eval_info instant at 5m http_requests_histogram < 80
+
+eval_info instant at 5m http_requests_histogram >= 80
+
+eval_info instant at 5m http_requests_histogram <= 80
+
+# Should produce valid results in case of (in)equality between two histograms.
+eval instant at 5m http_requests_histogram == http_requests_histogram
+    http_requests_histogram{job="app-server", instance="1", group="production"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}
+
+eval instant at 5m http_requests_histogram != http_requests_histogram
 
 # group_left/group_right.
 

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -508,3 +508,302 @@ eval instant at 1m 10 atan2 20
 
 eval instant at 1m 10 atan2 NaN
     NaN
+
+clear
+
+# Test comparison operations with floats and histograms.
+load 6m
+  left_floats  1 2 _ _ 3 stale 4  5  NaN Inf -Inf
+  right_floats 4 _ _ 5 3 7     -1 20 NaN Inf -Inf
+  left_histograms  {{schema:3 sum:4 count:4 buckets:[1 2 1]}} {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}} _                                          _ {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}}
+  right_histograms {{schema:3 sum:4 count:4 buckets:[1 2 1]}} {{schema:3 sum:4 count:4 buckets:[1 2 1]}}   {{schema:3 sum:4 count:4 buckets:[1 2 1]}} _ _
+  right_floats_for_histograms 0 -1 2 3 4
+
+eval range from 0 to 60m step 6m left_floats == right_floats
+  left_floats _ _ _ _ 3 _ _ _ _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats == bool right_floats
+  {} 0 _ _ _ 1 _ 0 0 0 1 1
+
+eval range from 0 to 60m step 6m left_floats == does_not_match
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms == right_histograms
+  left_histograms {{schema:3 sum:4 count:4 buckets:[1 2 1]}} _ _ _ _
+
+eval range from 0 to 24m step 6m left_histograms == bool right_histograms
+  {} 1 0 _ _ _
+
+eval_info range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats != right_floats
+  left_floats 1 _ _ _ _ _ 4 5 NaN _ _
+
+eval range from 0 to 60m step 6m left_floats != bool right_floats
+  {} 1 _ _ _ 0 _ 1 1 1 0 0
+
+eval range from 0 to 24m step 6m left_histograms != right_histograms
+  left_histograms _ {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}} _ _ _
+
+eval range from 0 to 24m step 6m left_histograms != bool right_histograms
+  {} 0 1 _ _ _
+
+eval_info range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats > right_floats
+  left_floats _ _ _ _ _ _ 4 _ _ _ _
+
+eval range from 0 to 60m step 6m left_floats > bool right_floats
+  {} 0 _ _ _ 0 _ 1 0 0 0 0
+
+eval_info range from 0 to 24m step 6m left_histograms > right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats >= right_floats
+  left_floats _ _ _ _ 3 _ 4 _ _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats >= bool right_floats
+  {} 0 _ _ _ 1 _ 1 0 0 1 1
+
+eval_info range from 0 to 24m step 6m left_histograms >= right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats < right_floats
+  left_floats 1 _ _ _ _ _ _ 5 _ _ _
+
+eval range from 0 to 60m step 6m left_floats < bool right_floats
+  {} 1 _ _ _ 0 _ 0 1 0 0 0
+
+eval_info range from 0 to 24m step 6m left_histograms < right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats <= right_floats
+  left_floats 1 _ _ _ 3 _ _ 5 _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats <= bool right_floats
+  {} 1 _ _ _ 1 _ 0 1 0 1 1
+
+eval_info range from 0 to 24m step 6m left_histograms <= right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool right_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
+  # No results.
+
+# Vector / scalar combinations with scalar on right side
+eval range from 0 to 60m step 6m left_floats == 3
+  left_floats _ _ _ _ 3 _ _ _ _ _ _
+
+eval range from 0 to 60m step 6m left_floats != 3
+  left_floats 1 2 _ _ _ _ 4 5 NaN Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats > 3
+  left_floats _ _ _ _ _ _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m left_floats >= 3
+  left_floats _ _ _ _ 3 _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m left_floats < 3
+  left_floats 1 2 _ _ _ _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m left_floats <= 3
+  left_floats 1 2 _ _ 3 _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m left_floats == bool 3
+  {} 0 0 _ _ 1 _ 0 0 0 0 0
+
+eval range from 0 to 60m step 6m left_floats == Inf
+  left_floats _ _ _ _ _ _ _ _ _ Inf _
+
+eval range from 0 to 60m step 6m left_floats == bool Inf
+  {} 0 0 _ _ 0 _ 0 0 0 1 0
+
+eval range from 0 to 60m step 6m left_floats == NaN
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats == bool NaN
+  {} 0 0 _ _ 0 _ 0 0 0 0 0
+
+eval_info range from 0 to 24m step 6m left_histograms == 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != 3
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms != 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > 0
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms >= 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= 3
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms <= 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool 0
+  # No results.
+
+# Vector / scalar combinations with scalar on left side
+eval range from 0 to 60m step 6m 3 == left_floats
+  left_floats _ _ _ _ 3 _ _ _ _ _ _
+
+eval range from 0 to 60m step 6m 3 != left_floats
+  left_floats 1 2 _ _ _ _ 4 5 NaN Inf -Inf
+
+eval range from 0 to 60m step 6m 3 < left_floats
+  left_floats _ _ _ _ _ _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m 3 <= left_floats
+  left_floats _ _ _ _ 3 _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m 3 > left_floats
+  left_floats 1 2 _ _ _ _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m 3 >= left_floats
+  left_floats 1 2 _ _ 3 _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m 3 == bool left_floats
+  {} 0 0 _ _ 1 _ 0 0 0 0 0
+
+eval range from 0 to 60m step 6m Inf == left_floats
+  left_floats _ _ _ _ _ _ _ _ _ Inf _
+
+eval range from 0 to 60m step 6m Inf == bool left_floats
+  {} 0 0 _ _ 0 _ 0 0 0 1 0
+
+eval range from 0 to 60m step 6m NaN == left_floats
+  # No results.
+
+eval range from 0 to 60m step 6m NaN == bool left_floats
+  {} 0 0 _ _ 0 _ 0 0 0 0 0
+
+eval range from 0 to 24m step 6m 3 == left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 == left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 != left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 != left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 > left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 > left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 >= left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 >= left_histograms
+  # No results.
+
+clear

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -147,6 +147,7 @@ var (
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
+	HistogramIgnoredInAggregationInfo       = fmt.Errorf("%w: ignored histogram in", PromQLInfo)
 )
 
 type annoErr struct {
@@ -281,5 +282,14 @@ func NewIncompatibleTypesInBinOpInfo(lhsType, operator, rhsType string, pos posr
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q: %s %s %s", IncompatibleTypesInBinOpInfo, operator, lhsType, operator, rhsType),
+	}
+}
+
+// NewHistogramIgnoredInAggregationInfo is used when a histogram is ignored by
+// an aggregation operator that cannot handle histograms.
+func NewHistogramIgnoredInAggregationInfo(aggregation string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %s aggregation", HistogramIgnoredInAggregationInfo, aggregation),
 	}
 }


### PR DESCRIPTION
Cherry-pick three native histograms fixes, [requested](https://github.com/grafana/mimir/pull/9948#issue-2670539860) by @charleskorn:

* https://github.com/prometheus/prometheus/pull/15245
* https://github.com/prometheus/prometheus/pull/15413
* https://github.com/prometheus/prometheus/pull/15414