### PR TITLE
Add ByteSize method for Labels

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -249,7 +249,7 @@ func (ls Labels) WithoutEmpty() Labels {
 }
 
 // ByteSize returns the approximate size of the labels in bytes.
-// String header size is ignored because it should be amortized to zero.
+// String and slice header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
 	var size = 0
 	for _, l := range ls {

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -248,6 +248,16 @@ func (ls Labels) WithoutEmpty() Labels {
 	return ls
 }
 
+// ByteSize returns the approximate size of the labels in bytes.
+// String header size is ignored because it should be amortized to zero.
+func (ls Labels) ByteSize() int {
+	var size = 0
+	for _, l := range ls {
+		size += len(l.Name) + len(l.Value)
+	}
+	return size
+}
+
 // Equal returns whether the two label sets are equal.
 func Equal(ls, o Labels) bool {
 	return slices.Equal(ls, o)

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -249,12 +249,12 @@ func (ls Labels) WithoutEmpty() Labels {
 }
 
 // ByteSize returns the approximate size of the labels in bytes.
+// String and slice header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
 	var size = 0
 	for _, l := range ls {
-		size += len(l.Name) + len(l.Value) + 2*int(unsafe.Sizeof(""))
+		size += len(l.Name) + len(l.Value)
 	}
-	size += int(unsafe.Sizeof([]Labels{}))
 	return size
 }
 

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -249,12 +249,12 @@ func (ls Labels) WithoutEmpty() Labels {
 }
 
 // ByteSize returns the approximate size of the labels in bytes.
-// String and slice header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
 	var size = 0
 	for _, l := range ls {
-		size += len(l.Name) + len(l.Value)
+		size += len(l.Name) + len(l.Value) + 2*int(unsafe.Sizeof(""))
 	}
+	size += int(unsafe.Sizeof([]Labels{}))
 	return size
 }
 

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -251,7 +251,7 @@ func (ls Labels) WithoutEmpty() Labels {
 // ByteSize returns the approximate size of the labels in bytes.
 // String and slice header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
-	var size = 0
+	size := 0
 	for _, l := range ls {
 		size += len(l.Name) + len(l.Value)
 	}

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -417,6 +417,12 @@ func (ls Labels) WithoutEmpty() Labels {
 	return ls
 }
 
+// ByteSize returns the approximate size of the labels in bytes.
+// String header size is ignored because it should be amortized to zero.
+func (ls Labels) ByteSize() int {
+	return len(ls.data)
+}
+
 // Equal returns whether the two label sets are equal.
 func Equal(a, b Labels) bool {
 	if a.syms == b.syms {

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -419,7 +419,7 @@ func (ls Labels) WithoutEmpty() Labels {
 
 // ByteSize returns the approximate size of the labels in bytes.
 // String header size is ignored because it should be amortized to zero.
-// TODO: this is not correct yet
+// SymbolTable size is also not taken into account.
 func (ls Labels) ByteSize() int {
 	return len(ls.data)
 }

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -419,6 +419,7 @@ func (ls Labels) WithoutEmpty() Labels {
 
 // ByteSize returns the approximate size of the labels in bytes.
 // String header size is ignored because it should be amortized to zero.
+// TODO: this is not correct yet
 func (ls Labels) ByteSize() int {
 	return len(ls.data)
 }

--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -56,11 +56,11 @@ func TestByteSize(t *testing.T) {
 	}{
 		{
 			lbls:     FromStrings("__name__", "foo"),
-			expected: 13,
+			expected: 4, // TODO: this is no correct yet
 		},
 		{
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 21,
+			expected: 8, // TODO: this is also not correct yet
 		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())

--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -56,11 +56,15 @@ func TestByteSize(t *testing.T) {
 	}{
 		{
 			lbls:     FromStrings("__name__", "foo"),
-			expected: 4, // TODO: this is no correct yet
+			expected: 4,
 		},
 		{
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 8, // TODO: this is also not correct yet
+			expected: 8,
+		},
+		{
+			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
+			expected: 32,
 		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright 2025 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -34,6 +34,10 @@ func TestByteSize(t *testing.T) {
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
 			expected: 17,
 		},
+		{
+			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
+			expected: 293,
+		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())
 	}

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -28,11 +28,11 @@ func TestByteSize(t *testing.T) {
 	}{
 		{
 			lbls:     FromStrings("__name__", "foo"),
-			expected: 67,
+			expected: 11,
 		},
 		{
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 105,
+			expected: 17,
 		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build dedupelabels
+//go:build slicelabels
 
 package labels
 
@@ -21,34 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVarint(t *testing.T) {
-	cases := []struct {
-		v        int
-		expected []byte
-	}{
-		{0, []byte{0, 0}},
-		{1, []byte{1, 0}},
-		{2, []byte{2, 0}},
-		{0x7FFF, []byte{0xFF, 0x7F}},
-		{0x8000, []byte{0x00, 0x80, 0x01}},
-		{0x8001, []byte{0x01, 0x80, 0x01}},
-		{0x3FFFFF, []byte{0xFF, 0xFF, 0x7F}},
-		{0x400000, []byte{0x00, 0x80, 0x80, 0x01}},
-		{0x400001, []byte{0x01, 0x80, 0x80, 0x01}},
-		{0x1FFFFFFF, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
-	}
-	var buf [16]byte
-	for _, c := range cases {
-		n := encodeVarint(buf[:], len(buf), c.v)
-		require.Equal(t, len(c.expected), len(buf)-n)
-		require.Equal(t, c.expected, buf[n:])
-		got, m := decodeVarint(string(buf[:]), n)
-		require.Equal(t, c.v, got)
-		require.Equal(t, len(buf), m)
-	}
-	require.Panics(t, func() { encodeVarint(buf[:], len(buf), 1<<29) })
-}
-
 func TestByteSize(t *testing.T) {
 	for _, testCase := range []struct {
 		lbls     Labels
@@ -56,11 +28,11 @@ func TestByteSize(t *testing.T) {
 	}{
 		{
 			lbls:     FromStrings("__name__", "foo"),
-			expected: 13,
+			expected: 67,
 		},
 		{
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 21,
+			expected: 105,
 		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -284,8 +284,9 @@ func (ls Labels) WithoutEmpty() Labels {
 }
 
 // ByteSize returns the approximate size of the labels in bytes.
+// String header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
-	return len(ls.data) + int(unsafe.Sizeof(""))
+	return len(ls.data)
 }
 
 // Equal returns whether the two label sets are equal.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -284,9 +284,8 @@ func (ls Labels) WithoutEmpty() Labels {
 }
 
 // ByteSize returns the approximate size of the labels in bytes.
-// String header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() int {
-	return len(ls.data)
+	return len(ls.data) + int(unsafe.Sizeof(""))
 }
 
 // Equal returns whether the two label sets are equal.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -283,6 +283,12 @@ func (ls Labels) WithoutEmpty() Labels {
 	return ls
 }
 
+// ByteSize returns the approximate size of the labels in bytes.
+// String header size is ignored because it should be amortized to zero.
+func (ls Labels) ByteSize() int {
+	return len(ls.data)
+}
+
 // Equal returns whether the two label sets are equal.
 func Equal(ls, o Labels) bool {
 	return ls.data == o.data

--- a/model/labels/labels_stringlabels_test.go
+++ b/model/labels/labels_stringlabels_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright 2025 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/model/labels/labels_stringlabels_test.go
+++ b/model/labels/labels_stringlabels_test.go
@@ -34,6 +34,10 @@ func TestByteSize(t *testing.T) {
 			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
 			expected: 21,
 		},
+		{
+			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
+			expected: 309,
+		},
 	} {
 		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())
 	}

--- a/model/labels/labels_stringlabels_test.go
+++ b/model/labels/labels_stringlabels_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build dedupelabels
+//go:build stringlabels
 
 package labels
 
@@ -20,34 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestVarint(t *testing.T) {
-	cases := []struct {
-		v        int
-		expected []byte
-	}{
-		{0, []byte{0, 0}},
-		{1, []byte{1, 0}},
-		{2, []byte{2, 0}},
-		{0x7FFF, []byte{0xFF, 0x7F}},
-		{0x8000, []byte{0x00, 0x80, 0x01}},
-		{0x8001, []byte{0x01, 0x80, 0x01}},
-		{0x3FFFFF, []byte{0xFF, 0xFF, 0x7F}},
-		{0x400000, []byte{0x00, 0x80, 0x80, 0x01}},
-		{0x400001, []byte{0x01, 0x80, 0x80, 0x01}},
-		{0x1FFFFFFF, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
-	}
-	var buf [16]byte
-	for _, c := range cases {
-		n := encodeVarint(buf[:], len(buf), c.v)
-		require.Equal(t, len(c.expected), len(buf)-n)
-		require.Equal(t, c.expected, buf[n:])
-		got, m := decodeVarint(string(buf[:]), n)
-		require.Equal(t, c.v, got)
-		require.Equal(t, len(buf), m)
-	}
-	require.Panics(t, func() { encodeVarint(buf[:], len(buf), 1<<29) })
-}
 
 func TestByteSize(t *testing.T) {
 	for _, testCase := range []struct {


### PR DESCRIPTION
Bring https://github.com/prometheus/prometheus/pull/16717 to mimir-prometheus so that we can use it in https://github.com/grafana/mimir/pull/11683 earlier.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
