### PR TITLE
Revert `stringlabels` default

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -14,8 +14,10 @@ build:
         all:
             - netgo
             - builtinassets
+            - stringlabels
         windows:
             - builtinassets
+            - stringlabels
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build slicelabels
+//go:build !stringlabels && !dedupelabels
 
 package labels
 
@@ -453,7 +453,7 @@ func (b *ScratchBuilder) Add(name, value string) {
 }
 
 // UnsafeAddBytes adds a name/value pair, using []byte instead of string.
-// The default version of this function is unsafe, hence the name.
+// The '-tags stringlabels' version of this function is unsafe, hence the name.
 // This version is safe - it copies the strings immediately - but we keep the same name so everything compiles.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: string(name), Value: string(value)})

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !slicelabels && !dedupelabels
+//go:build stringlabels
 
 package labels
 
@@ -70,7 +70,7 @@ func (ls Labels) IsZero() bool {
 
 // MatchLabels returns a subset of Labels that matches/does not match with the provided label names based on the 'on' boolean.
 // If on is set to true, it returns the subset of labels that match with the provided label names and its inverse when 'on' is set to false.
-// TODO: This is only used in printing an error message.
+// TODO: This is only used in printing an error message
 func (ls Labels) MatchLabels(on bool, names ...string) Labels {
 	b := NewBuilder(ls)
 	if on {
@@ -292,7 +292,6 @@ func Equal(ls, o Labels) bool {
 func EmptyLabels() Labels {
 	return Labels{}
 }
-
 func yoloBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
@@ -365,7 +364,7 @@ func Compare(a, b Labels) int {
 	return +1
 }
 
-// CopyFrom will copy labels from b on top of whatever was in ls previously, reusing memory or expanding if needed.
+// Copy labels from b on top of whatever was in ls previously, reusing memory or expanding if needed.
 func (ls *Labels) CopyFrom(b Labels) {
 	ls.data = b.data // strings are immutable
 }
@@ -435,11 +434,11 @@ func (ls Labels) DropMetricName() Labels {
 }
 
 // InternStrings is a no-op because it would only save when the whole set of labels is identical.
-func (ls *Labels) InternStrings(_ func(string) string) {
+func (ls *Labels) InternStrings(intern func(string) string) {
 }
 
 // ReleaseStrings is a no-op for the same reason as InternStrings.
-func (ls Labels) ReleaseStrings(_ func(string)) {
+func (ls Labels) ReleaseStrings(release func(string)) {
 }
 
 // Builder allows modifying Labels.
@@ -604,7 +603,7 @@ func (b *ScratchBuilder) Add(name, value string) {
 	b.add = append(b.add, Label{Name: name, Value: value})
 }
 
-// UnsafeAddBytes adds a name/value pair using []byte instead of string to reduce memory allocations.
+// Add a name/value pair, using []byte instead of string to reduce memory allocations.
 // The values must remain live until Labels() is called.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: yoloString(name), Value: yoloString(value)})
@@ -632,7 +631,7 @@ func (b *ScratchBuilder) Labels() Labels {
 	return b.output
 }
 
-// Overwrite will write the newly-built Labels out to ls, reusing an internal buffer.
+// Write the newly-built Labels out to ls, reusing an internal buffer.
 // Callers must ensure that there are no other references to ls, or any strings fetched from it.
 func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	size := labelsSize(b.add)
@@ -645,7 +644,7 @@ func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	ls.data = yoloString(b.overwriteBuffer)
 }
 
-// SymbolTable is no-op, just for api parity with dedupelabels.
+// Symbol-table is no-op, just for api parity with dedupelabels.
 type SymbolTable struct{}
 
 func NewSymbolTable() *SymbolTable { return nil }

--- a/model/labels/sharding.go
+++ b/model/labels/sharding.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build slicelabels
+//go:build !stringlabels && !dedupelabels
 
 package labels
 

--- a/model/labels/sharding_stringlabels.go
+++ b/model/labels/sharding_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !slicelabels && !dedupelabels
+//go:build stringlabels
 
 package labels
 

--- a/tsdb/agent/series_test.go
+++ b/tsdb/agent/series_test.go
@@ -77,13 +77,13 @@ func TestNoDeadlock(t *testing.T) {
 
 func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
-	ls1 := labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
-	ls2 := labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+	ls1 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
 	if ls1.Hash() != ls2.Hash() {
-		// These ones are the same when using -tags slicelabels
-		ls1 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
-		ls2 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
+		// These ones are the same when using -tags stringlabels
+		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
 	}
 
 	if ls1.Hash() != ls2.Hash() {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6586,13 +6586,13 @@ func TestHeadCompactionWhileAppendAndCommitExemplar(t *testing.T) {
 
 func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
-	ls1 := labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
-	ls2 := labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+	ls1 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
 	if ls1.Hash() != ls2.Hash() {
-		// These ones are the same when using -tags slicelabels
-		ls1 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
-		ls2 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
+		// These ones are the same when using -tags stringlabels
+		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
 	}
 
 	if ls1.Hash() != ls2.Hash() {


### PR DESCRIPTION
This temporarily reverts https://github.com/prometheus/prometheus/pull/16436, which is causing issues for one of the internal projects that pulls in this project through `grafana/mimir`, as this internal project has not been updated to work with `stringlabels`.

Projects such as Mimir and GEM that explicitly set `stringlabels` will continue to receive `stringlabels`, as they did before.