### PR TITLE
Check cached postings TTL before returning from cache + metrics

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -352,11 +352,11 @@ type Block struct {
 // OpenBlock opens the block in the directory. It can be passed a chunk pool, which is used
 // to instantiate chunk structs.
 func OpenBlock(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory) (pb *Block, err error) {
-	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce)
+	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
 }
 
 // OpenBlockWithOptions is like OpenBlock but allows to pass a cache provider and sharding function.
-func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, cache index.ReaderCacheProvider, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool) (pb *Block, err error) {
+func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, cache index.ReaderCacheProvider, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool, postingsCacheMetrics *PostingsForMatchersCacheMetrics) (pb *Block, err error) {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -385,7 +385,7 @@ func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, p
 	if err != nil {
 		return nil, err
 	}
-	pfmc := NewPostingsForMatchersCache(postingsCacheTTL, postingsCacheMaxItems, postingsCacheMaxBytes, postingsCacheForce)
+	pfmc := NewPostingsForMatchersCache(postingsCacheTTL, postingsCacheMaxItems, postingsCacheMaxBytes, postingsCacheForce, postingsCacheMetrics)
 	ir := indexReaderWithPostingsForMatchers{indexReader, pfmc}
 	closers = append(closers, ir)
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -100,6 +100,7 @@ func DefaultOptions() *Options {
 		HeadPostingsForMatchersCacheMaxItems:  DefaultPostingsForMatchersCacheMaxItems,
 		HeadPostingsForMatchersCacheMaxBytes:  DefaultPostingsForMatchersCacheMaxBytes,
 		HeadPostingsForMatchersCacheForce:     DefaultPostingsForMatchersCacheForce,
+		HeadPostingsForMatchersCacheMetrics:   NewPostingsForMatchersCacheMetrics(nil),
 		BlockPostingsForMatchersCacheTTL:      DefaultPostingsForMatchersCacheTTL,
 		BlockPostingsForMatchersCacheMaxItems: DefaultPostingsForMatchersCacheMaxItems,
 		BlockPostingsForMatchersCacheMaxBytes: DefaultPostingsForMatchersCacheMaxBytes,

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3118,11 +3118,13 @@ func TestCompactHead(t *testing.T) {
 
 	// Open a DB and append data to the WAL.
 	tsdbCfg := &Options{
-		RetentionDuration: int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:        true,
-		MinBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:    wlog.CompressionSnappy,
+		RetentionDuration:                    int64(time.Hour * 24 * 15 / time.Millisecond),
+		NoLockfile:                           true,
+		MinBlockDuration:                     int64(time.Hour * 2 / time.Millisecond),
+		MaxBlockDuration:                     int64(time.Hour * 2 / time.Millisecond),
+		WALCompression:                       wlog.CompressionSnappy,
+		HeadPostingsForMatchersCacheMetrics:  NewPostingsForMatchersCacheMetrics(nil),
+		BlockPostingsForMatchersCacheMetrics: NewPostingsForMatchersCacheMetrics(nil),
 	}
 
 	db, err := Open(dbDir, promslog.NewNopLogger(), prometheus.NewRegistry(), tsdbCfg, nil)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -193,6 +193,7 @@ type HeadOptions struct {
 	PostingsForMatchersCacheMaxItems int
 	PostingsForMatchersCacheMaxBytes int64
 	PostingsForMatchersCacheForce    bool
+	PostingsForMatchersCacheMetrics  *PostingsForMatchersCacheMetrics
 
 	// Optional hash function applied to each new series. Computed hash value is preserved for each series in the head,
 	// and values can be iterated by using Head.ForEachSecondaryHash method.
@@ -222,6 +223,7 @@ func DefaultHeadOptions() *HeadOptions {
 		PostingsForMatchersCacheMaxItems: DefaultPostingsForMatchersCacheMaxItems,
 		PostingsForMatchersCacheMaxBytes: DefaultPostingsForMatchersCacheMaxBytes,
 		PostingsForMatchersCacheForce:    DefaultPostingsForMatchersCacheForce,
+		PostingsForMatchersCacheMetrics:  NewPostingsForMatchersCacheMetrics(nil),
 		WALReplayConcurrency:             defaultWALReplayConcurrency,
 	}
 	ho.OutOfOrderCapMax.Store(DefaultOutOfOrderCapMax)
@@ -296,7 +298,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		stats:             stats,
 		reg:               r,
 		secondaryHashFunc: shf,
-		pfmc:              NewPostingsForMatchersCache(opts.PostingsForMatchersCacheTTL, opts.PostingsForMatchersCacheMaxItems, opts.PostingsForMatchersCacheMaxBytes, opts.PostingsForMatchersCacheForce),
+		pfmc:              NewPostingsForMatchersCache(opts.PostingsForMatchersCacheTTL, opts.PostingsForMatchersCacheMaxItems, opts.PostingsForMatchersCacheMaxBytes, opts.PostingsForMatchersCacheForce, opts.PostingsForMatchersCacheMetrics),
 	}
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -66,7 +66,10 @@ func NewPostingsForMatchersCache(ttl time.Duration, maxItems int, maxBytes int64
 		force:    force,
 		metrics:  metrics,
 
-		timeNow:             time.Now,
+		timeNow: func() time.Time {
+			// Ensure it is UTC, so that it's faster to compute the cache entry size.
+			return time.Now().UTC()
+		},
 		postingsForMatchers: PostingsForMatchers,
 
 		tracer:      otel.Tracer(""),
@@ -219,7 +222,9 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 			case <-oldPromise.done:
 				if c.timeNow().Sub(oldPromise.evaluationCompletedAt) >= c.ttl {
 					// The cached promise already expired, but it has not been evicted.
-					// TODO trace
+					span.AddEvent("skipping cached postingsForMatchers promise because its TTL already expired", trace.WithAttributes(
+						attribute.String("cache_key", key),
+					))
 					c.metrics.skipsBecauseStale.Inc()
 
 					return func(ctx context.Context) (index.Postings, error) {

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -101,6 +101,9 @@ type PostingsForMatchersCache struct {
 	// beginning of onPromiseExecutionDone() execution.
 	onPromiseExecutionDoneBeforeHook func()
 
+	// evictHeadBeforeHook is used for testing purposes. It allows to hook before calls to evictHead().
+	evictHeadBeforeHook func()
+
 	tracer trace.Tracer
 	// Preallocated for performance
 	ttlAttrib   attribute.KeyValue
@@ -299,6 +302,11 @@ func (c *PostingsForMatchersCache) expire() {
 		return
 	}
 	c.cachedMtx.RUnlock()
+
+	// Call the registered hook, if any. It's used only for testing purposes.
+	if c.evictHeadBeforeHook != nil {
+		c.evictHeadBeforeHook()
+	}
 
 	c.cachedMtx.Lock()
 	defer c.cachedMtx.Unlock()

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -223,6 +223,7 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 				if c.timeNow().Sub(oldPromise.evaluationCompletedAt) >= c.ttl {
 					// The cached promise already expired, but it has not been evicted.
 					span.AddEvent("skipping cached postingsForMatchers promise because its TTL already expired", trace.WithAttributes(
+						attribute.Stringer("cached promise evaluation completed at", oldPromise.evaluationCompletedAt),
 						attribute.String("cache_key", key),
 					))
 					c.metrics.skipsBecauseStale.Inc()

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/DmitriyVTitov/size"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -22,8 +24,8 @@ import (
 
 func TestPostingsForMatchersCache(t *testing.T) {
 	// newPostingsForMatchersCache tests the NewPostingsForMatcherCache constructor, but overrides the postingsForMatchers func
-	newPostingsForMatchersCache := func(ttl time.Duration, maxItems int, maxBytes int64, pfm func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error), timeMock *timeNowMock, force bool) *PostingsForMatchersCache {
-		c := NewPostingsForMatchersCache(ttl, maxItems, maxBytes, force)
+	newPostingsForMatchersCache := func(ttl time.Duration, maxItems int, maxBytes int64, pfm func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error), timeMock *timeNowMock, force bool, reg prometheus.Registerer) *PostingsForMatchersCache {
+		c := NewPostingsForMatchersCache(ttl, maxItems, maxBytes, force, NewPostingsForMatchersCacheMetrics(reg))
 		if c.postingsForMatchers == nil {
 			t.Fatalf("NewPostingsForMatchersCache() didn't assign postingsForMatchers func")
 		}
@@ -39,17 +41,46 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			t.Run(fmt.Sprintf("concurrent=%t", concurrent), func(t *testing.T) {
 				expectedMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 				expectedPostingsErr := errors.New("failed successfully")
+				reg := prometheus.NewRegistry()
 
 				c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, 5, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 					require.IsType(t, indexForPostingsMock{}, ix, "Incorrect IndexPostingsReader was provided to PostingsForMatchers, expected the mock, was given %v (%T)", ix, ix)
 					require.Equal(t, expectedMatchers, ms, "Wrong label matchers provided, expected %v, got %v", expectedMatchers, ms)
 					return index.ErrPostings(expectedPostingsErr), nil
-				}, &timeNowMock{}, false)
+				}, &timeNowMock{}, false, reg)
 
 				p, err := c.PostingsForMatchers(ctx, indexForPostingsMock{}, concurrent, expectedMatchers...)
 				require.NoError(t, err)
 				require.NotNil(t, p)
 				require.Equal(t, expectedPostingsErr, p.Err(), "Expected ErrPostings with err %q, got %T with err %q", expectedPostingsErr, p, p.Err())
+
+				expectedMisses := 0
+				expectedDisabled := 0
+				if concurrent {
+					expectedMisses = 1
+				} else {
+					expectedDisabled = 1
+				}
+
+				require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+					# TYPE postings_for_matchers_cache_requests_total counter
+					postings_for_matchers_cache_requests_total 1
+
+					# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+					# TYPE postings_for_matchers_cache_hits_total counter
+					postings_for_matchers_cache_hits_total 0
+
+					# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+					# TYPE postings_for_matchers_cache_misses_total counter
+					postings_for_matchers_cache_misses_total %d
+
+					# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+					# TYPE postings_for_matchers_cache_skips_total counter
+					postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+					postings_for_matchers_cache_skips_total{reason="ineligible"} %d
+					postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+				`, expectedMisses, expectedDisabled))))
 			})
 		}
 	})
@@ -57,13 +88,34 @@ func TestPostingsForMatchersCache(t *testing.T) {
 	t.Run("err returned", func(t *testing.T) {
 		expectedMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 		expectedErr := errors.New("failed successfully")
+		reg := prometheus.NewRegistry()
 
 		c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, 5, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			return nil, expectedErr
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		_, err := c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, expectedMatchers...)
 		require.ErrorIs(t, err, expectedErr)
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 1
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 0
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 1
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("happy case multiple concurrent calls: two same one different", func(t *testing.T) {
@@ -113,7 +165,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 							}
 							<-release
 							return nil, fmt.Errorf("%s", matchersString(ms))
-						}, &timeNowMock{}, forced)
+						}, &timeNowMock{}, forced, nil)
 
 						results := make([]error, len(calls))
 						resultsWg := sync.WaitGroup{}
@@ -151,12 +203,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 
 	t.Run("with concurrent==false, result is not cached", func(t *testing.T) {
 		expectedMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
+		reg := prometheus.NewRegistry()
 
 		var call int
 		c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, 5, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			call++
 			return index.ErrPostings(fmt.Errorf("result from call %d", call)), nil
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		// first call, fills the cache
 		p, err := c.PostingsForMatchers(ctx, indexForPostingsMock{}, false, expectedMatchers...)
@@ -167,16 +220,37 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		p, err = c.PostingsForMatchers(ctx, indexForPostingsMock{}, false, expectedMatchers...)
 		require.NoError(t, err)
 		require.EqualError(t, p.Err(), "result from call 2")
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 2
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 0
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 0
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 2
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("with cache disabled, result is not cached", func(t *testing.T) {
 		expectedMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
+		reg := prometheus.NewRegistry()
 
 		var call int
 		c := newPostingsForMatchersCache(0, 1000, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			call++
 			return index.ErrPostings(fmt.Errorf("result from call %d", call)), nil
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		// first call, fills the cache
 		p, err := c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, expectedMatchers...)
@@ -187,6 +261,26 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		p, err = c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, expectedMatchers...)
 		require.NoError(t, err)
 		require.EqualError(t, p.Err(), "result from call 2")
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 2
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 0
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 2
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("cached value is returned, then it expires", func(t *testing.T) {
@@ -194,12 +288,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		expectedMatchers := []*labels.Matcher{
 			labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
 		}
+		reg := prometheus.NewRegistry()
 
 		var call int
 		c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, 5, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			call++
 			return index.ErrPostings(fmt.Errorf("result from call %d", call)), nil
-		}, timeNow, false)
+		}, timeNow, false, reg)
 
 		// first call, fills the cache
 		p, err := c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, expectedMatchers...)
@@ -219,12 +314,34 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		p, err = c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, expectedMatchers...)
 		require.NoError(t, err)
 		require.EqualError(t, p.Err(), "result from call 2")
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 3
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 1
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 2
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("cached value is evicted because cache exceeds max items", func(t *testing.T) {
 		const maxItems = 5
 
 		timeNow := &timeNowMock{}
+		reg := prometheus.NewRegistry()
+
 		calls := make([][]*labels.Matcher, maxItems)
 		for i := range calls {
 			calls[i] = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "matchers", strconv.Itoa(i))}
@@ -235,7 +352,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			k := matchersKey(ms)
 			callsPerMatchers[k]++
 			return index.ErrPostings(fmt.Errorf("result from call %d", callsPerMatchers[k])), nil
-		}, timeNow, false)
+		}, timeNow, false, reg)
 
 		// each one of the first testCacheSize calls is cached properly
 		for _, matchers := range calls {
@@ -266,6 +383,26 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		p, err = c.PostingsForMatchers(ctx, indexForPostingsMock{}, true, calls[0]...)
 		require.NoError(t, err)
 		require.EqualError(t, p.Err(), "result from call 2")
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 13
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 6
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 7
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("cached value is evicted because cache exceeds max bytes", func(t *testing.T) {
@@ -275,6 +412,8 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			numMatchers      = 5
 			postingsListSize = 30 // 8 bytes per posting ref, so 30 x 8 = 240 bytes.
 		)
+
+		reg := prometheus.NewRegistry()
 
 		// Generate some matchers.
 		matchersLists := make([][]*labels.Matcher, numMatchers)
@@ -298,7 +437,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			k := matchersKey(ms)
 			callsPerMatchers[k]++
 			return index.NewListPostings(refsLists[k]), nil
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		// We expect to cache 3 items. So we're going to call PostingsForMatchers for 3 matchers
 		// and then double check they're all cached. To do it, we iterate twice.
@@ -340,11 +479,32 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.Equal(t, 1, callsPerMatchers[matchersKey(matchersLists[1])])
 		require.Equal(t, 1, callsPerMatchers[matchersKey(matchersLists[2])])
 		require.Equal(t, 1, callsPerMatchers[matchersKey(matchersLists[3])])
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 9
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 4
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 5
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("initial request context is canceled, no other in-flight requests", func(t *testing.T) {
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 		expectedPostings := index.NewPostingsCloner(index.NewListPostings([]storage.SeriesRef{1, 2, 3}))
+		reg := prometheus.NewRegistry()
 
 		var reqCtx context.Context
 		var cancelReqCtx context.CancelFunc
@@ -369,7 +529,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			case <-time.After(time.Second):
 				return expectedPostings.Clone(), nil
 			}
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		// Run PostingsForMatchers() a first time, cancelling the context while it's executing.
 		reqCtx, cancelReqCtx = context.WithCancel(context.Background())
@@ -387,11 +547,32 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedPostings.Clone(), actualPostings)
 		require.Equal(t, int32(2), callsCount.Load())
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 2
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 0
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 2
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("initial request context is cancelled, second request is not cancelled", func(t *testing.T) {
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 		expectedPostings := index.NewPostingsCloner(index.NewListPostings([]storage.SeriesRef{1, 2, 3}))
+		reg := prometheus.NewRegistry()
 
 		reqCtx1, cancelReqCtx1 := context.WithCancel(context.Background())
 		waitBeforeCancelReqCtx1 := make(chan struct{})
@@ -419,7 +600,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			case <-time.After(time.Second):
 				return expectedPostings.Clone(), nil
 			}
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -457,11 +638,32 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedPostings.Clone(), actualPostings)
 		require.Equal(t, int32(1), callsCount.Load())
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 3
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 2
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 1
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 
 	t.Run("initial and subsequent requests are canceled during execution", func(t *testing.T) {
 		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 		postings := index.NewPostingsCloner(index.NewListPostings([]storage.SeriesRef{1, 2, 3}))
+		reg := prometheus.NewRegistry()
 
 		reqCtx1, cancelReqCtx1 := context.WithCancel(context.Background())
 		reqCtx2, cancelReqCtx2 := context.WithCancel(context.Background())
@@ -491,7 +693,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			case <-time.After(time.Second):
 				return postings.Clone(), nil
 			}
-		}, &timeNowMock{}, false)
+		}, &timeNowMock{}, false, reg)
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -520,6 +722,26 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.Equal(t, 0, c.cached.Len())
 
 		require.Equal(t, int32(1), callsCount.Load())
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 2
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 1
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 1
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 	})
 }
 
@@ -529,9 +751,10 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 		ttl        = time.Second
 		ctx        = context.Background()
 		nextCallID = atomic.NewUint64(0)
+		reg        = prometheus.NewRegistry()
 	)
 
-	c := NewPostingsForMatchersCache(ttl, 1000, 1024*1024, true)
+	c := NewPostingsForMatchersCache(ttl, 1000, 1024*1024, true, NewPostingsForMatchersCacheMetrics(reg))
 
 	// Issue a first call to cache the postings.
 	c.postingsForMatchers = func(_ context.Context, _ IndexPostingsReader, _ ...*labels.Matcher) (index.Postings, error) {
@@ -592,11 +815,32 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 	callersWg.Wait()
 
 	require.ElementsMatch(t, []string{"result from call 2", "result from call 3"}, results)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+		# TYPE postings_for_matchers_cache_requests_total counter
+		postings_for_matchers_cache_requests_total 3
+
+		# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+		# TYPE postings_for_matchers_cache_hits_total counter
+		postings_for_matchers_cache_hits_total 0
+
+		# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+		# TYPE postings_for_matchers_cache_misses_total counter
+		postings_for_matchers_cache_misses_total 2
+
+		# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+		# TYPE postings_for_matchers_cache_skips_total counter
+		postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
+		postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+		postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 1
+	`)))
 }
 
 func TestPostingsForMatchersCache_RaceConditionBetweenExecutionContextCancellationAndNewRequest(t *testing.T) {
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")}
 	expectedPostings := index.NewPostingsCloner(index.NewListPostings([]storage.SeriesRef{1, 2, 3}))
+	reg := prometheus.NewRegistry()
 
 	reqCtx1, cancelReqCtx1 := context.WithCancel(context.Background())
 	callsCount := atomic.NewInt32(0)
@@ -604,7 +848,7 @@ func TestPostingsForMatchersCache_RaceConditionBetweenExecutionContextCancellati
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	c := NewPostingsForMatchersCache(time.Hour, 5, 1000, true)
+	c := NewPostingsForMatchersCache(time.Hour, 5, 1000, true, NewPostingsForMatchersCacheMetrics(reg))
 
 	c.postingsForMatchers = func(ctx context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 		callsCount.Inc()
@@ -655,6 +899,26 @@ func TestPostingsForMatchersCache_RaceConditionBetweenExecutionContextCancellati
 
 	// When the race condition is detected, we bypass the cache, and so we don't expect the result to be cached.
 	require.Equal(t, 0, c.cached.Len())
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_requests_total counter
+			postings_for_matchers_cache_requests_total 2
+
+			# HELP postings_for_matchers_cache_hits_total Total number of postings lists returned from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_hits_total counter
+			postings_for_matchers_cache_hits_total 0
+
+			# HELP postings_for_matchers_cache_misses_total Total number of requests to the PostingsForMatchers cache for which there is no valid cached entry. The subsequent result is cached.
+			# TYPE postings_for_matchers_cache_misses_total counter
+			postings_for_matchers_cache_misses_total 1
+
+			# HELP postings_for_matchers_cache_skips_total Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached.
+			# TYPE postings_for_matchers_cache_skips_total counter
+			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 1
+			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
+			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+		`)))
 }
 
 func BenchmarkPostingsForMatchersCache(b *testing.B) {
@@ -682,7 +946,7 @@ func BenchmarkPostingsForMatchersCache(b *testing.B) {
 
 	b.Run("no evictions", func(b *testing.B) {
 		// Configure the cache to never evict.
-		cache := NewPostingsForMatchersCache(time.Hour, 1000000, 1024*1024*1024, true)
+		cache := NewPostingsForMatchersCache(time.Hour, 1000000, 1024*1024*1024, true, NewPostingsForMatchersCacheMetrics(nil))
 		cache.postingsForMatchers = func(ctx context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			return index.NewListPostings(refs), nil
 		}
@@ -699,7 +963,7 @@ func BenchmarkPostingsForMatchersCache(b *testing.B) {
 
 	b.Run("high eviction rate", func(b *testing.B) {
 		// Configure the cache to evict continuously.
-		cache := NewPostingsForMatchersCache(time.Hour, 0, 0, true)
+		cache := NewPostingsForMatchersCache(time.Hour, 0, 0, true, NewPostingsForMatchersCacheMetrics(nil))
 		cache.postingsForMatchers = func(ctx context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			return index.NewListPostings(refs), nil
 		}
@@ -742,7 +1006,7 @@ func BenchmarkPostingsForMatchersCache_ConcurrencyOnHighEvictionRate(b *testing.
 	}
 
 	// Configure the cache to evict continuously.
-	cache := NewPostingsForMatchersCache(time.Hour, 0, 0, true)
+	cache := NewPostingsForMatchersCache(time.Hour, 0, 0, true, NewPostingsForMatchersCacheMetrics(nil))
 	cache.postingsForMatchers = func(ctx context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 		return index.NewListPostings(refs), nil
 	}

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DmitriyVTitov/size"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -779,8 +778,7 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 		select {
 		case <-firstCallReceived:
 		case <-time.After(5 * time.Second):
-			// Use "assert" instead of "require" so that the execution continues.
-			assert.Fail(t, "Expected a downstream PostingsForMatchers call but never arrived")
+			// Do not block forever. The test will anyway in this case.
 		}
 	}
 

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -780,7 +780,7 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 		select {
 		case <-firstCallReceived:
 		case <-time.After(5 * time.Second):
-			// Do not block forever. The test will anyway in this case.
+			// Do not block forever. The test will fail anyway in this case.
 		}
 	}
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -345,7 +345,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 	seriesHashCache := hashcache.NewSeriesHashCache(1024 * 1024 * 1024)
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce)
+	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())


### PR DESCRIPTION
In this PR I propose two changes to PostingsForMatchers cache:

1. Check if the TTL for cached postings is still valid before returning it from cache, to fix a race condition that could happen between a goroutine running `expire()` and another one skipping the `expire()` execution because it's already in progress.
2. Add metrics to PostingsForMatchers cache, to have better visibility over it. This is something I wanted to do since a long time. The design I picked is to allow to pass the metrics struct as DB options, so that we can use 1 single struct for all per-tenant TSDBs in a Mimir ingester.

The following benchmark shows the difference betweeen:

- `01bb37aae`: the commit before https://github.com/grafana/mimir-prometheus/pull/734
- `6c2603082`: the commit at https://github.com/grafana/mimir-prometheus/pull/734
- `main`
- This PR

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M3 Pro
                                                          │ 01bb37aae.txt │           6c2603082.txt            │              main.txt              │               pr.txt               │
                                                          │    sec/op     │   sec/op     vs base               │   sec/op     vs base               │   sec/op     vs base               │
PostingsForMatchersCache/no_evictions-11                      594.8n ± 3%   584.2n ± 1%   -1.78% (p=0.015 n=6)   602.9n ± 3%        ~ (p=0.589 n=6)   644.6n ± 1%   +8.38% (p=0.002 n=6)
PostingsForMatchersCache/high_eviction_rate-11                10.52µ ± 5%   10.39µ ± 1%   -1.28% (p=0.002 n=6)   10.85µ ± 1%        ~ (p=0.065 n=6)   10.77µ ± 0%        ~ (p=0.065 n=6)
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11    1411.5n ± 2%   301.1n ± 1%  -78.67% (p=0.002 n=6)   306.2n ± 1%  -78.31% (p=0.002 n=6)   331.2n ± 2%  -76.54% (p=0.002 n=6)
geomean                                                       2.067µ        1.222µ       -40.86%                 1.260µ       -39.03%                 1.320µ       -36.15%

                                                          │ 01bb37aae.txt │             6c2603082.txt             │               main.txt                │               pr.txt                │
                                                          │     B/op      │     B/op      vs base                 │     B/op      vs base                 │     B/op      vs base               │
PostingsForMatchersCache/no_evictions-11                       958.0 ± 0%     958.0 ± 0%        ~ (p=1.000 n=6) ¹     958.0 ± 0%        ~ (p=1.000 n=6) ¹     974.0 ± 0%   +1.67% (p=0.002 n=6)
PostingsForMatchersCache/high_eviction_rate-11               26.38Ki ± 0%   26.38Ki ± 0%        ~ (p=1.000 n=6) ¹   26.38Ki ± 0%        ~ (p=1.000 n=6) ¹   26.32Ki ± 0%   -0.24% (p=0.002 n=6)
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11     1441.0 ± 0%    1017.0 ± 0%  -29.42% (p=0.002 n=6)      1014.0 ± 0%  -29.63% (p=0.002 n=6)      1024.5 ± 0%  -28.90% (p=0.002 n=6)
geomean                                                      3.263Ki        2.905Ki       -10.97%                   2.902Ki       -11.05%                   2.926Ki       -10.33%
¹ all samples are equal

                                                          │ 01bb37aae.txt │            6c2603082.txt            │              main.txt               │               pr.txt                │
                                                          │   allocs/op   │ allocs/op   vs base                 │ allocs/op   vs base                 │ allocs/op   vs base                 │
PostingsForMatchersCache/no_evictions-11                       20.00 ± 0%   20.00 ± 0%        ~ (p=1.000 n=6) ¹   20.00 ± 0%        ~ (p=1.000 n=6) ¹   20.00 ± 0%        ~ (p=1.000 n=6) ¹
PostingsForMatchersCache/high_eviction_rate-11                 48.00 ± 0%   48.00 ± 0%        ~ (p=1.000 n=6) ¹   48.00 ± 0%        ~ (p=1.000 n=6) ¹   46.00 ± 0%   -4.17% (p=0.002 n=6)
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11      29.00 ± 0%   21.00 ± 0%  -27.59% (p=0.002 n=6)     21.00 ± 0%  -27.59% (p=0.002 n=6)     20.00 ± 5%  -31.03% (p=0.002 n=6)
geomean                                                        30.31        27.22       -10.20%                   27.22       -10.20%                   26.40       -12.89%
¹ all samples are equal
```
