### PR TITLE
merge-upstream-prometheus: close PR by force-pushing to base branch instead of HEAD~1

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -288,9 +288,9 @@ jobs:
 
       - name: Close PR by force-pushing to HEAD~1
         run: |
-          # Force-push to HEAD~1 to close the existing PR (removes the empty commit, leaving no commits)
+          # Force-push to the same commit as the base branch (removes the empty commit, leaving no commits in the PR).
           # This closes the PR while keeping the branch and instructions as a placeholder
-          git push --force origin HEAD~1:${{ needs.check-merge.outputs.bot_branch }}
+          git push --force origin ${{needs.check-merge.outputs.local_branch}}:${{ needs.check-merge.outputs.bot_branch }}
 
       - name: Send Slack notification for merge conflicts
         uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0


### PR DESCRIPTION

### Problem

I can't explain it but for some reason this command skipped two commits. I suspect it's to do with creating the PR - maybe it checks back out the base branch after creating a PR? IDK

Resetting to HEAD~1 from 9b2459804 should lead to 609b9c7c04c1ab675ebff483567caf3a3595818f not to d3be9d0e3

From https://github.com/grafana/mimir-prometheus/actions/runs/16172079971/job/45647987237:

```
Run # Force-push to HEAD~1 to close the existing PR (removes the empty commit, leaving no commits)
  # Force-push to HEAD~1 to close the existing PR (removes the empty commit, leaving no commits)
  # This closes the PR while keeping the branch and instructions as a placeholder
  git push --force origin HEAD~1:bot/main/merge-upstream-main-202507091426
  shell: /usr/bin/bash -e {0}
  env:
    APP_ID: ***
    PRIVATE_KEY: ***
...
    PULL_REQUEST_NUMBER: 931
To https://github.com/grafana/mimir-prometheus
 + 9b2459804...d3be9d0e3 HEAD~1 -> bot/main/merge-upstream-main-202507091426 (forced update)
 ```

 ### What this PR does

 So just to be on the safe side, we'll take the same ref that we based the branch on - `local_branch` and force-push that.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
