### PR TITLE
Include cache entry timestamp in trace events emitted by postings for matchers cache

### DIFF
--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -270,7 +270,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 	t.Run("cached value is evicted because cache exceeds max bytes", func(t *testing.T) {
 		const (
 			maxItems         = 100 // Never hit it.
-			maxBytes         = 1250
+			maxBytes         = 1300
 			numMatchers      = 5
 			postingsListSize = 30 // 8 bytes per posting ref, so 30 x 8 = 240 bytes.
 		)


### PR DESCRIPTION
This makes it easier to understand the age of a cached entry, which is useful when debugging the behaviour of the cache.