### PR TITLE
OTLP receiver: Fix conversion of non-monotonic sums

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -93,7 +93,7 @@ func TranslatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter


### PR DESCRIPTION
Translation of OTLP non-monotonic sum metrics has been broken in Prometheus since https://github.com/prometheus/prometheus/pull/16626, because [translatorMetricFromOtelMetric](https://github.com/prometheus/prometheus/pull/16626/files#diff-1e76309731ff41b269672516ed66c8848b751e0d48a596dc8c15a4dda9a2cbecR78) associates sum metric monotonicity with cumulative aggregation temporality. There is no such connection, one should instead (as before that PR) check whether the sum is monotonic. I'm proposing a fix in this PR, and have written a corresponding test in Mimir (see [PR](https://github.com/grafana/mimir/pull/11810)), as a guard against this reoccurring.

I will make an upstream PR, including tests, after this and the Mimir PR get merged.