### PR TITLE
Make caching in CI workflow more effective

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,31 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.1.0
         with:
           go-version: '~1.23.0'
+          cache: false # We do this ourselves below to avoid conflicts between the different jobs.
+
+      - name: Get Go paths
+        id: gopaths
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4.1.2
+        with:
+          path: ${{ steps.gopaths.outputs.GOMODCACHE }}
+          # Use the same dependencies cache for all instances of this 'test' job, given each will use the same dependencies.
+          # We don't share this cache with the 'fuzz' job below because it only uses (and therefore downloads) a subset of dependencies.
+          key: ci-test-dependencies-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
+      - name: Cache build cache
+        uses: actions/cache@v4.1.2
+        with:
+          path: ${{ steps.gopaths.outputs.GOCACHE }}
+          # Use a unique build cache for each instance of this 'test' job, given each will be built with different build tags.
+          key: ci-test-build-cache-${{ runner.os }}-${{ matrix.buildtags }}-${{ hashFiles('**/go.sum') }}
 
       - name: Run Tests
         run: GOOPTS=-tags=${{ matrix.buildtags }} make common-test
@@ -37,9 +59,30 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.1.0
         with:
           go-version: '~1.23.0'
+          cache: false # We do this ourselves below to avoid conflicts between the different jobs.
+
+      - name: Get Go paths
+        id: gopaths
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4.1.2
+        with:
+          path: ${{ steps.gopaths.outputs.GOMODCACHE }}
+          # Use the same dependencies cache for all instances of this 'fuzz' job, given each will use the same dependencies.
+          key: ci-fuzz-dependencies-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+
+      - name: Cache build cache
+        uses: actions/cache@v4.1.2
+        with:
+          path: ${{ steps.gopaths.outputs.GOCACHE }}
+          # Use the same build cache for each instance of this 'fuzz' job, given each will build the same package (model/labels) with the same build tags.
+          key: ci-fuzz-build-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
       - name: Set -fuzztime=10m for 'main' branch
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
`actions/setup-go` creates and uses a single GitHub Actions cache entry for all jobs, but this is ineffective in our CI workflow:

* The `fuzz` job uses only [a subset](https://github.com/grafana/mimir-prometheus/actions/runs/12129753682/job/33819073754?pr=780#step:6:7) of dependencies, and so only those dependencies are downloaded to the runner-local cache. The `fuzz` job is far faster than the `test` job, so it wins the race to populate the cache entry for subsequent runs, but then the `test` job will always need to download a large number of dependencies.
* Similarly, the `fuzz` job only needs to build a subset of all packages, so populating the Go build cache from this means that the `test` job will always need to build a number of packages.
* The `test` job runs with different Go build tags, so sharing the Go build cache between different instances of the job is ineffective.

Instead, in this PR, we create separate GitHub Actions caches to avoid the issues above.

This improved CI build speed quite dramatically: [a cold build](https://github.com/grafana/mimir-prometheus/actions/runs/12130743029/attempts/1) took 14m52s, but [a warm build](https://github.com/grafana/mimir-prometheus/actions/runs/12130743029/attempts/2) took 10m5s.