### PR TITLE
Cherry-pick alexweav:alexweav/validate-unexported

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -92,7 +92,7 @@ type RuleGroups struct {
 }
 
 type ruleGroups struct {
-	Groups []ruleGroupNode `yaml:"groups"`
+	Groups []RuleGroupNode `yaml:"groups"`
 }
 
 // Validate validates all rules in the rule groups.
@@ -164,8 +164,8 @@ type RuleGroup struct {
 	AlignEvaluationTimeOnInterval bool              `yaml:"align_evaluation_time_on_interval,omitempty"`
 }
 
-// ruleGroupNode adds yaml.v3 layer to support line and columns outputs for invalid rule groups.
-type ruleGroupNode struct {
+// RuleGroupNode adds yaml.v3 layer to support line and columns outputs for invalid rule groups.
+type RuleGroupNode struct {
 	yaml.Node
 	Name        string            `yaml:"name"`
 	Interval    model.Duration    `yaml:"interval,omitempty"`

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -171,7 +171,7 @@ type ruleGroupNode struct {
 	Interval    model.Duration    `yaml:"interval,omitempty"`
 	QueryOffset *model.Duration   `yaml:"query_offset,omitempty"`
 	Limit       int               `yaml:"limit,omitempty"`
-	Rules       []ruleNode        `yaml:"rules"`
+	Rules       []RuleNode        `yaml:"rules"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
@@ -186,8 +186,8 @@ type Rule struct {
 	Annotations   map[string]string `yaml:"annotations,omitempty"`
 }
 
-// ruleNode adds yaml.v3 layer to support line and column outputs for invalid rules.
-type ruleNode struct {
+// RuleNode adds yaml.v3 layer to support line and column outputs for invalid rules.
+type RuleNode struct {
 	Record        yaml.Node         `yaml:"record,omitempty"`
 	Alert         yaml.Node         `yaml:"alert,omitempty"`
 	Expr          yaml.Node         `yaml:"expr"`
@@ -198,7 +198,7 @@ type ruleNode struct {
 }
 
 // Validate the rule and return a list of encountered errors.
-func (r *Rule) Validate(node ruleNode) (nodes []WrappedError) {
+func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
 	if r.Record != "" && r.Alert != "" {
 		nodes = append(nodes, WrappedError{
 			err:     errors.New("only one of 'record' and 'alert' must be set"),


### PR DESCRIPTION
This is a cherry-pick of the two commits in https://github.com/prometheus/prometheus/pull/16252 that export `RuleGroupNode` and `RuleNode`. This missing export is currently blocking updates of mimir-prometheus -> mimir (see https://github.com/grafana/mimir/pull/10884). 