### PR TITLE
Log instances where WAL replay detect unknown series references, but the series records are found later in the WAL segment

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -467,6 +467,24 @@ Outer:
 			"tombstones", unknownTombstoneRefs.Load(),
 		)
 
+		// @patryk: Check if any of the series reported as missing were actually found later in the WAL segment.
+		// This is a mimir-only change and currently purely diagnostic to gauge the size of the problem, and whether it
+		// enapsulates the whole of the instances of unknown series references we see.
+		foundSeries := 0
+		for walRef := range unknownSeriesRefs.refs {
+			headRef := walRef
+			// The series might be a duplicate, so use the original series ref.
+			if mr, ok := multiRef[walRef]; ok {
+				headRef = mr
+			}
+			if h.series.getByID(headRef) != nil {
+				h.logger.Warn("Series reported as missing but was found later in the WAL segment", "walRef", walRef, "headRef", headRef, "segment", r.Segment())
+				foundSeries++
+			}
+		}
+		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(foundSeries), "found_series")
+		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()-foundSeries), "truly_missing_series")
+
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()), "series")
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSampleRefs.Load()), "samples")
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownExemplarRefs.Load()), "exemplars")


### PR DESCRIPTION
It seems that sometimes we end up with sample records written to the WAL before their corresponding series record. Because the WAL is processed in-order, these leads to the replay reporting unknown series references. It's unclear whether this explains ALL of the instances of unknown series references we see in our cluster, so this PR adds some logging/metrics to let us determine that.

I'm making this change in mimir-prometheus rather than prometheus itself because it's purely a diagnostic thing for now. Impact should be minimal, as this only runs when we already know we have unknown series refs.