### PR TITLE
[PERF] Replace Sprintf in PromQL to string conversion

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -80,9 +80,12 @@ func MustNewMatcher(mt MatchType, name, val string) *Matcher {
 
 func (m *Matcher) String() string {
 	// Start a buffer with a pre-allocated size on stack to cover most needs.
-	var bytea [1024]byte
-	b := bytes.NewBuffer(bytea[:0])
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	m.WriteTo(b)
+	return b.String()
+}
 
+func (m *Matcher) WriteTo(b *bytes.Buffer) {
 	if m.shouldQuoteName() {
 		b.Write(strconv.AppendQuote(b.AvailableBuffer(), m.Name))
 	} else {
@@ -90,8 +93,6 @@ func (m *Matcher) String() string {
 	}
 	b.WriteString(m.Type.String())
 	b.Write(strconv.AppendQuote(b.AvailableBuffer(), m.Value))
-
-	return b.String()
 }
 
 func (m *Matcher) shouldQuoteName() bool {

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -14,6 +14,7 @@
 package parser
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -80,6 +81,8 @@ type Expr interface {
 	// Type returns the type the expression evaluates to. It does not perform
 	// in-depth checks as this is done at parsing-time.
 	Type() ValueType
+	// WriteTo writes the string for this expression into b.
+	WriteTo(b *bytes.Buffer)
 	// PromQLExpr ensures that no other types accidentally implement the interface.
 	PromQLExpr()
 }
@@ -195,7 +198,8 @@ type StepInvariantExpr struct {
 	Expr Expr
 }
 
-func (e *StepInvariantExpr) String() string { return e.Expr.String() }
+func (e *StepInvariantExpr) String() string          { return e.Expr.String() }
+func (e *StepInvariantExpr) WriteTo(b *bytes.Buffer) { e.Expr.WriteTo(b) }
 
 func (e *StepInvariantExpr) PositionRange() posrange.PositionRange {
 	return e.Expr.PositionRange()

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -427,7 +427,7 @@ func (p *parser) assembleVectorSelector(vs *VectorSelector) {
 		if err != nil {
 			panic(err) // Must not happen with labels.MatchEqual
 		}
-		vs.LabelMatchers = append(vs.LabelMatchers, nameMatcher)
+		vs.LabelMatchers = append([]*labels.Matcher{nameMatcher}, vs.LabelMatchers...)
 	}
 }
 
@@ -836,10 +836,9 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 
 	case *VectorSelector:
 		if n.Name != "" {
-			// In this case the last LabelMatcher is checking for the metric name
-			// set outside the braces. This checks if the name has already been set
-			// previously.
-			for _, m := range n.LabelMatchers[0 : len(n.LabelMatchers)-1] {
+			// In this case the first LabelMatcher is checking for the metric name
+			// set outside the braces. This checks if the name is checked again.
+			for _, m := range n.LabelMatchers[1:] {
 				if m != nil && m.Name == labels.MetricName {
 					p.addParseErrf(n.PositionRange(), "metric name must not be set twice: %q or %q", n.Name, m.Value)
 				}

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -1708,8 +1708,8 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "foo:bar",
 			LabelMatchers: []*labels.Matcher{
-				MustLabelMatcher(labels.MatchEqual, "a", "bc"),
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo:bar"),
+				MustLabelMatcher(labels.MatchEqual, "a", "bc"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -1777,8 +1777,8 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "foo",
 			LabelMatchers: []*labels.Matcher{
-				MustLabelMatcher(labels.MatchEqual, "NaN", "bc"),
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+				MustLabelMatcher(labels.MatchEqual, "NaN", "bc"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -1791,8 +1791,8 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "foo",
 			LabelMatchers: []*labels.Matcher{
-				MustLabelMatcher(labels.MatchEqual, "bar", "}"),
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+				MustLabelMatcher(labels.MatchEqual, "bar", "}"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -1805,11 +1805,11 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "foo",
 			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 				MustLabelMatcher(labels.MatchEqual, "a", "b"),
 				MustLabelMatcher(labels.MatchNotEqual, "foo", "bar"),
 				MustLabelMatcher(labels.MatchRegexp, "test", "test"),
 				MustLabelMatcher(labels.MatchNotRegexp, "bar", "baz"),
-				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -1839,11 +1839,11 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "foo",
 			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 				MustLabelMatcher(labels.MatchEqual, "a", "b"),
 				MustLabelMatcher(labels.MatchNotEqual, "foo", "bar"),
 				MustLabelMatcher(labels.MatchRegexp, "test", "test"),
 				MustLabelMatcher(labels.MatchNotRegexp, "bar", "baz"),
-				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -2120,8 +2120,8 @@ var testExpr = []struct {
 				Name:           "test",
 				OriginalOffset: 3 * 24 * time.Hour,
 				LabelMatchers: []*labels.Matcher{
-					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 				},
 				PosRange: posrange.PositionRange{
 					Start: 0,
@@ -2139,8 +2139,8 @@ var testExpr = []struct {
 				Name:           "test",
 				OriginalOffset: 1 * time.Hour,
 				LabelMatchers: []*labels.Matcher{
-					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 				},
 				PosRange: posrange.PositionRange{
 					Start: 0,
@@ -2248,8 +2248,8 @@ var testExpr = []struct {
 				Name:      "test",
 				Timestamp: makeInt64Pointer(1603774699000),
 				LabelMatchers: []*labels.Matcher{
-					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "test"),
+					MustLabelMatcher(labels.MatchEqual, "a", "b"),
 				},
 				PosRange: posrange.PositionRange{
 					Start: 0,
@@ -2808,8 +2808,8 @@ var testExpr = []struct {
 				&VectorSelector{
 					Name: "some_metric",
 					LabelMatchers: []*labels.Matcher{
-						MustLabelMatcher(labels.MatchNotEqual, "foo", "bar"),
 						MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
+						MustLabelMatcher(labels.MatchNotEqual, "foo", "bar"),
 					},
 					PosRange: posrange.PositionRange{
 						Start: 6,
@@ -3099,8 +3099,8 @@ var testExpr = []struct {
 			Expr: &VectorSelector{
 				Name: "foo",
 				LabelMatchers: []*labels.Matcher{
-					MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+					MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 				},
 				PosRange: posrange.PositionRange{
 					Start: 0,
@@ -3118,8 +3118,8 @@ var testExpr = []struct {
 			Expr: &VectorSelector{
 				Name: "foo",
 				LabelMatchers: []*labels.Matcher{
-					MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+					MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 				},
 				PosRange: posrange.PositionRange{
 					Start: 0,
@@ -3161,8 +3161,8 @@ var testExpr = []struct {
 								VectorSelector: &VectorSelector{
 									Name: "foo",
 									LabelMatchers: []*labels.Matcher{
-										MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 										MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+										MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 									},
 									PosRange: posrange.PositionRange{
 										Start: 19,
@@ -3204,8 +3204,8 @@ var testExpr = []struct {
 									VectorSelector: &VectorSelector{
 										Name: "foo",
 										LabelMatchers: []*labels.Matcher{
-											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 											MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 										},
 										PosRange: posrange.PositionRange{
 											Start: 19,
@@ -3249,8 +3249,8 @@ var testExpr = []struct {
 									VectorSelector: &VectorSelector{
 										Name: "foo",
 										LabelMatchers: []*labels.Matcher{
-											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 											MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 										},
 										PosRange: posrange.PositionRange{
 											Start: 19,
@@ -3295,8 +3295,8 @@ var testExpr = []struct {
 									VectorSelector: &VectorSelector{
 										Name: "foo",
 										LabelMatchers: []*labels.Matcher{
-											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 											MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 										},
 										PosRange: posrange.PositionRange{
 											Start: 19,
@@ -3341,8 +3341,8 @@ var testExpr = []struct {
 									VectorSelector: &VectorSelector{
 										Name: "foo",
 										LabelMatchers: []*labels.Matcher{
-											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 											MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+											MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
 										},
 										PosRange: posrange.PositionRange{
 											Start: 19,
@@ -3520,8 +3520,8 @@ var testExpr = []struct {
 					RHS: &VectorSelector{
 						Name: "bar",
 						LabelMatchers: []*labels.Matcher{
-							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "bar"),
+							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 						},
 						PosRange: posrange.PositionRange{
 							Start: 7,
@@ -3560,8 +3560,8 @@ var testExpr = []struct {
 					RHS: &VectorSelector{
 						Name: "bar",
 						LabelMatchers: []*labels.Matcher{
-							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "bar"),
+							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 						},
 						PosRange: posrange.PositionRange{
 							Start: 7,
@@ -3601,8 +3601,8 @@ var testExpr = []struct {
 					RHS: &VectorSelector{
 						Name: "bar",
 						LabelMatchers: []*labels.Matcher{
-							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "bar"),
+							MustLabelMatcher(labels.MatchEqual, "nm", "val"),
 						},
 						Timestamp: makeInt64Pointer(1234000),
 						PosRange: posrange.PositionRange{
@@ -3786,8 +3786,8 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "start",
 			LabelMatchers: []*labels.Matcher{
-				MustLabelMatcher(labels.MatchEqual, "end", "foo"),
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "start"),
+				MustLabelMatcher(labels.MatchEqual, "end", "foo"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -3800,8 +3800,8 @@ var testExpr = []struct {
 		expected: &VectorSelector{
 			Name: "end",
 			LabelMatchers: []*labels.Matcher{
-				MustLabelMatcher(labels.MatchEqual, "start", "foo"),
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "end"),
+				MustLabelMatcher(labels.MatchEqual, "start", "foo"),
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
@@ -3920,8 +3920,8 @@ var testExpr = []struct {
 				&VectorSelector{
 					Name: "http_request_counter_total",
 					LabelMatchers: []*labels.Matcher{
-						MustLabelMatcher(labels.MatchEqual, "namespace", "zzz"),
 						MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "http_request_counter_total"),
+						MustLabelMatcher(labels.MatchEqual, "namespace", "zzz"),
 					},
 					PosRange: posrange.PositionRange{
 						Start: 5,
@@ -4958,10 +4958,10 @@ func TestExtractSelectors(t *testing.T) {
 			[]string{`{__name__="foo"}`},
 		}, {
 			`foo{bar="baz"}`,
-			[]string{`{bar="baz", __name__="foo"}`},
+			[]string{`{__name__="foo", bar="baz"}`},
 		}, {
 			`foo{bar="baz"} / flip{flop="flap"}`,
-			[]string{`{bar="baz", __name__="foo"}`, `{flop="flap", __name__="flip"}`},
+			[]string{`{__name__="foo", bar="baz"}`, `{__name__="flip", flop="flap"}`},
 		}, {
 			`rate(foo[5m])`,
 			[]string{`{__name__="foo"}`},

--- a/promql/parser/prettier.go
+++ b/promql/parser/prettier.go
@@ -54,7 +54,7 @@ func (e *AggregateExpr) Pretty(level int) string {
 		return s
 	}
 
-	s += e.getAggOpStr()
+	s += e.ShortString()
 	s += "(\n"
 
 	if e.Op.IsAggregatorWithParam() {

--- a/promql/parser/prettier.go
+++ b/promql/parser/prettier.go
@@ -14,6 +14,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -75,8 +76,9 @@ func (e *BinaryExpr) Pretty(level int) string {
 		returnBool = " bool"
 	}
 
-	matching := e.getMatchingStr()
-	return fmt.Sprintf("%s\n%s%s%s%s\n%s", e.LHS.Pretty(level+1), indent(level), e.Op, returnBool, matching, e.RHS.Pretty(level+1))
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	e.writeMatchingStr(b)
+	return fmt.Sprintf("%s\n%s%s%s%s\n%s", e.LHS.Pretty(level+1), indent(level), e.Op, returnBool, b.String(), e.RHS.Pretty(level+1))
 }
 
 func (e *DurationExpr) Pretty(int) string {

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -118,11 +118,11 @@ func (node *BinaryExpr) returnBool() string {
 
 func (node *BinaryExpr) String() string {
 	matching := node.getMatchingStr()
-	return fmt.Sprintf("%s %s%s%s %s", node.LHS, node.Op, node.returnBool(), matching, node.RHS)
+	return node.LHS.String() + " " + node.Op.String() + node.returnBool() + matching + " " + node.RHS.String()
 }
 
 func (node *BinaryExpr) ShortString() string {
-	return fmt.Sprintf("%s%s%s", node.Op, node.returnBool(), node.getMatchingStr())
+	return node.Op.String() + node.returnBool() + node.getMatchingStr()
 }
 
 func (node *BinaryExpr) getMatchingStr() string {
@@ -165,7 +165,7 @@ func (node *DurationExpr) ShortString() string {
 }
 
 func (node *Call) String() string {
-	return fmt.Sprintf("%s(%s)", node.Func.Name, node.Args)
+	return node.Func.Name + "(" + node.Args.String() + ")"
 }
 
 func (node *Call) ShortString() string {
@@ -279,15 +279,15 @@ func (node *NumberLiteral) String() string {
 }
 
 func (node *ParenExpr) String() string {
-	return fmt.Sprintf("(%s)", node.Expr)
+	return "(" + node.Expr.String() + ")"
 }
 
 func (node *StringLiteral) String() string {
-	return fmt.Sprintf("%q", node.Val)
+	return strconv.Quote(node.Val)
 }
 
 func (node *UnaryExpr) String() string {
-	return fmt.Sprintf("%s%s", node.Op, node.Expr)
+	return node.Op.String() + node.Expr.String()
 }
 
 func (node *UnaryExpr) ShortString() string {

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -404,19 +404,38 @@ func (node *VectorSelector) String() string {
 }
 
 func (node *VectorSelector) WriteTo(b *bytes.Buffer) {
-	var labelStrings []string
-	if len(node.LabelMatchers) > 1 {
-		labelStrings = make([]string, 0, len(node.LabelMatchers)-1)
-	}
-	for _, matcher := range node.LabelMatchers {
-		// Only include the __name__ label if its equality matching and matches the name, but don't skip if it's an explicit empty name matcher.
-		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name && matcher.Value != "" {
-			continue
-		}
-		labelStrings = append(labelStrings, matcher.String())
-	}
 	b.WriteString(node.Name)
-	if len(labelStrings) != 0 {
+	switch {
+	case len(node.LabelMatchers) == 0:
+	case labelMatchersSorted(node.LabelMatchers):
+		count := 0
+		for _, matcher := range node.LabelMatchers {
+			if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name && matcher.Value != "" {
+				continue
+			}
+			if count == 0 {
+				b.WriteByte('{')
+			} else {
+				b.WriteByte(',')
+			}
+			matcher.WriteTo(b)
+			count++
+		}
+		if count > 0 {
+			b.WriteByte('}')
+		}
+	default:
+		var labelStrings []string
+		if len(node.LabelMatchers) > 1 {
+			labelStrings = make([]string, 0, len(node.LabelMatchers)-1)
+		}
+		for _, matcher := range node.LabelMatchers {
+			// Only include the __name__ label if it isn't equality matching on the name, but don't skip if it's an explicit empty name matcher.
+			if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual && matcher.Value == node.Name && matcher.Value != "" {
+				continue
+			}
+			labelStrings = append(labelStrings, matcher.String())
+		}
 		b.WriteByte('{')
 		sort.Strings(labelStrings)
 		writeStringsJoin(b, labelStrings, ",")
@@ -442,4 +461,16 @@ func (node *VectorSelector) WriteTo(b *bytes.Buffer) {
 		b.WriteString(" offset -")
 		b.WriteString(model.Duration(-node.OriginalOffset).String())
 	}
+}
+
+func labelMatchersSorted(matchers []*labels.Matcher) bool {
+	if len(matchers) <= 1 {
+		return true
+	}
+	for i := range matchers[1:] {
+		if matchers[i].Name > matchers[i+1].Name {
+			return false
+		}
+	}
+	return true
 }

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -444,7 +444,7 @@ func (node *VectorSelector) WriteTo(b *bytes.Buffer) {
 	switch {
 	case node.Timestamp != nil:
 		b.WriteString(" @ ")
-		b.WriteString(fmt.Sprintf("%.3f", float64(*node.Timestamp)/1000.0))
+		fmt.Fprintf(b, "%.3f", float64(*node.Timestamp)/1000.0)
 	case node.StartOrEnd == START:
 		b.WriteString(" @ start()")
 	case node.StartOrEnd == END:

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -53,49 +53,57 @@ func (node *EvalStmt) String() string {
 }
 
 func (es Expressions) String() (s string) {
-	if len(es) == 0 {
+	switch len(es) {
+	case 0:
 		return ""
+	case 1:
+		return es[0].String()
 	}
-	for _, e := range es {
-		s += e.String()
-		s += ", "
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b.WriteString(es[0].String())
+	for _, e := range es[1:] {
+		b.WriteString(", ")
+		b.WriteString(e.String())
 	}
-	return s[:len(s)-2]
+	return b.String()
 }
 
 func (node *AggregateExpr) String() string {
-	aggrString := node.getAggOpStr()
-	aggrString += "("
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	node.writeAggOpStr(b)
+	b.WriteString("(")
 	if node.Op.IsAggregatorWithParam() {
-		aggrString += fmt.Sprintf("%s, ", node.Param)
+		b.WriteString(node.Param.String())
+		b.WriteString(", ")
 	}
-	aggrString += fmt.Sprintf("%s)", node.Expr)
+	b.WriteString(node.Expr.String())
+	b.WriteString(")")
 
-	return aggrString
+	return b.String()
 }
 
 func (node *AggregateExpr) ShortString() string {
-	aggrString := node.getAggOpStr()
-	return aggrString
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	node.writeAggOpStr(b)
+	return b.String()
 }
 
-func (node *AggregateExpr) getAggOpStr() string {
-	aggrString := node.Op.String()
+func (node *AggregateExpr) writeAggOpStr(b *bytes.Buffer) {
+	b.WriteString(node.Op.String())
 
 	switch {
 	case node.Without:
-		aggrString += fmt.Sprintf(" without (%s) ", joinLabels(node.Grouping))
+		b.WriteString(" without (")
+		writeLabels(b, node.Grouping)
+		b.WriteString(") ")
 	case len(node.Grouping) > 0:
-		aggrString += fmt.Sprintf(" by (%s) ", joinLabels(node.Grouping))
+		b.WriteString(" by (")
+		writeLabels(b, node.Grouping)
+		b.WriteString(") ")
 	}
-
-	return aggrString
 }
 
-func joinLabels(ss []string) string {
-	var bytea [1024]byte // On stack to avoid memory allocation while building the output.
-	b := bytes.NewBuffer(bytea[:0])
-
+func writeLabels(b *bytes.Buffer, ss []string) {
 	for i, s := range ss {
 		if i > 0 {
 			b.WriteString(", ")
@@ -106,7 +114,18 @@ func joinLabels(ss []string) string {
 			b.WriteString(s)
 		}
 	}
-	return b.String()
+}
+
+// writeStringsJoin is like strings.Join but appending to a bytes.Buffer.
+func writeStringsJoin(b *bytes.Buffer, elems []string, sep string) {
+	if len(elems) == 0 {
+		return
+	}
+	b.WriteString(elems[0])
+	for _, s := range elems[1:] {
+		b.WriteString(sep)
+		b.WriteString(s)
+	}
 }
 
 func (node *BinaryExpr) returnBool() string {
@@ -147,17 +166,30 @@ func (node *BinaryExpr) getMatchingStr() string {
 }
 
 func (node *DurationExpr) String() string {
-	var expr string
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	node.writeTo(b)
+	return b.String()
+}
+
+func (node *DurationExpr) writeTo(b *bytes.Buffer) {
+	if node.Wrapped {
+		b.WriteByte('(')
+	}
 	if node.LHS == nil {
 		// This is a unary negative duration expression.
-		expr = fmt.Sprintf("%s%s", node.Op, node.RHS)
+		b.WriteString(node.Op.String())
+		b.WriteString(node.RHS.String())
 	} else {
-		expr = fmt.Sprintf("%s %s %s", node.LHS, node.Op, node.RHS)
+		b.WriteString(node.LHS.String())
+		b.WriteByte(' ')
+		b.WriteString(node.Op.String())
+		b.WriteByte(' ')
+		b.WriteString(node.RHS.String())
 	}
+
 	if node.Wrapped {
-		return fmt.Sprintf("(%s)", expr)
+		b.WriteByte(')')
 	}
-	return expr
 }
 
 func (node *DurationExpr) ShortString() string {
@@ -306,28 +338,33 @@ func (node *VectorSelector) String() string {
 		}
 		labelStrings = append(labelStrings, matcher.String())
 	}
-	offset := ""
-	switch {
-	case node.OriginalOffsetExpr != nil:
-		offset = fmt.Sprintf(" offset %s", node.OriginalOffsetExpr)
-	case node.OriginalOffset > time.Duration(0):
-		offset = fmt.Sprintf(" offset %s", model.Duration(node.OriginalOffset))
-	case node.OriginalOffset < time.Duration(0):
-		offset = fmt.Sprintf(" offset -%s", model.Duration(-node.OriginalOffset))
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b.WriteString(node.Name)
+	if len(labelStrings) != 0 {
+		b.WriteByte('{')
+		sort.Strings(labelStrings)
+		writeStringsJoin(b, labelStrings, ",")
+		b.WriteByte('}')
 	}
-	at := ""
 	switch {
 	case node.Timestamp != nil:
-		at = fmt.Sprintf(" @ %.3f", float64(*node.Timestamp)/1000.0)
+		b.WriteString(" @ ")
+		b.WriteString(fmt.Sprintf("%.3f", float64(*node.Timestamp)/1000.0))
 	case node.StartOrEnd == START:
-		at = " @ start()"
+		b.WriteString(" @ start()")
 	case node.StartOrEnd == END:
-		at = " @ end()"
+		b.WriteString(" @ end()")
 	}
-
-	if len(labelStrings) == 0 {
-		return fmt.Sprintf("%s%s%s", node.Name, at, offset)
+	switch {
+	case node.OriginalOffsetExpr != nil:
+		b.WriteString(" offset ")
+		node.OriginalOffsetExpr.writeTo(b)
+	case node.OriginalOffset > time.Duration(0):
+		b.WriteString(" offset ")
+		b.WriteString(model.Duration(node.OriginalOffset).String())
+	case node.OriginalOffset < time.Duration(0):
+		b.WriteString(" offset -")
+		b.WriteString(model.Duration(-node.OriginalOffset).String())
 	}
-	sort.Strings(labelStrings)
-	return fmt.Sprintf("%s{%s}%s%s", node.Name, strings.Join(labelStrings, ","), at, offset)
+	return b.String()
 }

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -59,27 +59,34 @@ func (es Expressions) String() (s string) {
 	case 1:
 		return es[0].String()
 	}
-	b := bytes.NewBuffer(make([]byte, 0, 1024))
-	b.WriteString(es[0].String())
-	for _, e := range es[1:] {
-		b.WriteString(", ")
-		b.WriteString(e.String())
-	}
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	es.WriteTo(b)
 	return b.String()
 }
 
+func (es Expressions) WriteTo(b *bytes.Buffer) {
+	es[0].WriteTo(b)
+	for _, e := range es[1:] {
+		b.WriteString(", ")
+		e.WriteTo(b)
+	}
+}
+
 func (node *AggregateExpr) String() string {
-	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *AggregateExpr) WriteTo(b *bytes.Buffer) {
 	node.writeAggOpStr(b)
 	b.WriteString("(")
 	if node.Op.IsAggregatorWithParam() {
 		b.WriteString(node.Param.String())
 		b.WriteString(", ")
 	}
-	b.WriteString(node.Expr.String())
+	node.Expr.WriteTo(b)
 	b.WriteString(")")
-
-	return b.String()
 }
 
 func (node *AggregateExpr) ShortString() string {
@@ -136,42 +143,59 @@ func (node *BinaryExpr) returnBool() string {
 }
 
 func (node *BinaryExpr) String() string {
-	matching := node.getMatchingStr()
-	return node.LHS.String() + " " + node.Op.String() + node.returnBool() + matching + " " + node.RHS.String()
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *BinaryExpr) WriteTo(b *bytes.Buffer) {
+	node.LHS.WriteTo(b)
+	b.WriteByte(' ')
+	b.WriteString(node.Op.String())
+	b.WriteString(node.returnBool())
+	node.writeMatchingStr(b)
+	b.WriteByte(' ')
+	node.RHS.WriteTo(b)
 }
 
 func (node *BinaryExpr) ShortString() string {
-	return node.Op.String() + node.returnBool() + node.getMatchingStr()
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	b.WriteString(node.Op.String())
+	b.WriteString(node.returnBool())
+	node.writeMatchingStr(b)
+	return b.String()
 }
 
-func (node *BinaryExpr) getMatchingStr() string {
-	matching := ""
+func (node *BinaryExpr) writeMatchingStr(b *bytes.Buffer) {
 	vm := node.VectorMatching
 	if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) {
-		vmTag := "ignoring"
 		if vm.On {
-			vmTag = "on"
+			b.WriteString(" on (")
+		} else {
+			b.WriteString(" ignoring (")
 		}
-		matching = fmt.Sprintf(" %s (%s)", vmTag, strings.Join(vm.MatchingLabels, ", "))
+		writeStringsJoin(b, vm.MatchingLabels, ", ")
+		b.WriteByte(')')
 
 		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
-			vmCard := "right"
 			if vm.Card == CardManyToOne {
-				vmCard = "left"
+				b.WriteString(" group_left (")
+			} else {
+				b.WriteString(" group_right (")
 			}
-			matching += fmt.Sprintf(" group_%s (%s)", vmCard, strings.Join(vm.Include, ", "))
+			writeStringsJoin(b, vm.Include, ", ")
+			b.WriteByte(')')
 		}
 	}
-	return matching
 }
 
 func (node *DurationExpr) String() string {
 	b := bytes.NewBuffer(make([]byte, 0, 1024))
-	node.writeTo(b)
+	node.WriteTo(b)
 	return b.String()
 }
 
-func (node *DurationExpr) writeTo(b *bytes.Buffer) {
+func (node *DurationExpr) WriteTo(b *bytes.Buffer) {
 	if node.Wrapped {
 		b.WriteByte('(')
 	}
@@ -198,6 +222,13 @@ func (node *DurationExpr) ShortString() string {
 
 func (node *Call) String() string {
 	return node.Func.Name + "(" + node.Args.String() + ")"
+}
+
+func (node *Call) WriteTo(b *bytes.Buffer) {
+	b.WriteString(node.Func.Name)
+	b.WriteByte('(')
+	node.Args.WriteTo(b)
+	b.WriteByte(')')
 }
 
 func (node *Call) ShortString() string {
@@ -229,6 +260,12 @@ func (node *MatrixSelector) atOffset() (string, string) {
 }
 
 func (node *MatrixSelector) String() string {
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *MatrixSelector) WriteTo(b *bytes.Buffer) {
 	at, offset := node.atOffset()
 	// Copy the Vector selector before changing the offset
 	vecSelector := *node.VectorSelector.(*VectorSelector)
@@ -243,11 +280,14 @@ func (node *MatrixSelector) String() string {
 	if node.RangeExpr != nil {
 		rangeStr = node.RangeExpr.String()
 	}
-	str := fmt.Sprintf("%s[%s]%s%s", vecSelector.String(), rangeStr, at, offset)
+	vecSelector.WriteTo(b)
+	b.WriteByte('[')
+	b.WriteString(rangeStr)
+	b.WriteByte(']')
+	b.WriteString(at)
+	b.WriteString(offset)
 
 	vecSelector.OriginalOffset, vecSelector.OriginalOffsetExpr, vecSelector.Timestamp, vecSelector.StartOrEnd = offsetVal, offsetExprVal, atVal, preproc
-
-	return str
 }
 
 func (node *MatrixSelector) ShortString() string {
@@ -261,6 +301,11 @@ func (node *MatrixSelector) ShortString() string {
 
 func (node *SubqueryExpr) String() string {
 	return fmt.Sprintf("%s%s", node.Expr.String(), node.getSubqueryTimeSuffix())
+}
+
+func (node *SubqueryExpr) WriteTo(b *bytes.Buffer) {
+	node.Expr.WriteTo(b)
+	b.WriteString(node.getSubqueryTimeSuffix())
 }
 
 func (node *SubqueryExpr) ShortString() string {
@@ -301,25 +346,51 @@ func (node *SubqueryExpr) getSubqueryTimeSuffix() string {
 }
 
 func (node *NumberLiteral) String() string {
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *NumberLiteral) WriteTo(b *bytes.Buffer) {
 	if node.Duration {
 		if node.Val < 0 {
-			return fmt.Sprintf("-%s", model.Duration(-node.Val*1e9).String())
+			b.WriteByte('-')
+			b.WriteString(model.Duration(-node.Val * 1e9).String())
+			return
 		}
-		return model.Duration(node.Val * 1e9).String()
+		b.WriteString(model.Duration(node.Val * 1e9).String())
+		return
 	}
-	return strconv.FormatFloat(node.Val, 'f', -1, 64)
+	b.Write(strconv.AppendFloat(b.AvailableBuffer(), node.Val, 'f', -1, 64))
 }
 
 func (node *ParenExpr) String() string {
-	return "(" + node.Expr.String() + ")"
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *ParenExpr) WriteTo(b *bytes.Buffer) {
+	b.WriteByte('(')
+	node.Expr.WriteTo(b)
+	b.WriteByte(')')
 }
 
 func (node *StringLiteral) String() string {
 	return strconv.Quote(node.Val)
 }
 
+func (node *StringLiteral) WriteTo(b *bytes.Buffer) {
+	b.Write(strconv.AppendQuote(b.AvailableBuffer(), node.Val))
+}
+
 func (node *UnaryExpr) String() string {
 	return node.Op.String() + node.Expr.String()
+}
+
+func (node *UnaryExpr) WriteTo(b *bytes.Buffer) {
+	b.WriteString(node.Op.String())
+	node.Expr.WriteTo(b)
 }
 
 func (node *UnaryExpr) ShortString() string {
@@ -327,6 +398,12 @@ func (node *UnaryExpr) ShortString() string {
 }
 
 func (node *VectorSelector) String() string {
+	b := bytes.NewBuffer(make([]byte, 0, 128))
+	node.WriteTo(b)
+	return b.String()
+}
+
+func (node *VectorSelector) WriteTo(b *bytes.Buffer) {
 	var labelStrings []string
 	if len(node.LabelMatchers) > 1 {
 		labelStrings = make([]string, 0, len(node.LabelMatchers)-1)
@@ -338,7 +415,6 @@ func (node *VectorSelector) String() string {
 		}
 		labelStrings = append(labelStrings, matcher.String())
 	}
-	b := bytes.NewBuffer(make([]byte, 0, 1024))
 	b.WriteString(node.Name)
 	if len(labelStrings) != 0 {
 		b.WriteByte('{')
@@ -358,7 +434,7 @@ func (node *VectorSelector) String() string {
 	switch {
 	case node.OriginalOffsetExpr != nil:
 		b.WriteString(" offset ")
-		node.OriginalOffsetExpr.writeTo(b)
+		node.OriginalOffsetExpr.WriteTo(b)
 	case node.OriginalOffset > time.Duration(0):
 		b.WriteString(" offset ")
 		b.WriteString(model.Duration(node.OriginalOffset).String())
@@ -366,5 +442,4 @@ func (node *VectorSelector) String() string {
 		b.WriteString(" offset -")
 		b.WriteString(model.Duration(-node.OriginalOffset).String())
 	}
-	return b.String()
 }

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -167,6 +167,9 @@ func TestExprString(t *testing.T) {
 			in:  "1048576",
 			out: "1048576",
 		},
+		{
+			in: `predict_linear(foo[1h], 3000)`,
+		},
 	}
 
 	for _, test := range inputs {

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -185,6 +185,27 @@ func TestExprString(t *testing.T) {
 	}
 }
 
+func BenchmarkExprString(b *testing.B) {
+	inputs := []string{
+		`sum by(code) (task:errors:rate10s{job="s"})`,
+		`max( 100 * (1 - avg by(instance) (irate(node_cpu_seconds_total{instance=~".*cust01.prd.*",mode="idle"}[86400s]))))`,
+		`http_requests_total{job="api-server", group="canary"} + rate(http_requests_total{job="api-server"}[10m]) * 5 * 60`,
+		`sum by (pod) ((kube_pod_container_status_restarts_total{namespace="mynamespace",cluster="mycluster"} - kube_pod_container_status_restarts_total{namespace="mynamespace}",cluster="mycluster}"} offset 10m) >= 1 and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{namespace="mynamespace",cluster="mycluster",reason="OOMKilled"}[10m]) == 1)`,
+		`sum by (pod) ((kube_pod_container_status_restarts_total{cluster="mycluster",namespace="mynamespace"} - kube_pod_container_status_restarts_total{cluster="mycluster",namespace="mynamespace}"} offset 10m) >= 1 and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{cluster="mycluster",namespace="mynamespace",reason="OOMKilled"}[10m]) == 1)`, // Sort matchers.
+		`label_replace(testmetric, "dst", "destination-value-$1", "src", "source-value-(.*)")`,
+	}
+
+	for _, test := range inputs {
+		b.Run(readable(test), func(b *testing.B) {
+			expr, err := ParseExpr(test)
+			require.NoError(b, err)
+			for i := 0; i < b.N; i++ {
+				expr.String()
+			}
+		})
+	}
+}
+
 func TestVectorSelector_String(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -200,7 +200,7 @@ func BenchmarkExprString(b *testing.B) {
 			expr, err := ParseExpr(test)
 			require.NoError(b, err)
 			for i := 0; i < b.N; i++ {
-				expr.String()
+				_ = expr.String()
 			}
 		})
 	}


### PR DESCRIPTION
Goes faster due to reduced memory allocation.

This PR is organized into 7 commits: the first two add a test case and some benchmarks.
The rest make printing faster, in increasing levels of complexity.

I'm not convinced we need maximum complexity; most of the benefit is achieved with the first two changes.

1. Replace some simple Sprintf with string concat. This goes faster because there is no runtime format parsing.

```
                                                            │  before.txt  │             after1.txt              │
                                                            │    sec/op    │    sec/op     vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8      455.9n ± 16%   441.6n ±  0%   -3.13% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8      2.002µ ±  5%   1.315µ ±  8%  -34.30% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8      1.737µ ±  6%   1.154µ ±  1%  -33.59% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8      3.536µ ±  6%   2.614µ ±  4%  -26.06% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8   3.520µ ±  2%   2.584µ ± 10%  -26.58% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8      927.5n ±  1%   675.9n ±  1%  -27.13% (p=0.002 n=6)
geomean                                                       1.623µ         1.205µ        -25.78%
```

2. Replace some Sprintf with bytes.Buffer 

```
                                                            │  before.txt   │             after2.txt              │
                                                            │    sec/op     │    sec/op     vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8       455.9n ± 16%   172.8n ±  1%  -62.10% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8      2001.5n ±  5%   888.1n ±  1%  -55.63% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8      1737.0n ±  6%   920.8n ± 13%  -46.99% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8       3.536µ ±  6%   1.891µ ±  1%  -46.53% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8    3.520µ ±  2%   1.875µ ±  2%  -46.73% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8       927.5n ±  1%   471.6n ±  1%  -49.15% (p=0.002 n=6)
geomean                                                        1.623µ         786.2n        -51.57%
```

3. Replace every Sprintf with bytes.Buffer - eliminate almost all string concatenation.

```
                                                            │  before.txt   │             after3.txt             │
                                                            │    sec/op     │   sec/op     vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8       455.9n ± 16%   173.0n ± 2%  -62.04% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8      2001.5n ±  5%   552.0n ± 3%  -72.42% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8      1737.0n ±  6%   640.6n ± 1%  -63.12% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8       3.536µ ±  6%   1.421µ ± 1%  -59.82% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8    3.520µ ±  2%   1.406µ ± 1%  -60.05% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8       927.5n ±  1%   342.8n ± 3%  -63.05% (p=0.002 n=6)
geomean                                                        1.623µ         589.3n       -63.69%
```


4. The last optimisation is to print `VectorSelector` faster when matchers are sorted, which in turn requires a change to the parser to put the `__name__` matcher first, and to fix up all the tests that check for this.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql/parser
cpu: Apple M2
                                                            │  before.txt   │              after.txt              │
                                                            │    sec/op     │    sec/op     vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8       455.9n ± 16%   129.0n ± 19%  -71.70% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8      2001.5n ±  5%   492.1n ±  9%  -75.41% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8      1737.0n ±  6%   604.6n ±  1%  -65.19% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8       3.536µ ±  6%   1.482µ ±  4%  -58.10% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8    3.520µ ±  2%   1.184µ ±  5%  -66.36% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8       927.5n ±  1%   352.2n ±  1%  -62.03% (p=0.002 n=6)
geomean                                                        1.623µ         536.0n        -66.98%

                                                            │  before.txt  │              after.txt              │
                                                            │     B/op     │     B/op      vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8        240.0 ± 0%     224.0 ± 0%   -6.67% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8       1456.0 ± 0%     306.0 ± 0%  -78.98% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8        856.0 ± 0%     371.0 ± 0%  -56.66% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8      3.432Ki ± 0%   1.608Ki ± 0%  -53.13% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8   3.385Ki ± 0%   1.335Ki ± 0%  -60.56% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8        720.0 ± 0%     352.0 ± 0%  -51.11% (p=0.002 n=6)
geomean                                                       1.147Ki          521.7       -55.58%

                                                            │ before.txt  │             after.txt             │
                                                            │  allocs/op  │ allocs/op   vs base               │
ExprString/sum_by(code)_(task:errors:rate10s{job="s...-8      12.000 ± 0%   3.000 ± 0%  -75.00% (p=0.002 n=6)
ExprString/max(_100_*_(1_-_avg_by(instance)_(irate(...-8      34.000 ± 0%   5.000 ± 0%  -85.29% (p=0.002 n=6)
ExprString/http_requests_total{job="api-server",_gr...-8      30.000 ± 0%   8.000 ± 0%  -73.33% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...-8       58.00 ± 0%   19.00 ± 0%  -67.24% (p=0.002 n=6)
ExprString/sum_by_(pod)_((kube_pod_container_status...#01-8   58.000 ± 0%   9.000 ± 0%  -84.48% (p=0.002 n=6)
ExprString/label_replace(testmetric,_"dst",_"destin...-8      22.000 ± 0%   4.000 ± 0%  -81.82% (p=0.002 n=6)
geomean                                                        31.11        6.592       -78.81%
```