### PR TITLE
Sync upstream Prometheus at 898af61

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,0 +1,30 @@
+---
+name: Dependabot auto-merge
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'prometheus' }}
+    steps:
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Enable auto-merge for Dependabot PRs
+      if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.23-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/setup_environment
         with:
           enable_npm: true
@@ -30,7 +30,7 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.23-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/setup_environment
       - run: go test --tags=dedupelabels ./...
       - run: GOARCH=386 go test ./...
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/setup_environment
         with:
           enable_go: false
@@ -122,7 +122,7 @@ jobs:
         thread: [ 0, 1, 2 ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/build
         with:
           promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
@@ -147,7 +147,7 @@ jobs:
     # should also be updated.
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/build
         with:
           parallelism: 12
@@ -209,7 +209,7 @@ jobs:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/publish_main
         with:
           docker_hub_login: ${{ secrets.docker_hub_login }}
@@ -226,7 +226,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/publish_release
         with:
           docker_hub_login: ${{ secrets.docker_hub_login }}
@@ -241,7 +241,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - name: Install nodejs
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -126,6 +126,9 @@ linters-settings:
           - allowTypesBefore: "*testing.T,testing.TB"
       - name: context-keys-type
       - name: dot-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
       # A lot of false positives: incorrectly identifies channel draining as "empty code block".
       # See https://github.com/mgechev/revive/issues/386
       - name: empty-block
@@ -137,6 +140,8 @@ linters-settings:
       - name: exported
       - name: increment-decrement
       - name: indent-error-flow
+        arguments:
+          - "preserveScope"
       - name: package-comments
         # TODO(beorn7): Currently, we have a lot of missing package doc comments. Maybe we should have them.
         disabled: true
@@ -144,6 +149,8 @@ linters-settings:
       - name: receiver-naming
       - name: redefines-builtin-id
       - name: superfluous-else
+        arguments:
+          - "preserveScope"
       - name: time-naming
       - name: unexported-return
       - name: unreachable-code

--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -149,7 +149,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				_, ts, v := p.Series()
 				if ts == nil {
 					l := labels.Labels{}
-					p.Metric(&l)
+					p.Labels(&l)
 					return fmt.Errorf("expected timestamp for series %v, got none", l)
 				}
 				if *ts < t {
@@ -163,7 +163,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				}
 
 				l := labels.Labels{}
-				p.Metric(&l)
+				p.Labels(&l)
 
 				lb.Reset(l)
 				for name, value := range customLabels {

--- a/cmd/promtool/tsdb_posix_test.go
+++ b/cmd/promtool/tsdb_posix_test.go
@@ -1,0 +1,69 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/tsdb"
+)
+
+func TestTSDBDumpOpenMetricsRoundTripPipe(t *testing.T) {
+	initialMetrics, err := os.ReadFile("testdata/dump-openmetrics-roundtrip-test.prom")
+	require.NoError(t, err)
+	initialMetrics = normalizeNewLine(initialMetrics)
+
+	pipeDir := t.TempDir()
+	dbDir := t.TempDir()
+
+	// create pipe
+	pipe := path.Join(pipeDir, "pipe")
+	err = syscall.Mkfifo(pipe, 0o666)
+	require.NoError(t, err)
+
+	go func() {
+		// open pipe to write
+		in, err := os.OpenFile(pipe, os.O_WRONLY, os.ModeNamedPipe)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, in.Close()) }()
+		_, err = io.Copy(in, bytes.NewReader(initialMetrics))
+		require.NoError(t, err)
+	}()
+
+	// Import samples from OM format
+	code := backfillOpenMetrics(pipe, dbDir, false, false, 2*time.Hour, map[string]string{})
+	require.Equal(t, 0, code)
+	db, err := tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	// Dump the blocks into OM format
+	dumpedMetrics := getDumpedSamples(t, dbDir, "", math.MinInt64, math.MaxInt64, []string{"{__name__=~'(?s:.*)'}"}, formatSeriesSetOpenMetrics)
+
+	// Should get back the initial metrics.
+	require.Equal(t, string(initialMetrics), dumpedMetrics)
+}

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -458,11 +458,10 @@ func (d *Discovery) vmToLabelSet(ctx context.Context, client client, vm virtualM
 				networkInterface, err = client.getVMScaleSetVMNetworkInterfaceByID(ctx, nicID, vm.ScaleSet, vm.InstanceID)
 			}
 			if err != nil {
-				if errors.Is(err, errorNotFound) {
-					d.logger.Warn("Network interface does not exist", "name", nicID, "err", err)
-				} else {
+				if !errors.Is(err, errorNotFound) {
 					return nil, err
 				}
+				d.logger.Warn("Network interface does not exist", "name", nicID, "err", err)
 				// Get out of this routine because we cannot continue without a network interface.
 				return nil, nil
 			}

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -194,13 +194,12 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		events, err := d.client.ListEvents(ctx, &eventsOpts)
 		if err != nil {
 			var e *linodego.Error
-			if errors.As(err, &e) && e.Code == http.StatusUnauthorized {
-				// If we get a 401, the token doesn't have `events:read_only` scope.
-				// Disable event polling and fallback to doing a full refresh every interval.
-				d.eventPollingEnabled = false
-			} else {
+			if !(errors.As(err, &e) && e.Code == http.StatusUnauthorized) {
 				return nil, err
 			}
+			// If we get a 401, the token doesn't have `events:read_only` scope.
+			// Disable event polling and fallback to doing a full refresh every interval.
+			d.eventPollingEnabled = false
 		} else {
 			// Event polling tells us changes the Linode API is aware of. Actions issued outside of the Linode API,
 			// such as issuing a `shutdown` at the VM's console instead of using the API to power off an instance,

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -101,12 +101,12 @@ func NewManager(ctx context.Context, logger *slog.Logger, registerer prometheus.
 
 	// Register the metrics.
 	// We have to do this after setting all options, so that the name of the Manager is set.
-	if metrics, err := NewManagerMetrics(registerer, mgr.name); err == nil {
-		mgr.metrics = metrics
-	} else {
+	metrics, err := NewManagerMetrics(registerer, mgr.name)
+	if err != nil {
 		logger.Error("Failed to create discovery manager metrics", "manager", mgr.name, "err", err)
 		return nil
 	}
+	mgr.metrics = metrics
 
 	return mgr
 }

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -237,17 +237,16 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		if len(networks) == 0 {
 			// Try to lookup shared networks
 			for {
-				if containerNetworkMode.IsContainer() {
-					tmpContainer, exists := allContainers[containerNetworkMode.ConnectedContainer()]
-					if !exists {
-						break
-					}
-					networks = tmpContainer.NetworkSettings.Networks
-					containerNetworkMode = container.NetworkMode(tmpContainer.HostConfig.NetworkMode)
-					if len(networks) > 0 {
-						break
-					}
-				} else {
+				if !containerNetworkMode.IsContainer() {
+					break
+				}
+				tmpContainer, exists := allContainers[containerNetworkMode.ConnectedContainer()]
+				if !exists {
+					break
+				}
+				networks = tmpContainer.NetworkSettings.Networks
+				containerNetworkMode = container.NetworkMode(tmpContainer.HostConfig.NetworkMode)
+				if len(networks) > 0 {
 					break
 				}
 			}

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -190,14 +190,12 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 			}
 
 			if len(ipv6Addresses) > 0 {
-				addr = ipv6Addresses[0]
 				labels[instancePublicIPv6AddressesLabel] = model.LabelValue(
 					separator +
 						strings.Join(ipv6Addresses, separator) +
 						separator)
 			}
 			if len(ipv4Addresses) > 0 {
-				addr = ipv4Addresses[0]
 				labels[instancePublicIPv4AddressesLabel] = model.LabelValue(
 					separator +
 						strings.Join(ipv4Addresses, separator) +

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -35,28 +35,30 @@ import (
 const (
 	instanceLabelPrefix = metaLabelPrefix + "instance_"
 
-	instanceBootTypeLabel          = instanceLabelPrefix + "boot_type"
-	instanceHostnameLabel          = instanceLabelPrefix + "hostname"
-	instanceIDLabel                = instanceLabelPrefix + "id"
-	instanceImageArchLabel         = instanceLabelPrefix + "image_arch"
-	instanceImageIDLabel           = instanceLabelPrefix + "image_id"
-	instanceImageNameLabel         = instanceLabelPrefix + "image_name"
-	instanceLocationClusterID      = instanceLabelPrefix + "location_cluster_id"
-	instanceLocationHypervisorID   = instanceLabelPrefix + "location_hypervisor_id"
-	instanceLocationNodeID         = instanceLabelPrefix + "location_node_id"
-	instanceNameLabel              = instanceLabelPrefix + "name"
-	instanceOrganizationLabel      = instanceLabelPrefix + "organization_id"
-	instancePrivateIPv4Label       = instanceLabelPrefix + "private_ipv4"
-	instanceProjectLabel           = instanceLabelPrefix + "project_id"
-	instancePublicIPv4Label        = instanceLabelPrefix + "public_ipv4"
-	instancePublicIPv6Label        = instanceLabelPrefix + "public_ipv6"
-	instanceSecurityGroupIDLabel   = instanceLabelPrefix + "security_group_id"
-	instanceSecurityGroupNameLabel = instanceLabelPrefix + "security_group_name"
-	instanceStateLabel             = instanceLabelPrefix + "status"
-	instanceTagsLabel              = instanceLabelPrefix + "tags"
-	instanceTypeLabel              = instanceLabelPrefix + "type"
-	instanceZoneLabel              = instanceLabelPrefix + "zone"
-	instanceRegionLabel            = instanceLabelPrefix + "region"
+	instanceBootTypeLabel            = instanceLabelPrefix + "boot_type"
+	instanceHostnameLabel            = instanceLabelPrefix + "hostname"
+	instanceIDLabel                  = instanceLabelPrefix + "id"
+	instanceImageArchLabel           = instanceLabelPrefix + "image_arch"
+	instanceImageIDLabel             = instanceLabelPrefix + "image_id"
+	instanceImageNameLabel           = instanceLabelPrefix + "image_name"
+	instanceLocationClusterID        = instanceLabelPrefix + "location_cluster_id"
+	instanceLocationHypervisorID     = instanceLabelPrefix + "location_hypervisor_id"
+	instanceLocationNodeID           = instanceLabelPrefix + "location_node_id"
+	instanceNameLabel                = instanceLabelPrefix + "name"
+	instanceOrganizationLabel        = instanceLabelPrefix + "organization_id"
+	instancePrivateIPv4Label         = instanceLabelPrefix + "private_ipv4"
+	instanceProjectLabel             = instanceLabelPrefix + "project_id"
+	instancePublicIPv4Label          = instanceLabelPrefix + "public_ipv4"
+	instancePublicIPv6Label          = instanceLabelPrefix + "public_ipv6"
+	instancePublicIPv4AddressesLabel = instanceLabelPrefix + "public_ipv4_addresses"
+	instancePublicIPv6AddressesLabel = instanceLabelPrefix + "public_ipv6_addresses"
+	instanceSecurityGroupIDLabel     = instanceLabelPrefix + "security_group_id"
+	instanceSecurityGroupNameLabel   = instanceLabelPrefix + "security_group_name"
+	instanceStateLabel               = instanceLabelPrefix + "status"
+	instanceTagsLabel                = instanceLabelPrefix + "tags"
+	instanceTypeLabel                = instanceLabelPrefix + "type"
+	instanceZoneLabel                = instanceLabelPrefix + "zone"
+	instanceRegionLabel              = instanceLabelPrefix + "region"
 )
 
 type instanceDiscovery struct {
@@ -175,6 +177,34 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 		}
 
 		addr := ""
+		if len(server.PublicIPs) > 0 {
+			var ipv4Addresses []string
+			var ipv6Addresses []string
+
+			for _, ip := range server.PublicIPs {
+				if ip.Family == instance.ServerIPIPFamilyInet {
+					ipv4Addresses = append(ipv4Addresses, ip.Address.String())
+				} else if ip.Family == instance.ServerIPIPFamilyInet6 {
+					ipv6Addresses = append(ipv6Addresses, ip.Address.String())
+				}
+			}
+
+			if len(ipv6Addresses) > 0 {
+				addr = ipv6Addresses[0]
+				labels[instancePublicIPv6AddressesLabel] = model.LabelValue(
+					separator +
+						strings.Join(ipv6Addresses, separator) +
+						separator)
+			}
+			if len(ipv4Addresses) > 0 {
+				addr = ipv4Addresses[0]
+				labels[instancePublicIPv4AddressesLabel] = model.LabelValue(
+					separator +
+						strings.Join(ipv4Addresses, separator) +
+						separator)
+			}
+		}
+
 		if server.IPv6 != nil { //nolint:staticcheck
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String()) //nolint:staticcheck
 			addr = server.IPv6.Address.String()                                              //nolint:staticcheck

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -209,8 +209,10 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 		}
 
 		if server.PublicIP != nil { //nolint:staticcheck
-			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String()) //nolint:staticcheck
-			addr = server.PublicIP.Address.String()                                              //nolint:staticcheck
+			if server.PublicIP.Family != instance.ServerIPIPFamilyInet6 { //nolint:staticcheck
+				labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String()) //nolint:staticcheck
+			}
+			addr = server.PublicIP.Address.String() //nolint:staticcheck
 		}
 
 		if server.PrivateIP != nil {

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -60,7 +60,7 @@ api_url: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Len(t, tg.Targets, 3)
+	require.Len(t, tg.Targets, 4)
 
 	for i, lbls := range []model.LabelSet{
 		{
@@ -133,6 +133,30 @@ api_url: %s
 			"__meta_scaleway_instance_status":                 "running",
 			"__meta_scaleway_instance_type":                   "DEV1-S",
 			"__meta_scaleway_instance_zone":                   "nl-ams-1",
+		},
+		{
+			"__address__":                                     "163.172.136.10:80",
+			"__meta_scaleway_instance_boot_type":              "local",
+			"__meta_scaleway_instance_hostname":               "multiple-ips",
+			"__meta_scaleway_instance_id":                     "658abbf4-e6c6-4239-a483-3307763cf6e0",
+			"__meta_scaleway_instance_image_arch":             "x86_64",
+			"__meta_scaleway_instance_image_id":               "f583f58c-1ea5-44ab-a1e6-2b2e7df32a86",
+			"__meta_scaleway_instance_image_name":             "Ubuntu 24.04 Noble Numbat",
+			"__meta_scaleway_instance_location_cluster_id":    "7",
+			"__meta_scaleway_instance_location_hypervisor_id": "801",
+			"__meta_scaleway_instance_location_node_id":       "95",
+			"__meta_scaleway_instance_name":                   "multiple-ips",
+			"__meta_scaleway_instance_organization_id":        "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+			"__meta_scaleway_instance_project_id":             "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+			"__meta_scaleway_instance_public_ipv4":            "163.172.136.10",
+			"__meta_scaleway_instance_public_ipv4_addresses":  ",163.172.136.10,212.47.248.223,51.15.231.134,",
+			"__meta_scaleway_instance_public_ipv6_addresses":  ",2001:bc8:710:4a69:dc00:ff:fe58:40c1,2001:bc8:710:d::,2001:bc8:710:5417::,",
+			"__meta_scaleway_instance_region":                 "fr-par",
+			"__meta_scaleway_instance_security_group_id":      "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
+			"__meta_scaleway_instance_security_group_name":    "Default security group",
+			"__meta_scaleway_instance_status":                 "running",
+			"__meta_scaleway_instance_type":                   "PLAY2-PICO",
+			"__meta_scaleway_instance_zone":                   "fr-par-1",
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -125,6 +125,8 @@ api_url: %s
 			"__meta_scaleway_instance_organization_id":        "20b3d507-96ac-454c-a795-bc731b46b12f",
 			"__meta_scaleway_instance_project_id":             "20b3d507-96ac-454c-a795-bc731b46b12f",
 			"__meta_scaleway_instance_public_ipv4":            "51.158.183.115",
+			"__meta_scaleway_instance_public_ipv4_addresses":  ",51.158.183.115,",
+			"__meta_scaleway_instance_public_ipv6_addresses":  ",2001:bc8:1640:1568:dc00:ff:fe21:91b,",
 			"__meta_scaleway_instance_region":                 "nl-ams",
 			"__meta_scaleway_instance_security_group_id":      "984414da-9fc2-49c0-a925-fed6266fe092",
 			"__meta_scaleway_instance_security_group_name":    "Default security group",

--- a/discovery/scaleway/testdata/instance.json
+++ b/discovery/scaleway/testdata/instance.json
@@ -356,6 +356,222 @@
       "placement_group": null,
       "private_nics": [],
       "zone": "nl-ams-1"
+    },
+    {
+      "id": "658abbf4-e6c6-4239-a483-3307763cf6e0",
+      "name": "multiple-ips",
+      "arch": "x86_64",
+      "commercial_type": "PLAY2-PICO",
+      "boot_type": "local",
+      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "multiple-ips",
+      "image": {
+        "id": "f583f58c-1ea5-44ab-a1e6-2b2e7df32a86",
+        "name": "Ubuntu 24.04 Noble Numbat",
+        "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "project": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "root_volume": {
+          "id": "cfab1e2e-fa24-480a-a372-61b19e8e2fda",
+          "name": "Ubuntu 24.04 Noble Numbat",
+          "volume_type": "unified",
+          "size": 10000000000
+        },
+        "extra_volumes": {
+
+        },
+        "public": true,
+        "arch": "x86_64",
+        "creation_date": "2024-04-26T09:24:38.624912+00:00",
+        "modification_date": "2024-04-26T09:24:38.624912+00:00",
+        "default_bootscript": null,
+        "from_server": "",
+        "state": "available",
+        "tags": [
+
+        ],
+        "zone": "fr-par-1"
+      },
+      "volumes": {
+        "0": {
+          "boot": false,
+          "id": "7d4dc5ae-3f3c-4f9c-91cf-4a47a2193e94",
+          "name": "Ubuntu 24.04 Noble Numbat",
+          "volume_type": "b_ssd",
+          "export_uri": null,
+          "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+          "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+          "server": {
+            "id": "658abbf4-e6c6-4239-a483-3307763cf6e0",
+            "name": "multiple-ips"
+          },
+          "size": 10000000000,
+          "state": "available",
+          "creation_date": "2024-06-07T13:33:17.697162+00:00",
+          "modification_date": "2024-06-07T13:33:17.697162+00:00",
+          "tags": [
+
+          ],
+          "zone": "fr-par-1"
+        }
+      },
+      "tags": [
+
+      ],
+      "state": "running",
+      "protected": false,
+      "state_detail": "booted",
+      "public_ip": {
+        "id": "63fd9ede-58d7-482c-b21d-1d79d81a90dc",
+        "address": "163.172.136.10",
+        "dynamic": false,
+        "gateway": "62.210.0.1",
+        "netmask": "32",
+        "family": "inet",
+        "provisioning_mode": "dhcp",
+        "tags": [
+
+        ],
+        "state": "attached",
+        "ipam_id": "700644ed-f6a2-4c64-8508-bb867bc07673"
+      },
+      "public_ips": [
+        {
+          "id": "63fd9ede-58d7-482c-b21d-1d79d81a90dc",
+          "address": "163.172.136.10",
+          "dynamic": false,
+          "gateway": "62.210.0.1",
+          "netmask": "32",
+          "family": "inet",
+          "provisioning_mode": "dhcp",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "700644ed-f6a2-4c64-8508-bb867bc07673"
+        },
+        {
+          "id": "eed4575b-90e5-4102-b956-df874c911e2b",
+          "address": "212.47.248.223",
+          "dynamic": false,
+          "gateway": "62.210.0.1",
+          "netmask": "32",
+          "family": "inet",
+          "provisioning_mode": "manual",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "e2bdef64-828b-4f4a-a56b-954a85759adf"
+        },
+        {
+          "id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
+          "address": "51.15.231.134",
+          "dynamic": false,
+          "gateway": "62.210.0.1",
+          "netmask": "32",
+          "family": "inet",
+          "provisioning_mode": "manual",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "e56808db-b348-4b7e-ad23-995ae08dc1a1"
+        },
+        {
+          "id": "3ffa6774-124c-4e64-8afb-148c15304b25",
+          "address": "2001:bc8:710:4a69:dc00:ff:fe58:40c1",
+          "dynamic": false,
+          "gateway": "fe80::dc00:ff:fe58:40c2",
+          "netmask": "64",
+          "family": "inet6",
+          "provisioning_mode": "slaac",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "d97773d9-fd2c-4085-92bb-5c471abd132e"
+        },
+        {
+          "id": "28fcf539-8492-4603-b627-de0501ce8489",
+          "address": "2001:bc8:710:d::",
+          "dynamic": false,
+          "gateway": "fe80::dc00:ff:fe58:40c2",
+          "netmask": "64",
+          "family": "inet6",
+          "provisioning_mode": "manual",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "005d19ac-203c-4034-ab16-9ff4caadbdd5"
+        },
+        {
+          "id": "db6fafda-3a12-403d-8c9c-1a1cb1c315ba",
+          "address": "2001:bc8:710:5417::",
+          "dynamic": false,
+          "gateway": "fe80::dc00:ff:fe58:40c2",
+          "netmask": "64",
+          "family": "inet6",
+          "provisioning_mode": "manual",
+          "tags": [
+
+          ],
+          "state": "attached",
+          "ipam_id": "8c62fac8-4134-462c-ba48-71ce4f8ac939"
+        }
+      ],
+      "mac_address": "de:00:00:58:40:c1",
+      "routed_ip_enabled": true,
+      "ipv6": null,
+      "extra_networks": [
+
+      ],
+      "dynamic_ip_required": false,
+      "enable_ipv6": false,
+      "private_ip": null,
+      "creation_date": "2024-06-07T13:33:17.697162+00:00",
+      "modification_date": "2024-06-07T13:33:26.021167+00:00",
+      "bootscript": {
+        "id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
+        "public": true,
+        "title": "x86_64 mainline 4.4.230 rev1",
+        "architecture": "x86_64",
+        "organization": "11111111-1111-4111-8111-111111111111",
+        "project": "11111111-1111-4111-8111-111111111111",
+        "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+        "dtb": "",
+        "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+        "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16",
+        "default": true,
+        "zone": "fr-par-1"
+      },
+      "security_group": {
+        "id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
+        "name": "Default security group"
+      },
+      "location": {
+        "zone_id": "par1",
+        "platform_id": "14",
+        "cluster_id": "7",
+        "hypervisor_id": "801",
+        "node_id": "95"
+      },
+      "maintenances": [
+
+      ],
+      "allowed_actions": [
+        "poweroff",
+        "terminate",
+        "reboot",
+        "stop_in_place",
+        "backup"
+      ],
+      "placement_group": null,
+      "private_nics": [
+
+      ],
+      "zone": "fr-par-1"
     }
   ]
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2955,6 +2955,8 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_scaleway_instance_project_id`: project id of the server
 * `__meta_scaleway_instance_public_ipv4`: the public IPv4 address of the server
 * `__meta_scaleway_instance_public_ipv6`: the public IPv6 address of the server
+* `__meta_scaleway_instance_public_ipv4_addresses`: the public IPv4 addresses of the server
+* `__meta_scaleway_instance_public_ipv6_addresses`: the public IPv6 addresses of the server
 * `__meta_scaleway_instance_region`: the region of the server
 * `__meta_scaleway_instance_security_group_id`: the ID of the security group of the server
 * `__meta_scaleway_instance_security_group_name`: the name of the security group of the server

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -288,11 +288,11 @@ func valuesToSamples(timestamp time.Time, value interface{}) (prompb.Sample, err
 	var valueInt64 int64
 	var ok bool
 	if valueFloat64, ok = value.(float64); !ok {
-		if valueInt64, ok = value.(int64); ok {
-			valueFloat64 = float64(valueInt64)
-		} else {
+		valueInt64, ok = value.(int64)
+		if !ok {
 			return prompb.Sample{}, fmt.Errorf("unable to convert sample value to float64: %v", value)
 		}
+		valueFloat64 = float64(valueInt64)
 	}
 
 	return prompb.Sample{

--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -203,7 +203,7 @@ func benchParse(b *testing.B, data []byte, parser string) {
 				b.Fatal("not implemented entry", t)
 			}
 
-			_ = p.Metric(&res)
+			p.Labels(&res)
 			_ = p.CreatedTimestamp()
 			for hasExemplar := p.Exemplar(&e); hasExemplar; hasExemplar = p.Exemplar(&e) {
 			}

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -57,11 +57,10 @@ type Parser interface {
 	// The returned byte slice becomes invalid after the next call to Next.
 	Comment() []byte
 
-	// Metric writes the labels of the current sample into the passed labels.
-	// It returns the string from which the metric was parsed.
+	// Labels writes the labels of the current sample into the passed labels.
 	// The values of the "le" labels of classic histograms and "quantile" labels
 	// of summaries should follow the OpenMetrics formatting rules.
-	Metric(l *labels.Labels) string
+	Labels(l *labels.Labels)
 
 	// Exemplar writes the exemplar of the current sample into the passed
 	// exemplar. It can be called repeatedly to retrieve multiple exemplars

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -238,7 +238,7 @@ func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 				got.m = string(m)
 			}
 
-			p.Metric(&got.lset)
+			p.Labels(&got.lset)
 			// Parser reuses int pointer.
 			if ct := p.CreatedTimestamp(); ct != nil {
 				got.ct = int64p(*ct)

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -67,8 +67,7 @@ type NHCBParser struct {
 	h     *histogram.Histogram
 	fh    *histogram.FloatHistogram
 	// For Metric.
-	lset         labels.Labels
-	metricString string
+	lset labels.Labels
 	// For Type.
 	bName []byte
 	typ   model.MetricType
@@ -141,13 +140,12 @@ func (p *NHCBParser) Comment() []byte {
 	return p.parser.Comment()
 }
 
-func (p *NHCBParser) Metric(l *labels.Labels) string {
+func (p *NHCBParser) Labels(l *labels.Labels) {
 	if p.state == stateEmitting {
 		*l = p.lsetNHCB
-		return p.metricStringNHCB
+		return
 	}
 	*l = p.lset
-	return p.metricString
 }
 
 func (p *NHCBParser) Exemplar(ex *exemplar.Exemplar) bool {
@@ -200,7 +198,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 		switch p.entry {
 		case EntrySeries:
 			p.bytes, p.ts, p.value = p.parser.Series()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			// Check the label set to see if we can continue or need to emit the NHCB.
 			var isNHCB bool
 			if p.compareLabels() {
@@ -224,7 +222,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 			return p.entry, p.err
 		case EntryHistogram:
 			p.bytes, p.ts, p.h, p.fh = p.parser.Histogram()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			p.storeExponentialLabels()
 		case EntryType:
 			p.bName, p.typ = p.parser.Type()

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -197,11 +197,9 @@ func (p *OpenMetricsParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+// Labels writes the labels of the current sample into the passed labels.
+func (p *OpenMetricsParser) Labels(l *labels.Labels) {
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
@@ -220,8 +218,6 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar writes the exemplar of the current sample into the passed exemplar.

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -223,11 +223,9 @@ func (p *PromParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *PromParser) Metric(l *labels.Labels) string {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+// Labels writes the labels of the current sample into the passed labels.
+func (p *PromParser) Labels(l *labels.Labels) {
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
@@ -246,8 +244,6 @@ func (p *PromParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar implements the Parser interface. However, since the classic

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -296,9 +296,9 @@ func (p *ProtobufParser) Comment() []byte {
 	return nil
 }
 
-// Metric writes the labels of the current sample into the passed labels.
+// Labels writes the labels of the current sample into the passed labels.
 // It returns the string from which the metric was parsed.
-func (p *ProtobufParser) Metric(l *labels.Labels) string {
+func (p *ProtobufParser) Labels(l *labels.Labels) {
 	p.builder.Reset()
 	p.builder.Add(labels.MetricName, p.getMagicName())
 
@@ -312,8 +312,6 @@ func (p *ProtobufParser) Metric(l *labels.Labels) string {
 	// Sort labels to maintain the sorted labels invariant.
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return p.metricBytes.String()
 }
 
 // Exemplar writes the exemplar of the current sample into the passed

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3553,11 +3553,11 @@ func formatDate(t time.Time) string {
 // unwrapParenExpr does the AST equivalent of removing parentheses around a expression.
 func unwrapParenExpr(e *parser.Expr) {
 	for {
-		if p, ok := (*e).(*parser.ParenExpr); ok {
-			*e = p.Expr
-		} else {
+		p, ok := (*e).(*parser.ParenExpr)
+		if !ok {
 			break
 		}
+		*e = p.Expr
 	}
 }
 

--- a/promql/promqltest/testdata/subquery.test
+++ b/promql/promqltest/testdata/subquery.test
@@ -134,3 +134,19 @@ eval instant at 20s min_over_time(metric_total[15s:10s])
 eval instant at 20m min_over_time(rate(metric_total[5m])[20m:1m])
   {} 0.12119047619047618
 
+clear
+
+# This native histogram series has a counter reset at 5m.
+# TODO(beorn7): Write this more nicely once https://github.com/prometheus/prometheus/issues/15984 is fixed.
+load 1m
+  native_histogram {{sum:100 count:100}} {{sum:103 count:103}} {{sum:106 count:106}} {{sum:109 count:109}} {{sum:112 count:112}} {{sum:3 count:3 counter_reset_hint:reset}} {{sum:6 count:6}}+{{sum:3 count:3}}x5
+
+# This sub-query has to detect the counter reset even if it does
+# not include the exact sample where the counter reset has happened.
+eval instant at 10m increase(native_histogram[10m:3m])
+  {} {{count:25 sum:25}}
+# This sub-query must not detect the counter reset multiple times
+# even though the sample where the counter reset happened is returned
+# by the sub-query multiple times.
+eval instant at 10m increase(native_histogram[10m:15s])
+  {} {{count:30.769230769230766 sum:30.769230769230766}}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1714,7 +1714,7 @@ loop:
 			lset = ce.lset
 			hash = ce.hash
 		} else {
-			p.Metric(&lset)
+			p.Labels(&lset)
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1988,7 +1988,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 
 	var lset labels.Labels
 	p.Next()
-	p.Metric(&lset)
+	p.Labels(&lset)
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -349,11 +349,10 @@ func (tokenProvider *tokenProvider) getToken(ctx context.Context) error {
 func (tokenProvider *tokenProvider) updateRefreshTime(accessToken azcore.AccessToken) error {
 	tokenExpiryTimestamp := accessToken.ExpiresOn.UTC()
 	deltaExpirytime := time.Now().Add(time.Until(tokenExpiryTimestamp) / 2)
-	if deltaExpirytime.After(time.Now().UTC()) {
-		tokenProvider.refreshTime = deltaExpirytime
-	} else {
+	if !deltaExpirytime.After(time.Now().UTC()) {
 		return errors.New("access token expiry is less than the current time")
 	}
+	tokenProvider.refreshTime = deltaExpirytime
 	return nil
 }
 

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -1026,12 +1026,11 @@ func (a *appender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.L
 		return 0, storage.ErrOutOfOrderCT
 	}
 
-	if ct > series.lastTs {
-		series.lastTs = ct
-	} else {
+	if ct <= series.lastTs {
 		// discard the sample if it's out of order.
 		return 0, storage.ErrOutOfOrderCT
 	}
+	series.lastTs = ct
 
 	switch {
 	case h != nil:
@@ -1091,12 +1090,11 @@ func (a *appender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t,
 		return 0, storage.ErrOutOfOrderSample
 	}
 
-	if ct > series.lastTs {
-		series.lastTs = ct
-	} else {
+	if ct <= series.lastTs {
 		// discard the sample if it's out of order.
 		return 0, storage.ErrOutOfOrderCT
 	}
+	series.lastTs = ct
 
 	// NOTE: always modify pendingSamples and sampleSeries together.
 	a.pendingSamples = append(a.pendingSamples, record.RefSample{

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -275,12 +275,11 @@ func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
 	pos := int(txr.txIDFirst)
 
 	for txr.txIDCount > 0 {
-		if txr.txIDs[pos] < bound {
-			txr.txIDFirst++
-			txr.txIDCount--
-		} else {
+		if txr.txIDs[pos] >= bound {
 			break
 		}
+		txr.txIDFirst++
+		txr.txIDCount--
 
 		pos++
 		if pos == len(txr.txIDs) {

--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -56,8 +56,13 @@ func (c *compressedResponseWriter) Close() {
 
 // Constructs a new compressedResponseWriter based on client request headers.
 func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) *compressedResponseWriter {
-	encodings := strings.Split(req.Header.Get(acceptEncodingHeader), ",")
-	for _, encoding := range encodings {
+	raw := req.Header.Get(acceptEncodingHeader)
+	var (
+		encoding   string
+		commaFound bool
+	)
+	for {
+		encoding, raw, commaFound = strings.Cut(raw, ",")
 		switch strings.TrimSpace(encoding) {
 		case gzipEncoding:
 			writer.Header().Set(contentEncodingHeader, gzipEncoding)
@@ -71,6 +76,9 @@ func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) 
 				ResponseWriter: writer,
 				writer:         zlib.NewWriter(writer),
 			}
+		}
+		if !commaFound {
+			break
 		}
 	}
 	return &compressedResponseWriter{

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/klauspost/compress/gzip"
@@ -70,6 +71,17 @@ func TestCompressionHandler_PlainText(t *testing.T) {
 	expected := "Hello World!"
 	actual := string(contents)
 	require.Equal(t, expected, actual, "expected response with content")
+}
+
+func BenchmarkNewCompressionHandler_MaliciousAcceptEncoding(b *testing.B) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+	req.Header.Set("Accept-Encoding", strings.Repeat(",", http.DefaultMaxHeaderBytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		newCompressedResponseWriter(rec, req)
+	}
 }
 
 func TestCompressionHandler_Gzip(t *testing.T) {

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -403,7 +403,7 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 		}
 		require.NoError(t, err)
 		if et == textparse.EntryHistogram || et == textparse.EntrySeries {
-			p.Metric(&l)
+			p.Labels(&l)
 		}
 		switch et {
 		case textparse.EntryHelp:

--- a/web/ui/mantine-ui/src/App.tsx
+++ b/web/ui/mantine-ui/src/App.tsx
@@ -332,14 +332,16 @@ function App() {
                       justify="space-between"
                       wrap="nowrap"
                     >
-                      <Group gap={65} wrap="nowrap">
+                      <Group gap={40} wrap="nowrap">
                         <Link
                           to="/"
                           style={{ textDecoration: "none", color: "white" }}
                         >
                           <Group gap={10} wrap="nowrap">
                             <img src={PrometheusLogo} height={30} />
-                            <Text fz={20}>Prometheus{agentMode && " Agent"}</Text>
+                            <Text hiddenFrom="sm" fz={20}>Prometheus</Text>
+                            <Text visibleFrom="md" fz={20}>Prometheus</Text>
+                            <Text fz={20}>{agentMode && "Agent"}</Text>
                           </Group>
                         </Link>
                         <Group gap={12} visibleFrom="sm" wrap="nowrap">

--- a/web/ui/mantine-ui/src/components/ThemeSelector.tsx
+++ b/web/ui/mantine-ui/src/components/ThemeSelector.tsx
@@ -1,8 +1,8 @@
 import { useMantineColorScheme, rem, ActionIcon } from "@mantine/core";
 import {
-  IconBrightnessFilled,
   IconMoonFilled,
   IconSunFilled,
+  IconBrightnessFilled,
 } from "@tabler/icons-react";
 import { FC } from "react";
 
@@ -30,11 +30,11 @@ export const ThemeSelector: FC = () => {
       }
     >
       {colorScheme === "light" ? (
-        <IconMoonFilled {...iconProps} />
-      ) : colorScheme === "dark" ? (
-        <IconBrightnessFilled {...iconProps} />
-      ) : (
         <IconSunFilled {...iconProps} />
+      ) : colorScheme === "dark" ? (
+        <IconMoonFilled {...iconProps} />
+      ) : (
+        <IconBrightnessFilled {...iconProps} />
       )}
     </ActionIcon>
   );

--- a/web/ui/mantine-ui/src/components/ThemeSelector.tsx
+++ b/web/ui/mantine-ui/src/components/ThemeSelector.tsx
@@ -1,14 +1,8 @@
+import { useMantineColorScheme, rem, ActionIcon } from "@mantine/core";
 import {
-  useMantineColorScheme,
-  SegmentedControl,
-  rem,
-  MantineColorScheme,
-  Tooltip,
-} from "@mantine/core";
-import {
+  IconBrightnessFilled,
   IconMoonFilled,
   IconSunFilled,
-  IconUserFilled,
 } from "@tabler/icons-react";
 import { FC } from "react";
 
@@ -20,45 +14,28 @@ export const ThemeSelector: FC = () => {
   };
 
   return (
-    <SegmentedControl
-      color="gray.7"
-      size="xs"
-      // styles={{ root: { backgroundColor: "var(--mantine-color-gray-7)" } }}
-      styles={{
-        root: {
-          padding: 3,
-          backgroundColor: "var(--mantine-color-gray-6)",
-        },
-      }}
-      withItemsBorders={false}
-      value={colorScheme}
-      onChange={(v) => setColorScheme(v as MantineColorScheme)}
-      data={[
-        {
-          value: "light",
-          label: (
-            <Tooltip label="Use light theme" offset={15}>
-              <IconSunFilled {...iconProps} />
-            </Tooltip>
-          ),
-        },
-        {
-          value: "dark",
-          label: (
-            <Tooltip label="Use dark theme" offset={15}>
-              <IconMoonFilled {...iconProps} />
-            </Tooltip>
-          ),
-        },
-        {
-          value: "auto",
-          label: (
-            <Tooltip label="Use browser-preferred theme" offset={15}>
-              <IconUserFilled {...iconProps} />
-            </Tooltip>
-          ),
-        },
-      ]}
-    />
+    <ActionIcon
+      color="gray"
+      title={`Switch to ${colorScheme === "light" ? "dark" : colorScheme === "dark" ? "browser-preferred" : "light"} theme`}
+      aria-label={`Switch to ${colorScheme === "light" ? "dark" : colorScheme === "dark" ? "browser-preferred" : "light"} theme`}
+      size={32}
+      onClick={() =>
+        setColorScheme(
+          colorScheme === "light"
+            ? "dark"
+            : colorScheme === "dark"
+              ? "auto"
+              : "light"
+        )
+      }
+    >
+      {colorScheme === "light" ? (
+        <IconMoonFilled {...iconProps} />
+      ) : colorScheme === "dark" ? (
+        <IconBrightnessFilled {...iconProps} />
+      ) : (
+        <IconSunFilled {...iconProps} />
+      )}
+    </ActionIcon>
   );
 };

--- a/web/ui/module/codemirror-promql/src/client/prometheus.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.ts
@@ -294,7 +294,7 @@ class Cache {
   constructor(config?: CacheConfig) {
     const maxAge = {
       ttl: config && config.maxAge ? config.maxAge : 5 * 60 * 1000,
-      ttlAutopurge: false,
+      ttlAutopurge: true,
     };
     this.completeAssociation = new LRUCache<string, Map<string, Set<string>>>(maxAge);
     this.metricMetadata = {};


### PR DESCRIPTION
This PR steps us closer to being in sync with the latest upstream changes.

Diff: https://github.com/prometheus/prometheus/compare/b74cebf...898af61

## Security improvements

* https://github.com/prometheus/prometheus/pull/16001

## Bug fixes

* https://github.com/prometheus/prometheus/pull/15987

## Refactoring

* https://github.com/prometheus/prometheus/pull/16007
* https://github.com/prometheus/prometheus/pull/16012 (this change will not impact Mimir, it does not use the `textparse.Parser` interface)

## Not relevant to Mimir (eg. CI changes, UI changes, `promtool` changes)

* https://github.com/prometheus/prometheus/pull/14228
* https://github.com/prometheus/prometheus/pull/16013
* https://github.com/prometheus/prometheus/pull/16000
* https://github.com/prometheus/prometheus/pull/16024
* https://github.com/prometheus/prometheus/pull/15967
* https://github.com/prometheus/prometheus/pull/16021
* https://github.com/prometheus/prometheus/pull/16011