### PR TITLE
Sync with upstream up to de399eb09 (2025-03-26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ always, be extra careful when loading third party code.
 
 ### Building the Docker image
 
-The `make docker` target is designed for use in our CI system.
 You can build a docker image locally with the following commands:
 
 ```bash
@@ -139,6 +138,9 @@ promu crossbuild -p linux/amd64
 make npm_licenses
 make common-docker-amd64
 ```
+
+The `make docker` target is intended only for use in our CI system and will not
+produce a fully working image when run locally.
 
 ## Using Prometheus as a Go Library
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/prometheus/prometheus
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,8 +2,6 @@ module github.com/prometheus/prometheus/internal/tools
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/bufbuild/buf v1.50.1
 	github.com/daixiang0/gci v0.13.5

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -145,8 +145,8 @@ type ReadClient interface {
 }
 
 // NewReadClient creates a new client for remote read.
-func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client")
+func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTPClientOption) (ReadClient, error) {
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", optFuncs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This brings changes from prometheus/prometheus up to 2025-03-26 commit https://github.com/prometheus/prometheus/commit/de399eb09c90ba4e643b58bb998b0c158892d72e

Diff: https://github.com/prometheus/prometheus/compare/bd5b2ea9...de399eb

No merge conflicts.

Included PRs:
- https://github.com/prometheus/prometheus/pull/16323
- https://github.com/prometheus/prometheus/pull/16322
- https://github.com/prometheus/prometheus/pull/16320
- https://github.com/prometheus/prometheus/pull/16319
- https://github.com/prometheus/prometheus/pull/15093

No major changes.