### PR TITLE
Fix merge instructions to fetch specific upstream commit

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -244,7 +244,7 @@ jobs:
             
             # 2. Fetch and merge the upstream commit to trigger conflicts
             git remote add upstream https://github.com/prometheus/prometheus.git # Omit this step if you already have a remote configured for prometheus/prometheus.
-            git fetch upstream
+            git fetch upstream ${{ needs.check-merge.outputs.upstream_commit }}
             git merge ${{ needs.check-merge.outputs.upstream_commit }} --no-edit
             
             # 3. If conflicts occur:


### PR DESCRIPTION
The merge conflict resolution instructions were missing the specific commit hash when fetching from upstream. This caused users to not have the required commit available locally when trying to merge.

This fixes the fetch command to include the specific commit that caused the conflict.

suggested by @charleskorn 