### PR TITLE
Track evictions in the PostingsForMatchers cache

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -387,6 +387,12 @@ func (c *PostingsForMatchersCache) evictHead(now time.Time) (reason int) {
 	oldest := front.Value.(*postingsForMatchersCachedCall)
 
 	// Detect the reason why we're evicting it.
+	//
+	// The checks order is:
+	// 1. TTL: if an item is expired, it should be tracked as such even if the cache was full.
+	// 2. Max bytes: "max items" is deprecated, and we expect to set it to a high value because
+	//    we want to primarily limit by bytes size.
+	// 3. Max items: the last one.
 	switch {
 	case now.Sub(oldest.ts) >= c.ttl:
 		reason = evictionReasonTTL

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -351,18 +351,10 @@ func (c *PostingsForMatchersCache) expire() {
 	}
 
 	// Keep track of the reason why items where evicted.
-	if evictionReasons[evictionReasonTTL] > 0 {
-		c.metrics.evictionsBecauseTTL.Add(float64(evictionReasons[evictionReasonTTL]))
-	}
-	if evictionReasons[evictionReasonMaxBytes] > 0 {
-		c.metrics.evictionsBecauseMaxBytes.Add(float64(evictionReasons[evictionReasonMaxBytes]))
-	}
-	if evictionReasons[evictionReasonMaxItems] > 0 {
-		c.metrics.evictionsBecauseMaxItems.Add(float64(evictionReasons[evictionReasonMaxItems]))
-	}
-	if evictionReasons[evictionReasonUnknown] > 0 {
-		c.metrics.evictionsBecauseUnknown.Add(float64(evictionReasons[evictionReasonUnknown]))
-	}
+	c.metrics.evictionsBecauseTTL.Add(float64(evictionReasons[evictionReasonTTL]))
+	c.metrics.evictionsBecauseMaxBytes.Add(float64(evictionReasons[evictionReasonMaxBytes]))
+	c.metrics.evictionsBecauseMaxItems.Add(float64(evictionReasons[evictionReasonMaxItems]))
+	c.metrics.evictionsBecauseUnknown.Add(float64(evictionReasons[evictionReasonUnknown]))
 }
 
 // shouldEvictHead returns true if cache head should be evicted, either because it's too old,

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -31,6 +31,14 @@ const (
 	DefaultPostingsForMatchersCacheForce    = false
 )
 
+const (
+	evictionReasonTTL = iota
+	evictionReasonMaxBytes
+	evictionReasonMaxItems
+	evictionReasonUnknown
+	evictionReasonsLength
+)
+
 // IndexPostingsReader is a subset of IndexReader methods, the minimum required to evaluate PostingsForMatchers.
 type IndexPostingsReader interface {
 	// LabelValues returns possible label values which may not be sorted.
@@ -316,7 +324,7 @@ func (c *PostingsForMatchersCache) expire() {
 	defer c.expireInProgress.Store(false)
 
 	c.cachedMtx.RLock()
-	if !c.shouldEvictHead() {
+	if !c.shouldEvictHead(c.timeNow()) {
 		c.cachedMtx.RUnlock()
 		return
 	}
@@ -327,18 +335,40 @@ func (c *PostingsForMatchersCache) expire() {
 		c.evictHeadBeforeHook()
 	}
 
-	c.cachedMtx.Lock()
-	defer c.cachedMtx.Unlock()
+	var evictionReasons [evictionReasonsLength]int
 
-	for c.shouldEvictHead() {
-		c.evictHead()
+	// Evict the head taking an exclusive lock.
+	{
+		c.cachedMtx.Lock()
+
+		now := c.timeNow()
+		for c.shouldEvictHead(now) {
+			reason := c.evictHead(now)
+			evictionReasons[reason]++
+		}
+
+		c.cachedMtx.Unlock()
+	}
+
+	// Keep track of the reason why items where evicted.
+	if evictionReasons[evictionReasonTTL] > 0 {
+		c.metrics.evictionsBecauseTTL.Add(float64(evictionReasons[evictionReasonTTL]))
+	}
+	if evictionReasons[evictionReasonMaxBytes] > 0 {
+		c.metrics.evictionsBecauseMaxBytes.Add(float64(evictionReasons[evictionReasonMaxBytes]))
+	}
+	if evictionReasons[evictionReasonMaxItems] > 0 {
+		c.metrics.evictionsBecauseMaxItems.Add(float64(evictionReasons[evictionReasonMaxItems]))
+	}
+	if evictionReasons[evictionReasonUnknown] > 0 {
+		c.metrics.evictionsBecauseUnknown.Add(float64(evictionReasons[evictionReasonUnknown]))
 	}
 }
 
 // shouldEvictHead returns true if cache head should be evicted, either because it's too old,
 // or because the cache has too many elements
 // should be called while read lock is held on cachedMtx.
-func (c *PostingsForMatchersCache) shouldEvictHead() bool {
+func (c *PostingsForMatchersCache) shouldEvictHead(now time.Time) bool {
 	// The cache should be evicted for sure if the max size (either items or bytes) is reached.
 	if c.cached.Len() > c.maxItems || c.cachedBytes > c.maxBytes {
 		return true
@@ -349,15 +379,31 @@ func (c *PostingsForMatchersCache) shouldEvictHead() bool {
 		return false
 	}
 	ts := h.Value.(*postingsForMatchersCachedCall).ts
-	return c.timeNow().Sub(ts) >= c.ttl
+	return now.Sub(ts) >= c.ttl
 }
 
-func (c *PostingsForMatchersCache) evictHead() {
+func (c *PostingsForMatchersCache) evictHead(now time.Time) (reason int) {
 	front := c.cached.Front()
 	oldest := front.Value.(*postingsForMatchersCachedCall)
+
+	// Detect the reason why we're evicting it.
+	switch {
+	case now.Sub(oldest.ts) >= c.ttl:
+		reason = evictionReasonTTL
+	case c.cachedBytes > c.maxBytes:
+		reason = evictionReasonMaxBytes
+	case c.cached.Len() > c.maxItems:
+		reason = evictionReasonMaxItems
+	default:
+		// This should never happen, but we track it to detect unexpected behaviours.
+		reason = evictionReasonUnknown
+	}
+
 	c.calls.Delete(oldest.key)
 	c.cached.Remove(front)
 	c.cachedBytes -= oldest.sizeBytes
+
+	return
 }
 
 // onPromiseExecutionDone must be called once the execution of PostingsForMatchers promise has done.
@@ -555,18 +601,25 @@ func (t *contextsTracker) trackedContextsCount() int {
 }
 
 type PostingsForMatchersCacheMetrics struct {
-	requests               prometheus.Counter
-	hits                   prometheus.Counter
-	misses                 prometheus.Counter
-	skipsBecauseIneligible prometheus.Counter
-	skipsBecauseStale      prometheus.Counter
-	skipsBecauseCanceled   prometheus.Counter
+	requests                 prometheus.Counter
+	hits                     prometheus.Counter
+	misses                   prometheus.Counter
+	skipsBecauseIneligible   prometheus.Counter
+	skipsBecauseStale        prometheus.Counter
+	skipsBecauseCanceled     prometheus.Counter
+	evictionsBecauseTTL      prometheus.Counter
+	evictionsBecauseMaxBytes prometheus.Counter
+	evictionsBecauseMaxItems prometheus.Counter
+	evictionsBecauseUnknown  prometheus.Counter
 }
 
 func NewPostingsForMatchersCacheMetrics(reg prometheus.Registerer) *PostingsForMatchersCacheMetrics {
 	const (
 		skipsMetric = "postings_for_matchers_cache_skips_total"
 		skipsHelp   = "Total number of requests to the PostingsForMatchers cache that have been skipped the cache. The subsequent result is not cached."
+
+		evictionsMetric = "postings_for_matchers_cache_evictions_total"
+		evictionsHelp   = "Total number of evictions from the PostingsForMatchers cache."
 	)
 
 	return &PostingsForMatchersCacheMetrics{
@@ -596,6 +649,26 @@ func NewPostingsForMatchersCacheMetrics(reg prometheus.Registerer) *PostingsForM
 			Name:        skipsMetric,
 			Help:        skipsHelp,
 			ConstLabels: map[string]string{"reason": "canceled-cached-entry"},
+		}),
+		evictionsBecauseTTL: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        evictionsMetric,
+			Help:        evictionsHelp,
+			ConstLabels: map[string]string{"reason": "ttl-expired"},
+		}),
+		evictionsBecauseMaxBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        evictionsMetric,
+			Help:        evictionsHelp,
+			ConstLabels: map[string]string{"reason": "max-bytes-reached"},
+		}),
+		evictionsBecauseMaxItems: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        evictionsMetric,
+			Help:        evictionsHelp,
+			ConstLabels: map[string]string{"reason": "max-items-reached"},
+		}),
+		evictionsBecauseUnknown: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        evictionsMetric,
+			Help:        evictionsHelp,
+			ConstLabels: map[string]string{"reason": "unknown"},
 		}),
 	}
 }

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -79,6 +79,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 					postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 					postings_for_matchers_cache_skips_total{reason="ineligible"} %d
 					postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+					# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+					# TYPE postings_for_matchers_cache_evictions_total counter
+					postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+					postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+					postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+					postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 				`, expectedMisses, expectedDisabled))))
 			})
 		}
@@ -114,6 +121,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -238,6 +252,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 2
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -279,6 +300,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -332,6 +360,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 1
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -347,7 +382,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		}
 
 		callsPerMatchers := map[string]int{}
-		c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, maxItems, 1000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
+		c := newPostingsForMatchersCache(DefaultPostingsForMatchersCacheTTL, maxItems, 100000, func(_ context.Context, ix IndexPostingsReader, ms ...*labels.Matcher) (index.Postings, error) {
 			k := matchersKey(ms)
 			callsPerMatchers[k]++
 			return index.ErrPostings(fmt.Errorf("result from call %d", callsPerMatchers[k])), nil
@@ -401,6 +436,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 1
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -497,6 +539,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 1
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -565,6 +614,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -656,6 +712,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 
@@ -740,6 +803,13 @@ func TestPostingsForMatchersCache(t *testing.T) {
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 	})
 }
@@ -834,6 +904,13 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 		postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 0
 		postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 		postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 1
+
+		# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+		# TYPE postings_for_matchers_cache_evictions_total counter
+		postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+		postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+		postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 1
+		postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 	`)))
 }
 
@@ -918,6 +995,13 @@ func TestPostingsForMatchersCache_RaceConditionBetweenExecutionContextCancellati
 			postings_for_matchers_cache_skips_total{reason="canceled-cached-entry"} 1
 			postings_for_matchers_cache_skips_total{reason="ineligible"} 0
 			postings_for_matchers_cache_skips_total{reason="stale-cached-entry"} 0
+
+			# HELP postings_for_matchers_cache_evictions_total Total number of evictions from the PostingsForMatchers cache.
+			# TYPE postings_for_matchers_cache_evictions_total counter
+			postings_for_matchers_cache_evictions_total{reason="max-bytes-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="max-items-reached"} 0
+			postings_for_matchers_cache_evictions_total{reason="ttl-expired"} 0
+			postings_for_matchers_cache_evictions_total{reason="unknown"} 0
 		`)))
 }
 


### PR DESCRIPTION
In https://github.com/grafana/mimir-prometheus/pull/822 I've introduced metrics for the `PostingsForMatchers` cache. In this PR I'm extending the metrics to count evictions by reason.

Ref: https://github.com/grafana/pir-actions/issues/307

**Benchmarks**

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M3 Pro
                                                          │ before.txt  │             after.txt             │
                                                          │   sec/op    │   sec/op     vs base              │
PostingsForMatchersCache/no_evictions-11                    639.1n ± 2%   636.2n ± 1%       ~ (p=0.394 n=6)
PostingsForMatchersCache/high_eviction_rate-11              10.66µ ± 0%   10.70µ ± 1%       ~ (p=0.071 n=6)
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   328.2n ± 1%   326.3n ± 3%       ~ (p=0.167 n=6)
geomean                                                     1.308µ        1.305µ       -0.24%

                                                          │  before.txt  │              after.txt               │
                                                          │     B/op     │     B/op      vs base                │
PostingsForMatchersCache/no_evictions-11                      974.0 ± 0%     974.0 ± 0%       ~ (p=1.000 n=6) ¹
PostingsForMatchersCache/high_eviction_rate-11              26.32Ki ± 0%   26.32Ki ± 0%       ~ (p=1.000 n=6) ¹
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   1.000Ki ± 0%   1.000Ki ± 0%       ~ (p=1.000 n=6)
geomean                                                     2.925Ki        2.925Ki       +0.00%
¹ all samples are equal

                                                          │ before.txt │             after.txt              │
                                                          │ allocs/op  │ allocs/op   vs base                │
PostingsForMatchersCache/no_evictions-11                    20.00 ± 0%   20.00 ± 0%       ~ (p=1.000 n=6) ¹
PostingsForMatchersCache/high_eviction_rate-11              46.00 ± 0%   46.00 ± 0%       ~ (p=1.000 n=6) ¹
PostingsForMatchersCache_ConcurrencyOnHighEvictionRate-11   20.00 ± 0%   20.00 ± 5%       ~ (p=1.000 n=6)
geomean                                                     26.40        26.40       +0.00%
¹ all samples are equal
```