### PR TITLE
Sync upstream Prometheus at 39d7242

### DIFF
--- a/rules/fixtures/alert_rule.yaml
+++ b/rules/fixtures/alert_rule.yaml
@@ -1,0 +1,6 @@
+groups:
+  - name: test
+    interval: 1s
+    rules:
+      - alert: rule1
+        expr: 1 < bool 2

--- a/rules/fixtures/alert_rule1.yaml
+++ b/rules/fixtures/alert_rule1.yaml
@@ -1,0 +1,6 @@
+groups:
+  - name: test2
+    interval: 1s
+    rules:
+      - alert: rule2
+        expr: 1 < bool 2

--- a/rules/fixtures/rules_alerts.yaml
+++ b/rules/fixtures/rules_alerts.yaml
@@ -1,5 +1,0 @@
-groups:
-  - name: test
-    rules:
-      - alert: test
-        expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/fixtures/rules_alerts2.yaml
+++ b/rules/fixtures/rules_alerts2.yaml
@@ -1,5 +1,0 @@
-groups:
-  - name: test
-    rules:
-      - alert: test_2
-        expr: sum by (job)(rate(http_requests_total[5m]))

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -854,69 +854,6 @@ func TestUpdate(t *testing.T) {
 	reloadAndValidate(rgs, t, tmpFile, ruleManager, ogs)
 }
 
-func TestUpdate_AlwaysRestore(t *testing.T) {
-	st := teststorage.New(t)
-	defer st.Close()
-
-	ruleManager := NewManager(&ManagerOptions{
-		Appendable:           st,
-		Queryable:            st,
-		Context:              context.Background(),
-		Logger:               promslog.NewNopLogger(),
-		RestoreNewRuleGroups: true,
-	})
-	ruleManager.start()
-	defer ruleManager.Stop()
-
-	err := ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts.yaml"}, labels.EmptyLabels(), "", nil)
-	require.NoError(t, err)
-
-	for _, g := range ruleManager.groups {
-		require.True(t, g.shouldRestore)
-		g.shouldRestore = false // set to false to check if Update will set it to true again
-	}
-
-	// Use different file, so groups haven't changed, therefore, we expect state restoration
-	err = ruleManager.Update(10*time.Second, []string{"fixtures/rules_alerts2.yaml"}, labels.EmptyLabels(), "", nil)
-	for _, g := range ruleManager.groups {
-		require.True(t, g.shouldRestore)
-	}
-
-	require.NoError(t, err)
-}
-
-func TestUpdate_AlwaysRestoreDoesntAffectUnchangedGroups(t *testing.T) {
-	files := []string{"fixtures/rules_alerts.yaml"}
-	st := teststorage.New(t)
-	defer st.Close()
-
-	ruleManager := NewManager(&ManagerOptions{
-		Appendable:           st,
-		Queryable:            st,
-		Context:              context.Background(),
-		Logger:               promslog.NewNopLogger(),
-		RestoreNewRuleGroups: true,
-	})
-	ruleManager.start()
-	defer ruleManager.Stop()
-
-	err := ruleManager.Update(10*time.Second, files, labels.EmptyLabels(), "", nil)
-	require.NoError(t, err)
-
-	for _, g := range ruleManager.groups {
-		require.True(t, g.shouldRestore)
-		g.shouldRestore = false // set to false to check if Update will set it to true again
-	}
-
-	// Use the same file, so groups haven't changed, therefore, we don't expect state restoration
-	err = ruleManager.Update(10*time.Second, files, labels.EmptyLabels(), "", nil)
-	for _, g := range ruleManager.groups {
-		require.False(t, g.shouldRestore)
-	}
-
-	require.NoError(t, err)
-}
-
 func TestUpdateSetsSourceTenants(t *testing.T) {
 	st := teststorage.New(t)
 	defer st.Close()

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -859,11 +859,11 @@ func TestUpdate_AlwaysRestore(t *testing.T) {
 	defer st.Close()
 
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable:              st,
-		Queryable:               st,
-		Context:                 context.Background(),
-		Logger:                  promslog.NewNopLogger(),
-		AlwaysRestoreAlertState: true,
+		Appendable:           st,
+		Queryable:            st,
+		Context:              context.Background(),
+		Logger:               promslog.NewNopLogger(),
+		RestoreNewRuleGroups: true,
 	})
 	ruleManager.start()
 	defer ruleManager.Stop()
@@ -891,11 +891,11 @@ func TestUpdate_AlwaysRestoreDoesntAffectUnchangedGroups(t *testing.T) {
 	defer st.Close()
 
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable:              st,
-		Queryable:               st,
-		Context:                 context.Background(),
-		Logger:                  promslog.NewNopLogger(),
-		AlwaysRestoreAlertState: true,
+		Appendable:           st,
+		Queryable:            st,
+		Context:              context.Background(),
+		Logger:               promslog.NewNopLogger(),
+		RestoreNewRuleGroups: true,
 	})
 	ruleManager.start()
 	defer ruleManager.Stop()
@@ -2499,6 +2499,139 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		// Each rule produces one vector.
 		require.EqualValues(t, ruleCount, testutil.ToFloat64(group.metrics.GroupSamples))
 	})
+}
+
+func TestNewRuleGroupRestoration(t *testing.T) {
+	store := teststorage.New(t)
+	t.Cleanup(func() { store.Close() })
+	var (
+		inflightQueries atomic.Int32
+		maxInflight     atomic.Int32
+		maxConcurrency  int64
+		interval        = 60 * time.Second
+	)
+
+	waitForEvaluations := func(t *testing.T, ch <-chan int32, targetCount int32) {
+		for {
+			select {
+			case cnt := <-ch:
+				if cnt == targetCount {
+					return
+				}
+			case <-time.After(5 * time.Second):
+				return
+			}
+		}
+	}
+
+	files := []string{"fixtures/alert_rule.yaml"}
+
+	option := optsFactory(store, &maxInflight, &inflightQueries, maxConcurrency)
+	option.Queryable = store
+	option.Appendable = store
+	option.NotifyFunc = func(ctx context.Context, expr string, alerts ...*Alert) {}
+
+	var evalCount atomic.Int32
+	ch := make(chan int32)
+	noopEvalIterFunc := func(ctx context.Context, g *Group, evalTimestamp time.Time) {
+		evalCount.Inc()
+		ch <- evalCount.Load()
+	}
+
+	ruleManager := NewManager(option)
+	go ruleManager.Run()
+	err := ruleManager.Update(interval, files, labels.EmptyLabels(), "", noopEvalIterFunc)
+	require.NoError(t, err)
+
+	waitForEvaluations(t, ch, 3)
+	require.Equal(t, int32(3), evalCount.Load())
+	ruleGroups := make(map[string]struct{})
+	for _, group := range ruleManager.groups {
+		ruleGroups[group.Name()] = struct{}{}
+		require.False(t, group.shouldRestore)
+		for _, rule := range group.rules {
+			require.True(t, rule.(*AlertingRule).restored.Load())
+		}
+	}
+
+	files = append(files, "fixtures/alert_rule1.yaml")
+	err = ruleManager.Update(interval, files, labels.EmptyLabels(), "", nil)
+	require.NoError(t, err)
+	ruleManager.Stop()
+	for _, group := range ruleManager.groups {
+		// new rule groups added to existing manager will not be restored
+		require.False(t, group.shouldRestore)
+	}
+}
+
+func TestNewRuleGroupRestorationWithRestoreNewGroupOption(t *testing.T) {
+	store := teststorage.New(t)
+	t.Cleanup(func() { store.Close() })
+	var (
+		inflightQueries atomic.Int32
+		maxInflight     atomic.Int32
+		maxConcurrency  int64
+		interval        = 60 * time.Second
+	)
+
+	waitForEvaluations := func(t *testing.T, ch <-chan int32, targetCount int32) {
+		for {
+			select {
+			case cnt := <-ch:
+				if cnt == targetCount {
+					return
+				}
+			case <-time.After(5 * time.Second):
+				return
+			}
+		}
+	}
+
+	files := []string{"fixtures/alert_rule.yaml"}
+
+	option := optsFactory(store, &maxInflight, &inflightQueries, maxConcurrency)
+	option.Queryable = store
+	option.Appendable = store
+	option.RestoreNewRuleGroups = true
+	option.NotifyFunc = func(ctx context.Context, expr string, alerts ...*Alert) {}
+
+	var evalCount atomic.Int32
+	ch := make(chan int32)
+	noopEvalIterFunc := func(ctx context.Context, g *Group, evalTimestamp time.Time) {
+		evalCount.Inc()
+		ch <- evalCount.Load()
+	}
+
+	ruleManager := NewManager(option)
+	go ruleManager.Run()
+	err := ruleManager.Update(interval, files, labels.EmptyLabels(), "", noopEvalIterFunc)
+	require.NoError(t, err)
+
+	waitForEvaluations(t, ch, 3)
+	require.Equal(t, int32(3), evalCount.Load())
+	ruleGroups := make(map[string]struct{})
+	for _, group := range ruleManager.groups {
+		ruleGroups[group.Name()] = struct{}{}
+		require.False(t, group.shouldRestore)
+		for _, rule := range group.rules {
+			require.True(t, rule.(*AlertingRule).restored.Load())
+		}
+	}
+
+	files = append(files, "fixtures/alert_rule1.yaml")
+	err = ruleManager.Update(interval, files, labels.EmptyLabels(), "", nil)
+	require.NoError(t, err)
+	// stop eval
+	ruleManager.Stop()
+	for _, group := range ruleManager.groups {
+		if _, OK := ruleGroups[group.Name()]; OK {
+			// already restored
+			require.False(t, group.shouldRestore)
+			continue
+		}
+		// new rule groups added to existing manager will be restored
+		require.True(t, group.shouldRestore)
+	}
 }
 
 func TestBoundedRuleEvalConcurrency(t *testing.T) {


### PR DESCRIPTION
This PR steps us closer to being in sync with the latest upstream changes.

Diff: https://github.com/prometheus/prometheus/compare/0962d08...39d7242

The only change in this PR is https://github.com/prometheus/prometheus/pull/15669, which is a direct replacement for a similar change we had made in this fork in https://github.com/grafana/mimir-prometheus/pull/328.

To confirm there are no regressions, I ran the tests from #328 with the newly introduced `RestoreNewRuleGroups` option, and they passed. Given the upstream PR also introduced similar tests for this feature, I've therefore removed the tests added in #328.