### PR TITLE
Log instances where WAL replay detect unknown series references, but the series records are found in a later WAL segment

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -789,6 +789,7 @@ func (h *Head) Init(minValidTime int64) error {
 
 	syms := labels.NewSymbolTable() // One table for the whole WAL.
 	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
+	unknownSeriesRefs := &seriesRefSet{refs: make(map[chunks.HeadSeriesRef]struct{}), mtx: sync.Mutex{}}
 	if err == nil && startFrom >= snapIdx {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -802,7 +803,7 @@ func (h *Head) Init(minValidTime int64) error {
 
 		// A corrupted checkpoint is a hard error for now and requires user
 		// intervention. There's likely little data that can be recovered anyway.
-		if err := h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks, endAt); err != nil {
+		if err := h.loadWAL(wlog.NewReader(sr), syms, multiRef, unknownSeriesRefs, mmappedChunks, oooMmappedChunks, endAt); err != nil {
 			return fmt.Errorf("backfill checkpoint: %w", err)
 		}
 		h.updateWALReplayStatusRead(startFrom)
@@ -836,7 +837,7 @@ func (h *Head) Init(minValidTime int64) error {
 		if err != nil {
 			return fmt.Errorf("segment reader (offset=%d): %w", offset, err)
 		}
-		err = h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks, endAt)
+		err = h.loadWAL(wlog.NewReader(sr), syms, multiRef, unknownSeriesRefs, mmappedChunks, oooMmappedChunks, endAt)
 		if err := sr.Close(); err != nil {
 			h.logger.Warn("Error while closing the wal segments reader", "err", err)
 		}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -76,7 +76,7 @@ func counterAddNonZero(v *prometheus.CounterVec, value float64, lvs ...string) {
 	}
 }
 
-func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk, lastSegment int) (err error) {
+func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, globalMissingSeriesRefs *seriesRefSet, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk, lastSegment int) (err error) {
 	// Track number of missing series records that were referenced by other records.
 	unknownSeriesRefs := &seriesRefSet{refs: make(map[chunks.HeadSeriesRef]struct{}), mtx: sync.Mutex{}}
 	// Track number of different records that referenced a series we don't know about
@@ -456,6 +456,35 @@ Outer:
 		return fmt.Errorf("read records: %w", err)
 	}
 
+	// @patryk: Check if any of the series reported as missing in prior segments now exist.
+	// This is a mimir-only change and currently purely diagnostic to gauge the size of the problem, and whether it
+	// enapsulates the whole of the instances of unknown series references we see.
+	foundSeriesForPriorSegments := 0
+	toDelete := []chunks.HeadSeriesRef{}
+	globalMissingSeriesRefs.mtx.Lock()
+	for walRef := range globalMissingSeriesRefs.refs {
+		headRef := walRef
+		// The series might be a duplicate, so use the original series ref.
+		if mr, ok := multiRef[walRef]; ok {
+			headRef = mr
+		}
+		if h.series.getByID(headRef) != nil {
+			h.logger.Warn("Series reported as missing in prior segment but was found in this WAL segment", "walRef", walRef, "headRef", headRef, "segment", r.Segment())
+			foundSeriesForPriorSegments++
+			toDelete = append(toDelete, walRef)
+		}
+	}
+	for _, walRef := range toDelete {
+		delete(globalMissingSeriesRefs.refs, walRef)
+	}
+	globalMissingSeriesRefs.mtx.Unlock()
+
+	counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(foundSeriesForPriorSegments), "found_series_for_prior_segments")
+
+	if foundSeriesForPriorSegments > 0 {
+		h.logger.Warn("Series reported as missing in prior segments but were found in this WAL segment", "count", foundSeriesForPriorSegments, "segment", r.Segment())
+	}
+
 	if unknownSampleRefs.Load()+unknownExemplarRefs.Load()+unknownHistogramRefs.Load()+unknownMetadataRefs.Load()+unknownTombstoneRefs.Load() > 0 {
 		h.logger.Warn(
 			"Unknown series references",
@@ -465,12 +494,15 @@ Outer:
 			"histograms", unknownHistogramRefs.Load(),
 			"metadata", unknownMetadataRefs.Load(),
 			"tombstones", unknownTombstoneRefs.Load(),
+			"segment", r.Segment(),
 		)
 
 		// @patryk: Check if any of the series reported as missing were actually found later in the WAL segment.
 		// This is a mimir-only change and currently purely diagnostic to gauge the size of the problem, and whether it
 		// enapsulates the whole of the instances of unknown series references we see.
 		foundSeries := 0
+		toDelete := []chunks.HeadSeriesRef{}
+		unknownSeriesRefs.mtx.Lock()
 		for walRef := range unknownSeriesRefs.refs {
 			headRef := walRef
 			// The series might be a duplicate, so use the original series ref.
@@ -480,12 +512,21 @@ Outer:
 			if h.series.getByID(headRef) != nil {
 				h.logger.Warn("Series reported as missing but was found later in the WAL segment", "walRef", walRef, "headRef", headRef, "segment", r.Segment())
 				foundSeries++
+				toDelete = append(toDelete, walRef)
 			}
 		}
-		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(foundSeries), "found_series")
-		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()-foundSeries), "truly_missing_series")
+		for _, walRef := range toDelete {
+			delete(unknownSeriesRefs.refs, walRef)
+		}
+		unknownSeriesRefs.mtx.Unlock()
 
-		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()), "series")
+		// Merge missing series refs in this segment into the global list.
+		globalMissingSeriesRefs.merge(unknownSeriesRefs.refs)
+
+		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(foundSeries), "found_series")
+		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()), "truly_missing_series")
+
+		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSeriesRefs.count()+foundSeries), "series")
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownSampleRefs.Load()), "samples")
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownExemplarRefs.Load()), "exemplars")
 		counterAddNonZero(h.metrics.walReplayUnknownRefsTotal, float64(unknownHistogramRefs.Load()), "histograms")


### PR DESCRIPTION
This builds on https://github.com/grafana/mimir-prometheus/pull/861 to also track if a sample record is written before its series record into a completely different WAL segment. Hopefully this will explain the remaining instances of unknown series refs we see.

I'm keeping this to mimir-prometheus because it is still just diagnostic information.