### PR TITLE
Fix branch name in conflict resolution guide

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -249,13 +249,13 @@ jobs:
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "🚧 DRAFT: Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} into ${{ needs.check-merge.outputs.local_branch }} (CONFLICTS)"
+          title: "DRAFT: Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} into ${{ needs.check-merge.outputs.local_branch }} (CONFLICTS)"
           body: |
-            ## ⚠️ Merge Conflicts Detected
+            ## Merge Conflicts Detected
             
             *This DRAFT PR was automatically created by the [merge-upstream-prometheus workflow](https://github.com/grafana/mimir-prometheus/blob/main/.github/workflows/merge-upstream-prometheus.yml) due to merge conflicts.*
             
-            ### 🔧 Action Required
+            ### Action Required
             This PR contains **unresolved merge conflicts** with conflict markers preserved in the files. To complete this merge:
             
             1. **Find conflicts**: Search for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
@@ -264,13 +264,13 @@ jobs:
             4. **Test changes**: Ensure the merge works correctly
             5. **Mark ready**: Convert from draft when resolved
             
-            ### 📋 Details
+            ### Details
             - **Upstream branch**: `${{ needs.check-merge.outputs.upstream_branch }}`
             - **Local branch**: `${{ needs.check-merge.outputs.local_branch }}`
             - **Latest upstream commit**: ${{ format('[`{0}`](https://github.com/prometheus/prometheus/commit/{0})', needs.check-merge.outputs.upstream_commit) }}
             - **Latest upstream commit date**: ${{ needs.check-merge.outputs.commit_date }}
             
-            ### 🔍 Conflict Resolution Guide
+            ### Conflict Resolution Guide
             ```bash
             # Fetch and check out this branch locally
             git fetch origin ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
@@ -290,7 +290,7 @@ jobs:
             git push
             ```
             
-            ### 📊 Changes
+            ### Changes
             This PR merges the latest changes from the upstream prometheus/prometheus `${{ needs.check-merge.outputs.upstream_branch }}` branch.
           commit-message: "WIP: Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} (${{ needs.check-merge.outputs.upstream_short }}) - CONFLICTS NEED RESOLUTION"
           branch: ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -273,7 +273,7 @@ jobs:
             ### 🔍 Conflict Resolution Guide
             ```bash
             # Check out this branch locally
-            git checkout ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts
+            git checkout ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
             
             # Find conflicted files
             git status

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -249,20 +249,10 @@ jobs:
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "DRAFT: Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} into ${{ needs.check-merge.outputs.local_branch }} (CONFLICTS)"
+          title: "DRAFT: [${{ needs.check-merge.outputs.local_branch }}] Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }}"
           body: |
-            ## Merge Conflicts Detected
-            
-            *This DRAFT PR was automatically created by the [merge-upstream-prometheus workflow](https://github.com/grafana/mimir-prometheus/blob/main/.github/workflows/merge-upstream-prometheus.yml) due to merge conflicts.*
-            
-            ### Action Required
-            This PR contains **unresolved merge conflicts** with conflict markers preserved in the files. To complete this merge:
-            
-            1. **Find conflicts**: Search for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
-            2. **Resolve conflicts**: Edit files to choose the correct changes
-            3. **Remove markers**: Delete all conflict marker lines  
-            4. **Test changes**: Ensure the merge works correctly
-            5. **Mark ready**: Convert from draft when resolved
+            ## Changes
+            This PR merges the latest changes from the upstream prometheus/prometheus `${{ needs.check-merge.outputs.upstream_branch }}` branch.
             
             ### Details
             - **Upstream branch**: `${{ needs.check-merge.outputs.upstream_branch }}`
@@ -270,7 +260,13 @@ jobs:
             - **Latest upstream commit**: ${{ format('[`{0}`](https://github.com/prometheus/prometheus/commit/{0})', needs.check-merge.outputs.upstream_commit) }}
             - **Latest upstream commit date**: ${{ needs.check-merge.outputs.commit_date }}
             
-            ### Conflict Resolution Guide
+            ## Merge Conflicts Detected
+            
+            *This DRAFT PR was automatically created by the [merge-upstream-prometheus workflow](https://github.com/grafana/mimir-prometheus/blob/main/.github/workflows/merge-upstream-prometheus.yml) due to merge conflicts.*
+            
+            ### Action Required
+            This PR contains **unresolved merge conflicts** with conflict markers preserved in the files. To complete this merge:
+            
             ```bash
             # Fetch and check out this branch locally
             git fetch origin ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
@@ -289,9 +285,6 @@ jobs:
             git commit -m "Resolve merge conflicts"
             git push
             ```
-            
-            ### Changes
-            This PR merges the latest changes from the upstream prometheus/prometheus `${{ needs.check-merge.outputs.upstream_branch }}` branch.
           commit-message: "WIP: Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} (${{ needs.check-merge.outputs.upstream_short }}) - CONFLICTS NEED RESOLUTION"
           branch: ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
           base: ${{ needs.check-merge.outputs.local_branch }}
@@ -378,7 +371,7 @@ jobs:
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }} into ${{ needs.check-merge.outputs.local_branch }}"
+          title: "[${{ needs.check-merge.outputs.local_branch }}] Merge upstream prometheus/${{ needs.check-merge.outputs.upstream_branch }}"
           body: |
             ## Merge from prometheus/prometheus
             

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -297,7 +297,7 @@ jobs:
           channel-id: C04AF91LPFX #mimir-ci-notifications
           payload: |
             {
-              "text": ":warning: *Merge conflicts detected in upstream prometheus merge*\n\n*Details:*\n• Upstream branch: `${{ needs.check-merge.outputs.upstream_branch }}`\n• Local branch: `${{ needs.check-merge.outputs.local_branch }}`\n• Latest upstream commit: <https://github.com/prometheus/prometheus/commit/${{ needs.check-merge.outputs.upstream_commit }}|${{ needs.check-merge.outputs.upstream_short }}>\n\n:point_right: **Draft PR created**: <${{ steps.create-conflict-pr.outputs.pull-request-url }}|Click here to resolve conflicts>\n\n<!subteam^S03C2P8659U> the PR contains conflict markers and needs manual resolution. Check the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow logs> for details."
+              "text": ":warning: *Merge conflicts detected in upstream prometheus merge*\n\n*Details:*\n• Upstream branch: `${{ needs.check-merge.outputs.upstream_branch }}`\n• Local branch: `${{ needs.check-merge.outputs.local_branch }}`\n• Latest upstream commit: <https://github.com/prometheus/prometheus/commit/${{ needs.check-merge.outputs.upstream_commit }}|${{ needs.check-merge.outputs.upstream_short }}>\n\n:point_right: *Draft PR created*: <${{ steps.create-conflict-pr.outputs.pull-request-url }}|Click here to resolve conflicts>\n\n<!subteam^S03C2P8659U> the PR contains conflict markers and needs manual resolution. Check the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow logs> for details."
             }
 
   handle-error:

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -272,11 +272,9 @@ jobs:
             
             ### 🔍 Conflict Resolution Guide
             ```bash
-            # Check out this branch locally
+            # Fetch and check out this branch locally
+            git fetch origin ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
             git checkout ${{ needs.check-merge.outputs.local_branch }}-merge-conflicts-${{ needs.check-merge.outputs.timestamp }}
-            
-            # Find conflicted files
-            git status
             
             # Edit each conflicted file and resolve conflicts
             # Look for these markers and resolve:


### PR DESCRIPTION
The guide was referencing the wrong branch name. Now correctly shows
the actual branch name with timestamp suffix that gets created.## Fixes

- **Fix branch name** in conflict resolution guide to include timestamp suffix
- **Add fetch step** to ensure branch is available locally
- **Remove git status** command since it doesn't show conflicts after they're committed with markers
- **Remove emojis** it gave away too much that this is ai slop
- **Reorder Conflict PR description**
- **Update PR titles**
- **Update slack message** because `**` is not **bold** in slack markdown, it's jutt `**`