### PR TITLE
Add a EnableBiggerOOOBlockForOldSamples option for the TSDB

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9104,6 +9104,7 @@ func TestBiggerBlocksForOldOOOData(t *testing.T) {
 
 	opts := DefaultOptions()
 	opts.OutOfOrderTimeWindow = 10 * day
+	opts.EnableBiggerOOOBlockForOldSamples = true
 	db := openTestDB(t, opts, nil)
 	db.DisableCompactions()
 	t.Cleanup(func() {


### PR DESCRIPTION
This is a follow up of https://github.com/grafana/mimir-prometheus/pull/751, making the feature opt-in