### PR TITLE
Revert "Include cache entry timestamp in trace events emitted by postings for matchers cache"

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -141,9 +141,6 @@ type postingsForMatcherPromise struct {
 	// callers contexts get canceled.
 	callersCtxTracker *contextsTracker
 
-	// Keep track of the time this promise was evaluated, so we can understand the age of this cache entry in traces.
-	evaluatedAt time.Time
-
 	// The result of the promise is stored either in cloner or err (only of the two is valued).
 	// Do not access these fields until the done channel is closed.
 	done   chan struct{}
@@ -172,9 +169,7 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 	span := trace.SpanFromContext(ctx)
 
 	promiseCallersCtxTracker, promiseExecCtx := newContextsTracker()
-	ts := c.timeNow()
 	promise := &postingsForMatcherPromise{
-		evaluatedAt:       ts,
 		done:              make(chan struct{}),
 		callersCtxTracker: promiseCallersCtxTracker,
 	}
@@ -218,16 +213,12 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 
 		span.AddEvent("using cached postingsForMatchers promise", trace.WithAttributes(
 			attribute.String("cache_key", key),
-			attribute.Int64("cache_entry_evaluated_at", promise.evaluatedAt.Unix()),
 		))
 
 		return oldPromise.result
 	}
 
-	span.AddEvent("no postingsForMatchers promise in cache, executing query", trace.WithAttributes(
-		attribute.String("cache_key", key),
-		attribute.Int64("cache_entry_evaluated_at", promise.evaluatedAt.Unix()),
-	))
+	span.AddEvent("no postingsForMatchers promise in cache, executing query", trace.WithAttributes(attribute.String("cache_key", key)))
 
 	// promise was stored, close its channel after fulfilment
 	defer close(promise.done)
@@ -250,7 +241,7 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 
 	sizeBytes := int64(len(key) + size.Of(promise))
 
-	c.onPromiseExecutionDone(ctx, key, ts, sizeBytes, promise.err)
+	c.onPromiseExecutionDone(ctx, key, c.timeNow(), sizeBytes, promise.err)
 	return promise.result
 }
 

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -270,7 +270,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 	t.Run("cached value is evicted because cache exceeds max bytes", func(t *testing.T) {
 		const (
 			maxItems         = 100 // Never hit it.
-			maxBytes         = 1300
+			maxBytes         = 1250
 			numMatchers      = 5
 			postingsListSize = 30 // 8 bytes per posting ref, so 30 x 8 = 240 bytes.
 		)


### PR DESCRIPTION
Reverts grafana/mimir-prometheus#820

@pracucci pointed out in https://github.com/grafana/mimir/pull/10467#discussion_r1920420948 that this may make the cache ineffective in the case where computing the postings takes a long time.