### PR TITLE
[TESTS] Labels: Simplify TestByteSize 

### DIFF
--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -49,24 +49,11 @@ func TestVarint(t *testing.T) {
 	require.Panics(t, func() { encodeVarint(buf[:], len(buf), 1<<29) })
 }
 
-func TestByteSize(t *testing.T) {
-	for _, testCase := range []struct {
-		lbls     Labels
-		expected int
-	}{
-		{
-			lbls:     FromStrings("__name__", "foo"),
-			expected: 4,
-		},
-		{
-			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 8,
-		},
-		{
-			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
-			expected: 32,
-		},
-	} {
-		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())
-	}
+var expectedByteSize = []uint64{ // Values must line up with testCaseLabels.
+	8,
+	0,
+	8,
+	8,
+	8,
+	32,
 }

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build slicelabels
+//go:build !stringlabels && !dedupelabels
 
 package labels
 

--- a/model/labels/labels_slicelabels_test.go
+++ b/model/labels/labels_slicelabels_test.go
@@ -15,30 +15,11 @@
 
 package labels
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
-
-func TestByteSize(t *testing.T) {
-	for _, testCase := range []struct {
-		lbls     Labels
-		expected int
-	}{
-		{
-			lbls:     FromStrings("__name__", "foo"),
-			expected: 11,
-		},
-		{
-			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 17,
-		},
-		{
-			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
-			expected: 293,
-		},
-	} {
-		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())
-	}
+var expectedByteSize = []uint64{ // Values must line up with testCaseLabels.
+	8,
+	0,
+	33,
+	262,
+	263,
+	293,
 }

--- a/model/labels/labels_stringlabels_test.go
+++ b/model/labels/labels_stringlabels_test.go
@@ -15,30 +15,11 @@
 
 package labels
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
-
-func TestByteSize(t *testing.T) {
-	for _, testCase := range []struct {
-		lbls     Labels
-		expected int
-	}{
-		{
-			lbls:     FromStrings("__name__", "foo"),
-			expected: 13,
-		},
-		{
-			lbls:     FromStrings("__name__", "foo", "pod", "bar"),
-			expected: 21,
-		},
-		{
-			lbls:     FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
-			expected: 309,
-		},
-	} {
-		require.Equal(t, testCase.expected, testCase.lbls.ByteSize())
-	}
+var expectedByteSize = []uint64{ // Values must line up with testCaseLabels.
+	12,
+	0,
+	37,
+	266,
+	270,
+	309,
 }

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -26,37 +26,31 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var (
+	s254 = strings.Repeat("x", 254) // Edge cases for stringlabels encoding.
+	s255 = strings.Repeat("x", 255)
+)
+
+var testCaseLabels = []Labels{
+	FromStrings("t1", "t1", "t2", "t2"),
+	{},
+	FromStrings("service.name", "t1", "whatever\\whatever", "t2"),
+	FromStrings("aaa", "111", "xx", s254),
+	FromStrings("aaa", "111", "xx", s255),
+}
+
 func TestLabels_String(t *testing.T) {
-	s254 := strings.Repeat("x", 254) // Edge cases for stringlabels encoding.
-	s255 := strings.Repeat("x", 255)
-	cases := []struct {
-		labels   Labels
-		expected string
-	}{
-		{
-			labels:   FromStrings("t1", "t1", "t2", "t2"),
-			expected: "{t1=\"t1\", t2=\"t2\"}",
-		},
-		{
-			labels:   Labels{},
-			expected: "{}",
-		},
-		{
-			labels:   FromStrings("service.name", "t1", "whatever\\whatever", "t2"),
-			expected: `{"service.name"="t1", "whatever\\whatever"="t2"}`,
-		},
-		{
-			labels:   FromStrings("aaa", "111", "xx", s254),
-			expected: `{aaa="111", xx="` + s254 + `"}`,
-		},
-		{
-			labels:   FromStrings("aaa", "111", "xx", s255),
-			expected: `{aaa="111", xx="` + s255 + `"}`,
-		},
+	expected := []string{ // Values must line up with testCaseLabels.
+		"{t1=\"t1\", t2=\"t2\"}",
+		"{}",
+		`{"service.name"="t1", "whatever\\whatever"="t2"}`,
+		`{aaa="111", xx="` + s254 + `"}`,
+		`{aaa="111", xx="` + s255 + `"}`,
 	}
-	for _, c := range cases {
-		str := c.labels.String()
-		require.Equal(t, c.expected, str)
+	require.Equal(t, len(testCaseLabels), len(expected))
+	for i, c := range expected {
+		str := testCaseLabels[i].String()
+		require.Equal(t, c, str)
 	}
 }
 

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -37,6 +37,7 @@ var testCaseLabels = []Labels{
 	FromStrings("service.name", "t1", "whatever\\whatever", "t2"),
 	FromStrings("aaa", "111", "xx", s254),
 	FromStrings("aaa", "111", "xx", s255),
+	FromStrings("__name__", "kube_pod_container_status_last_terminated_exitcode", "cluster", "prod-af-north-0", " container", "prometheus", "instance", "kube-state-metrics-0:kube-state-metrics:ksm", "job", "kube-state-metrics/kube-state-metrics", " namespace", "observability-prometheus", "pod", "observability-prometheus-0", "uid", "d3ec90b2-4975-4607-b45d-b9ad64bb417e"),
 }
 
 func TestLabels_String(t *testing.T) {
@@ -46,6 +47,7 @@ func TestLabels_String(t *testing.T) {
 		`{"service.name"="t1", "whatever\\whatever"="t2"}`,
 		`{aaa="111", xx="` + s254 + `"}`,
 		`{aaa="111", xx="` + s255 + `"}`,
+		`{" container"="prometheus", " namespace"="observability-prometheus", __name__="kube_pod_container_status_last_terminated_exitcode", cluster="prod-af-north-0", instance="kube-state-metrics-0:kube-state-metrics:ksm", job="kube-state-metrics/kube-state-metrics", pod="observability-prometheus-0", uid="d3ec90b2-4975-4607-b45d-b9ad64bb417e"}`,
 	}
 	require.Equal(t, len(testCaseLabels), len(expected))
 	for i, c := range expected {
@@ -58,6 +60,13 @@ func BenchmarkString(b *testing.B) {
 	ls := New(benchmarkLabels...)
 	for i := 0; i < b.N; i++ {
 		_ = ls.String()
+	}
+}
+
+func TestSizeOfLabels(t *testing.T) {
+	require.Len(t, expectedByteSize, len(testCaseLabels))
+	for i, c := range expectedByteSize { // Declared in build-tag-specific files, e.g. labels_slicelabels_test.go.
+		require.Equal(t, c, uint64(testCaseLabels[i].ByteSize()))
 	}
 }
 


### PR DESCRIPTION
Remove lots of duplicated code, in favour of a small table of results for each build.

Cherry-picks one commit from https://github.com/prometheus/prometheus/pull/16807, which is the basis for the simplification.

Also fix `model/labels/labels_slicelabels_test.go` which excluded from compilation.
