### PR TITLE
Update backport action version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,7 +28,8 @@ jobs:
           path: ./actions
           # pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
           # we don't want to have the same strict rules for PR labels
-          ref: d284afd314ca3625c23595e9f62b52d215ead7ce
+          # We also use our own version which works with merge commits since a lot of the commits in this repo are merge commits.
+          ref: ea415d5eaa70337430db7ae7782f28dd14a15525
           persist-credentials: false
 
       - name: Install Actions


### PR DESCRIPTION
I pushed a small patch to the action: https://github.com/grafana/grafana-github-actions/commit/ea415d5eaa70337430db7ae7782f28dd14a15525

The previous version didn't handle merge commits ([example](https://github.com/grafana/mimir-prometheus/actions/runs/15214022955/job/42795000753)). Here we assume that all merge commits are towards the main branch.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
