### PR TITLE
Add instructions on how to fetch commits from upstream when merge conflicts occur

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -242,7 +242,9 @@ jobs:
             git fetch origin
             git checkout ${{ needs.check-merge.outputs.bot_branch }}
             
-            # 2. Merge the upstream commit to trigger conflicts
+            # 2. Fetch and merge the upstream commit to trigger conflicts
+            git remote add upstream https://github.com/prometheus/prometheus.git # Omit this step if you already have a remote configured for prometheus/prometheus.
+            git fetch upstream
             git merge ${{ needs.check-merge.outputs.upstream_commit }} --no-edit
             
             # 3. If conflicts occur:
@@ -292,7 +294,7 @@ jobs:
             {
               "text": ":sadcomputer: *Upstream prometheus merge failed*\(prometheus/`${{ needs.check-merge.outputs.upstream_branch }}` -> mimir-prometheus/`${{ needs.check-merge.outputs.local_branch }})\n\nTODO please investigate the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow logs> and resolve manually."
             }
-      
+
       - name: Mark workflow as failed
         run: exit 1
 


### PR DESCRIPTION
This PR improves the instructions included in PRs like https://github.com/grafana/mimir-prometheus/pull/907. It adds commands for fetching upstream before attempting the merge, as the commit being merged may not have been fetched locally yet.