### PR TITLE
tsdb index: introduce scan matchers

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -126,6 +126,9 @@ type IndexReader interface {
 	// The names returned are sorted.
 	LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error)
 
+	// IndexLookupPlanner returns the index lookup planner for this reader.
+	IndexLookupPlanner() index.LookupPlanner
+
 	// Close releases the underlying resources of the reader.
 	Close() error
 }
@@ -345,11 +348,11 @@ type Block struct {
 // OpenBlock opens the block in the directory. It can be passed a chunk pool, which is used
 // to instantiate chunk structs.
 func OpenBlock(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory) (pb *Block, err error) {
-	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
+	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, &index.ScanEmptyMatchersLookupPlanner{}, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
 }
 
 // OpenBlockWithOptions is like OpenBlock but allows to pass a cache provider and sharding function.
-func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, cache index.ReaderCacheProvider, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool, postingsCacheMetrics *PostingsForMatchersCacheMetrics) (pb *Block, err error) {
+func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, planner index.LookupPlanner, cache index.ReaderCacheProvider, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool, postingsCacheMetrics *PostingsForMatchersCacheMetrics) (pb *Block, err error) {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -374,7 +377,7 @@ func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, p
 	if postingsDecoderFactory != nil {
 		decoder = postingsDecoderFactory(meta)
 	}
-	indexReader, err := index.NewFileReaderWithOptions(filepath.Join(dir, indexFilename), decoder, cache)
+	indexReader, err := index.NewFileReaderWithOptions(filepath.Join(dir, indexFilename), decoder, planner, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +532,7 @@ func (r blockIndexReader) LabelValues(ctx context.Context, name string, hints *s
 		return st, nil
 	}
 
-	return labelValuesWithMatchers(ctx, r.ir, name, hints, matchers...)
+	return labelValuesWithMatchers(ctx, r, name, hints, matchers...)
 }
 
 func (r blockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {
@@ -537,7 +540,7 @@ func (r blockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Ma
 		return r.b.LabelNames(ctx)
 	}
 
-	return labelNamesWithMatchers(ctx, r.ir, matchers...)
+	return labelNamesWithMatchers(ctx, r, matchers...)
 }
 
 func (r blockIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
@@ -600,6 +603,12 @@ func (r blockIndexReader) LabelValueFor(ctx context.Context, id storage.SeriesRe
 // The names returned are sorted.
 func (r blockIndexReader) LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error) {
 	return r.ir.LabelNamesFor(ctx, postings)
+}
+
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// Block readers use the default index-only planner.
+func (r blockIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return r.ir.IndexLookupPlanner()
 }
 
 type blockTombstoneReader struct {

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -606,7 +606,6 @@ func (r blockIndexReader) LabelNamesFor(ctx context.Context, postings index.Post
 }
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
-// Block readers use the default index-only planner.
 func (r blockIndexReader) IndexLookupPlanner() index.LookupPlanner {
 	return r.ir.IndexLookupPlanner()
 }

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -95,6 +95,7 @@ func DefaultOptions() *Options {
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
+		IndexLookupPlanner:          &index.ScanEmptyMatchersLookupPlanner{},
 
 		HeadChunksEndTimeVariance:             0,
 		HeadPostingsForMatchersCacheTTL:       DefaultPostingsForMatchersCacheTTL,
@@ -294,6 +295,9 @@ type Options struct {
 
 	// UseUncachedIO allows bypassing the page cache when appropriate.
 	UseUncachedIO bool
+
+	// IndexLookupPlanner can be optionally used when querying the index of blocks.
+	IndexLookupPlanner index.LookupPlanner
 }
 
 type NewCompactorFunc func(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts *Options) (Compactor, error)
@@ -708,7 +712,7 @@ func (db *DBReadOnly) Blocks() ([]BlockReader, error) {
 		return nil, ErrClosed
 	default:
 	}
-	loadable, corrupted, err := openBlocks(db.logger, db.dir, nil, nil, DefaultPostingsDecoderFactory, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
+	loadable, corrupted, err := openBlocks(db.logger, db.dir, nil, nil, DefaultPostingsDecoderFactory, &index.ScanEmptyMatchersLookupPlanner{}, nil, DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -887,6 +891,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	if opts.OutOfOrderTimeWindow < 0 {
 		opts.OutOfOrderTimeWindow = 0
 	}
+	if opts.IndexLookupPlanner == nil {
+		opts.IndexLookupPlanner = &index.ScanEmptyMatchersLookupPlanner{}
+	}
 
 	if len(rngs) == 0 {
 		// Start with smallest block duration and create exponential buckets until the exceed the
@@ -1051,6 +1058,9 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.PostingsForMatchersCacheForce = opts.HeadPostingsForMatchersCacheForce
 	headOpts.PostingsForMatchersCacheMetrics = opts.HeadPostingsForMatchersCacheMetrics
 	headOpts.SecondaryHashFunction = opts.SecondaryHashFunction
+	if opts.IndexLookupPlanner != nil {
+		headOpts.IndexLookupPlanner = opts.IndexLookupPlanner
+	}
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency
 	}
@@ -1683,7 +1693,7 @@ func (db *DB) reloadBlocks() (err error) {
 	}()
 
 	db.mtx.RLock()
-	loadable, corrupted, err := openBlocks(db.logger, db.dir, db.blocks, db.chunkPool, db.opts.PostingsDecoderFactory, db.opts.SeriesHashCache, db.opts.BlockPostingsForMatchersCacheTTL, db.opts.BlockPostingsForMatchersCacheMaxItems, db.opts.BlockPostingsForMatchersCacheMaxBytes, db.opts.BlockPostingsForMatchersCacheForce, db.opts.BlockPostingsForMatchersCacheMetrics)
+	loadable, corrupted, err := openBlocks(db.logger, db.dir, db.blocks, db.chunkPool, db.opts.PostingsDecoderFactory, db.opts.IndexLookupPlanner, db.opts.SeriesHashCache, db.opts.BlockPostingsForMatchersCacheTTL, db.opts.BlockPostingsForMatchersCacheMaxItems, db.opts.BlockPostingsForMatchersCacheMaxBytes, db.opts.BlockPostingsForMatchersCacheForce, db.opts.BlockPostingsForMatchersCacheMetrics)
 	db.mtx.RUnlock()
 	if err != nil {
 		return err
@@ -1783,7 +1793,7 @@ func (db *DB) reloadBlocks() (err error) {
 	return nil
 }
 
-func openBlocks(l *slog.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, cache *hashcache.SeriesHashCache, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool, postingsCacheMetrics *PostingsForMatchersCacheMetrics) (blocks []*Block, corrupted map[ulid.ULID]error, err error) {
+func openBlocks(l *slog.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, planner index.LookupPlanner, cache *hashcache.SeriesHashCache, postingsCacheTTL time.Duration, postingsCacheMaxItems int, postingsCacheMaxBytes int64, postingsCacheForce bool, postingsCacheMetrics *PostingsForMatchersCacheMetrics) (blocks []*Block, corrupted map[ulid.ULID]error, err error) {
 	bDirs, err := blockDirs(dir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("find blocks: %w", err)
@@ -1805,7 +1815,7 @@ func openBlocks(l *slog.Logger, dir string, loaded []*Block, chunkPool chunkenc.
 				cacheProvider = cache.GetBlockCacheProvider(meta.ULID.String())
 			}
 
-			block, err = OpenBlockWithOptions(l, bDir, chunkPool, postingsDecoderFactory, cacheProvider, postingsCacheTTL, postingsCacheMaxItems, postingsCacheMaxBytes, postingsCacheForce, postingsCacheMetrics)
+			block, err = OpenBlockWithOptions(l, bDir, chunkPool, postingsDecoderFactory, planner, cacheProvider, postingsCacheTTL, postingsCacheMaxItems, postingsCacheMaxBytes, postingsCacheForce, postingsCacheMetrics)
 			if err != nil {
 				corrupted[meta.ULID] = err
 				continue

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3065,15 +3065,14 @@ func TestCompactHead(t *testing.T) {
 	dbDir := t.TempDir()
 
 	// Open a DB and append data to the WAL.
-	tsdbCfg := &Options{
-		RetentionDuration:                    int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:                           true,
-		MinBlockDuration:                     int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:                     int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:                       compression.Snappy,
-		HeadPostingsForMatchersCacheMetrics:  NewPostingsForMatchersCacheMetrics(nil),
-		BlockPostingsForMatchersCacheMetrics: NewPostingsForMatchersCacheMetrics(nil),
-	}
+	tsdbCfg := DefaultOptions()
+	tsdbCfg.RetentionDuration = int64(time.Hour * 24 * 15 / time.Millisecond)
+	tsdbCfg.NoLockfile = true
+	tsdbCfg.MinBlockDuration = int64(time.Hour * 2 / time.Millisecond)
+	tsdbCfg.MaxBlockDuration = int64(time.Hour * 2 / time.Millisecond)
+	tsdbCfg.WALCompression = compression.Snappy
+	tsdbCfg.HeadPostingsForMatchersCacheMetrics = NewPostingsForMatchersCacheMetrics(nil)
+	tsdbCfg.BlockPostingsForMatchersCacheMetrics = NewPostingsForMatchersCacheMetrics(nil)
 
 	db, err := Open(dbDir, promslog.NewNopLogger(), prometheus.NewRegistry(), tsdbCfg, nil)
 	require.NoError(t, err)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -192,6 +192,9 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
+	// IndexLookupPlanner can be optionally used when querying the index of the Head.
+	IndexLookupPlanner index.LookupPlanner
+
 	// Timely compaction allows head compaction to happen when min block range can no longer be appended,
 	// without requiring 1.5x the chunk range worth of data in the head.
 	TimelyCompaction bool
@@ -232,6 +235,7 @@ func DefaultHeadOptions() *HeadOptions {
 		PostingsForMatchersCacheForce:    DefaultPostingsForMatchersCacheForce,
 		PostingsForMatchersCacheMetrics:  NewPostingsForMatchersCacheMetrics(nil),
 		WALReplayConcurrency:             defaultWALReplayConcurrency,
+		IndexLookupPlanner:               &index.ScanEmptyMatchersLookupPlanner{},
 	}
 	ho.OutOfOrderCapMax.Store(DefaultOutOfOrderCapMax)
 	return ho

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -323,7 +323,6 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 }
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
-// Head readers use the default index-only planner.
 func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
 	return h.head.opts.IndexLookupPlanner
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -322,6 +322,12 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 	return names, nil
 }
 
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// Head readers use the default index-only planner.
+func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return h.head.opts.IndexLookupPlanner
+}
+
 // Chunks returns a ChunkReader against the block.
 func (h *Head) Chunks() (ChunkReader, error) {
 	return h.chunksRange(math.MinInt64, math.MaxInt64, h.iso.State(math.MinInt64, math.MaxInt64))

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1138,6 +1138,12 @@ type Reader struct {
 
 	// Provides a cache mapping series labels hash by series ID.
 	cacheProvider ReaderCacheProvider
+
+	lookupPlanner LookupPlanner
+}
+
+func (r *Reader) IndexLookupPlanner() LookupPlanner {
+	return r.lookupPlanner
 }
 
 type postingOffset struct {
@@ -1168,26 +1174,26 @@ func (b realByteSlice) Sub(start, end int) ByteSlice {
 // NewReader returns a new index reader on the given byte slice. It automatically
 // handles different format versions.
 func NewReader(b ByteSlice, decoder PostingsDecoder) (*Reader, error) {
-	return newReader(b, io.NopCloser(nil), decoder, nil)
+	return newReader(b, io.NopCloser(nil), decoder, &ScanEmptyMatchersLookupPlanner{}, nil)
 }
 
 // NewReaderWithCache is like NewReader but allows to pass a cache provider.
 func NewReaderWithCache(b ByteSlice, decoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
-	return newReader(b, io.NopCloser(nil), decoder, cacheProvider)
+	return newReader(b, io.NopCloser(nil), decoder, &ScanEmptyMatchersLookupPlanner{}, cacheProvider)
 }
 
 // NewFileReader returns a new index reader against the given index file.
 func NewFileReader(path string, decoder PostingsDecoder) (*Reader, error) {
-	return NewFileReaderWithOptions(path, decoder, nil)
+	return NewFileReaderWithOptions(path, decoder, &ScanEmptyMatchersLookupPlanner{}, nil)
 }
 
 // NewFileReaderWithOptions is like NewFileReader but allows to pass a cache provider.
-func NewFileReaderWithOptions(path string, decoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
+func NewFileReaderWithOptions(path string, decoder PostingsDecoder, planner LookupPlanner, cacheProvider ReaderCacheProvider) (*Reader, error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(realByteSlice(f.Bytes()), f, decoder, cacheProvider)
+	r, err := newReader(realByteSlice(f.Bytes()), f, decoder, planner, cacheProvider)
 	if err != nil {
 		return nil, tsdb_errors.NewMulti(
 			err,
@@ -1198,13 +1204,14 @@ func NewFileReaderWithOptions(path string, decoder PostingsDecoder, cacheProvide
 	return r, nil
 }
 
-func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
+func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder, planner LookupPlanner, cacheProvider ReaderCacheProvider) (*Reader, error) {
 	r := &Reader{
 		b:             b,
 		c:             c,
 		postings:      map[string][]postingOffset{},
 		cacheProvider: cacheProvider,
 		st:            labels.NewSymbolTable(),
+		lookupPlanner: planner,
 	}
 
 	// Verify header.

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -747,7 +747,7 @@ func createFileReaderWithOptions(ctx context.Context, tb testing.TB, input index
 
 	var ir *Reader
 	if withCache {
-		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
+		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, &ScanEmptyMatchersLookupPlanner{}, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
 	} else {
 		ir, err = NewFileReader(fn, DecodePostingsRaw)
 	}

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -100,13 +100,13 @@ func (p *ScanEmptyMatchersLookupPlanner) PlanIndexLookup(_ context.Context, plan
 	}
 
 	if len(indexMatchers) == 0 && len(scanMatchers) > 0 {
-		// Zero index matchers match no series. We retain one index matchers so that we have a base set of series which we can scan.
+		// Zero index matchers match no series. We retain one index matcher so that we have a base set of series which we can scan.
 		indexMatchers = scanMatchers[:1]
 		scanMatchers = scanMatchers[1:]
 	}
 
 	if len(scanMatchers) == 0 {
-		// Avoid an allocation if the sample is simple.
+		// Avoid an allocation if the plan is simple.
 		return NewIndexOnlyLookupPlan(indexMatchers), nil
 	}
 

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -1,0 +1,152 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"slices"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// LookupPlanner plans how to execute index lookups by deciding which matchers
+// to apply during index lookup versus after series retrieval.
+type LookupPlanner interface {
+	PlanIndexLookup(ctx context.Context, plan LookupPlan, minT, maxT int64) (LookupPlan, error)
+}
+
+// ChainLookupPlanners is useful to break up the planning logic into multiple independent planners and connect them in sequence.
+// The returned LookupPlanner calls the planners in sequence and feeds the output of one planner as the input of the next.
+func ChainLookupPlanners(planners ...LookupPlanner) LookupPlanner {
+	return chainedLookupPlanner{planners: planners}
+}
+
+type chainedLookupPlanner struct {
+	planners []LookupPlanner
+}
+
+func (c chainedLookupPlanner) PlanIndexLookup(ctx context.Context, plan LookupPlan, minT, maxT int64) (LookupPlan, error) {
+	var err error
+	for _, p := range c.planners {
+		plan, err = p.PlanIndexLookup(ctx, plan, minT, maxT)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return plan, nil
+}
+
+// LookupPlan represents the decision of which matchers to apply during
+// index lookup versus during series scanning.
+type LookupPlan interface {
+	// ScanMatchers returns matchers that should be applied during series scanning
+	ScanMatchers() []*labels.Matcher
+	// IndexMatchers returns matchers that should be applied during index lookup
+	IndexMatchers() []*labels.Matcher
+}
+
+// NewIndexOnlyLookupPlan creates a new LookupPlan which uses the provided matchers for looking up the index only.
+func NewIndexOnlyLookupPlan(matchers []*labels.Matcher) LookupPlan {
+	return indexOnlyLookupPlan(matchers)
+}
+
+type indexOnlyLookupPlan []*labels.Matcher
+
+func (l indexOnlyLookupPlan) ScanMatchers() []*labels.Matcher {
+	return nil
+}
+
+func (l indexOnlyLookupPlan) IndexMatchers() []*labels.Matcher {
+	return l
+}
+
+// ScanEmptyMatchersLookupPlanner implements LookupPlanner by deferring empty matchers such as l="", l=~".+" to scan matchers.
+type ScanEmptyMatchersLookupPlanner struct{}
+
+func (p *ScanEmptyMatchersLookupPlanner) PlanIndexLookup(_ context.Context, plan LookupPlan, _, _ int64) (LookupPlan, error) {
+	indexMatchers := plan.IndexMatchers()
+	if len(indexMatchers) <= 1 || !p.canOptimizeIndexMatchers(indexMatchers) {
+		// If there is only one matcher, then using the index is usually more efficient.
+		// This also covers test cases which use matchers such as {""=""} or {""=~".*"} to mean "match all series"
+		// Also avoid allocating a plan if we're not going to change any of the index matchers.
+		return plan, nil
+	}
+
+	// Clone so that we don't overwrite the matchers of clients when we resize the slice
+	indexMatchers = slices.Clone(indexMatchers)
+	scanMatchers := slices.Clone(plan.ScanMatchers())
+
+	for i := 0; i < len(indexMatchers); i++ {
+		matcher := indexMatchers[i]
+		if p.shouldDropMatcher(matcher) {
+			indexMatchers = append(indexMatchers[:i], indexMatchers[i+1:]...)
+			i--
+		} else if p.shouldScanMatcher(matcher) {
+			indexMatchers = append(indexMatchers[:i], indexMatchers[i+1:]...)
+			i--
+			scanMatchers = append(scanMatchers, matcher)
+		}
+	}
+
+	if len(indexMatchers) == 0 && len(scanMatchers) > 0 {
+		// Zero index matchers match no series. We retain one index matchers so that we have a base set of series which we can scan.
+		indexMatchers = scanMatchers[:1]
+		scanMatchers = scanMatchers[1:]
+	}
+
+	if len(scanMatchers) == 0 {
+		// Avoid an allocation if the sample is simple.
+		return NewIndexOnlyLookupPlan(indexMatchers), nil
+	}
+
+	return &concreteLookupPlan{
+		indexMatchers: indexMatchers,
+		scanMatchers:  scanMatchers,
+	}, nil
+}
+
+func (p *ScanEmptyMatchersLookupPlanner) shouldDropMatcher(matcher *labels.Matcher) bool {
+	// This matches everything (empty and arbitrary values), so it doesn't reduce the selectivity of the whole set of matchers.
+	return matcher.Type == labels.MatchRegexp && matcher.Value == ".*"
+}
+
+func (p *ScanEmptyMatchersLookupPlanner) shouldScanMatcher(matcher *labels.Matcher) bool {
+	// Put empty string matchers and regex matchers that match everything in scan matchers.
+	// These matchers are unlikely to reduce the selectivity of the matchers, but can still filter out some series, so we can't ignore them.
+	return (matcher.Type == labels.MatchEqual && matcher.Value == "") ||
+		(matcher.Type == labels.MatchRegexp && matcher.Value == ".+")
+}
+
+func (p *ScanEmptyMatchersLookupPlanner) canOptimizeIndexMatchers(matchers []*labels.Matcher) bool {
+	for _, matcher := range matchers {
+		if p.shouldScanMatcher(matcher) || p.shouldDropMatcher(matcher) {
+			return true
+		}
+	}
+	return false
+}
+
+// concreteLookupPlan implements LookupPlan by storing pre-computed index and scan matchers.
+type concreteLookupPlan struct {
+	indexMatchers []*labels.Matcher
+	scanMatchers  []*labels.Matcher
+}
+
+func (p *concreteLookupPlan) ScanMatchers() []*labels.Matcher {
+	return p.scanMatchers
+}
+
+func (p *concreteLookupPlan) IndexMatchers() []*labels.Matcher {
+	return p.indexMatchers
+}

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -124,7 +124,17 @@ func TestScanEmptyMatchersLookupPlanner(t *testing.T) {
 			expectedScan: []*labels.Matcher{},
 		},
 		{
-			name: "single empty matcher goes to index",
+			name: "single match-non-empty regex goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".+"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".+"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single empty matcher goes to index; this is an invalid matcher on the API, but some internal code uses it",
 			matchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "", ""),
 			},

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestScanEmptyMatchersLookupPlanner(t *testing.T) {
+	planner := &ScanEmptyMatchersLookupPlanner{}
+
+	testCases := []struct {
+		name          string
+		matchers      []*labels.Matcher
+		expectedIndex []*labels.Matcher
+		expectedScan  []*labels.Matcher
+	}{
+		{
+			name: "splits matchers between index and scan",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"), // index
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),   // dropped
+				labels.MustNewMatcher(labels.MatchEqual, "env", ""),           // scan
+				labels.MustNewMatcher(labels.MatchNotEqual, "status", "down"), // index
+				labels.MustNewMatcher(labels.MatchRegexp, "region", ".+"),     // scan
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "status", "down"),
+			},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "env", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "region", ".+"),
+			},
+		},
+		{
+			name: "all selective matchers go to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "instance", "localhost"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "prod|staging"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "instance", "localhost"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "prod|staging"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "even with only non-selective matchers, there is still one which stays as index matcher",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+		},
+		{
+			name: "all non-selective matchers go to scan",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+		},
+		{
+			name: "single matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single empty matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single match-all regex goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".*"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".*"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single empty matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "", ""),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "", ""),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name:          "empty matchers slice",
+			matchers:      []*labels.Matcher{},
+			expectedIndex: []*labels.Matcher{},
+			expectedScan:  []*labels.Matcher{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, _ := planner.PlanIndexLookup(context.TODO(), NewIndexOnlyLookupPlan(tc.matchers), 0, 1000)
+
+			require.Equal(t, matchersToString(tc.expectedScan), matchersToString(plan.ScanMatchers()))
+			require.Equal(t, matchersToString(tc.expectedIndex), matchersToString(plan.IndexMatchers()))
+		})
+	}
+}
+
+func matchersToString(matchers []*labels.Matcher) string {
+	if len(matchers) == 0 {
+		return ""
+	}
+	var result string
+	for i, m := range matchers {
+		if i > 0 {
+			result += ","
+		}
+		result += m.String()
+	}
+	return result
+}

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -194,6 +194,12 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 	return labelValuesWithMatchers(ctx, oh, name, hints, matchers...)
 }
 
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// HeadAndOOO readers use the default index-only planner.
+func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return oh.head.opts.IndexLookupPlanner
+}
+
 func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
 	switch {
 	case a.MinTime < b.MinTime:
@@ -526,6 +532,12 @@ func (ir *OOOCompactionHeadIndexReader) LabelNamesFor(_ context.Context, _ index
 
 func (ir *OOOCompactionHeadIndexReader) Close() error {
 	return nil
+}
+
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// OOO compaction head readers use the default index-only planner.
+func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return ir.ch.head.opts.IndexLookupPlanner
 }
 
 // HeadAndOOOQuerier queries both the head and the out-of-order head.

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -195,7 +195,6 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 }
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
-// HeadAndOOO readers use the default index-only planner.
 func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
 	return oh.head.opts.IndexLookupPlanner
 }
@@ -535,7 +534,6 @@ func (ir *OOOCompactionHeadIndexReader) Close() error {
 }
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
-// OOO compaction head readers use the default index-only planner.
 func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
 	return ir.ch.head.opts.IndexLookupPlanner
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -119,32 +119,42 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 }
 
 func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.SelectHints, ms []*labels.Matcher,
-	index IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
+	ix IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
 ) storage.SeriesSet {
 	disableTrimming := false
 	sharded := hints != nil && hints.ShardCount > 0
-	p, err := index.PostingsForMatchers(ctx, sharded, ms...)
-	if err != nil {
-		return storage.ErrSeriesSet(err)
-	}
-	if sharded {
-		p = index.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
-	}
-	if sortSeries {
-		p = index.SortedPostings(p)
-	}
 
 	if hints != nil {
 		mint = hints.Start
 		maxt = hints.End
 		disableTrimming = hints.DisableTrimming
-		if hints.Func == "series" {
-			// When you're only looking up metadata (for example series API), you don't need to load any chunks.
-			return newBlockSeriesSet(index, newNopChunkReader(), tombstones, p, mint, maxt, disableTrimming)
-		}
 	}
 
-	return newBlockSeriesSet(index, chunks, tombstones, p, mint, maxt, disableTrimming)
+	// Use the planner to decide which matchers to apply during index lookup vs scanning
+	plan, err := ix.IndexLookupPlanner().PlanIndexLookup(ctx, index.NewIndexOnlyLookupPlan(ms), mint, maxt)
+	if err != nil {
+		return storage.ErrSeriesSet(fmt.Errorf("creating index lookup plan: %w", err))
+	}
+	indexMatchers := plan.IndexMatchers()
+	scanMatchers := plan.ScanMatchers()
+
+	p, err := ix.PostingsForMatchers(ctx, sharded, indexMatchers...)
+	if err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+	if sharded {
+		p = ix.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
+	}
+	if sortSeries {
+		p = ix.SortedPostings(p)
+	}
+
+	if hints != nil && hints.Func == "series" {
+		// When you're only looking up metadata (for example series API), you don't need to load any chunks.
+		return newBlockSeriesSetWithScanMatchers(ix, newNopChunkReader(), tombstones, p, mint, maxt, disableTrimming, scanMatchers)
+	}
+
+	return newBlockSeriesSetWithScanMatchers(ix, chunks, tombstones, p, mint, maxt, disableTrimming, scanMatchers)
 }
 
 // blockChunkQuerier provides chunk querying access to a single block database.
@@ -166,7 +176,7 @@ func (q *blockChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *
 }
 
 func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.SelectHints, ms []*labels.Matcher,
-	blockID ulid.ULID, index IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
+	blockID ulid.ULID, ix IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
 ) storage.ChunkSeriesSet {
 	disableTrimming := false
 	sharded := hints != nil && hints.ShardCount > 0
@@ -176,17 +186,26 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 		maxt = hints.End
 		disableTrimming = hints.DisableTrimming
 	}
-	p, err := index.PostingsForMatchers(ctx, sharded, ms...)
+
+	// Use the planner to decide which matchers to apply during index lookup vs scanning
+	plan, err := ix.IndexLookupPlanner().PlanIndexLookup(ctx, index.NewIndexOnlyLookupPlan(ms), mint, maxt)
+	if err != nil {
+		return storage.ErrChunkSeriesSet(fmt.Errorf("creating index lookup plan: %w", err))
+	}
+	indexMatchers := plan.IndexMatchers()
+	scanMatchers := plan.ScanMatchers()
+
+	p, err := ix.PostingsForMatchers(ctx, sharded, indexMatchers...)
 	if err != nil {
 		return storage.ErrChunkSeriesSet(err)
 	}
 	if sharded {
-		p = index.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
+		p = ix.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
 	}
 	if sortSeries {
-		p = index.SortedPostings(p)
+		p = ix.SortedPostings(p)
 	}
-	return NewBlockChunkSeriesSet(blockID, index, chunks, tombstones, p, mint, maxt, disableTrimming)
+	return NewBlockChunkSeriesSetWithScanMatchers(blockID, ix, chunks, tombstones, p, mint, maxt, disableTrimming, scanMatchers)
 }
 
 // PostingsForMatchers assembles a single postings iterator against the index reader
@@ -482,6 +501,7 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, hi
 	}
 
 	values := make([]string, 0, len(indexes))
+
 	for _, idx := range indexes {
 		values = append(values, allValues[idx])
 		if hints != nil && hints.Limit > 0 && len(values) >= hints.Limit {
@@ -1208,6 +1228,63 @@ func (b *blockSeriesSet) At() storage.Series {
 	}
 }
 
+// newBlockSeriesSetWithScanMatchers creates a blockSeriesSet that applies scan matchers during series scanning.
+func newBlockSeriesSetWithScanMatchers(i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings, mint, maxt int64, disableTrimming bool, scanMatchers []*labels.Matcher) storage.SeriesSet {
+	base := newBlockSeriesSet(i, c, t, p, mint, maxt, disableTrimming)
+	if len(scanMatchers) == 0 {
+		return base
+	}
+	return &scanMatcherSeriesSet[storage.Series]{
+		base:         base,
+		scanMatchers: scanMatchers,
+	}
+}
+
+type genericSeriesSet[S storage.Labels] interface {
+	Next() bool
+	At() S
+	Err() error
+	Warnings() annotations.Annotations
+}
+
+// scanMatcherSeriesSet wraps a SeriesSet and applies additional matchers during series scanning.
+type scanMatcherSeriesSet[S storage.Labels] struct {
+	base         genericSeriesSet[S]
+	scanMatchers []*labels.Matcher
+	allocatedAt  S
+}
+
+func (s *scanMatcherSeriesSet[S]) Next() bool {
+	for s.base.Next() {
+		s.allocatedAt = s.base.At()
+		if labelsMatchMatchers(s.allocatedAt.Labels(), s.scanMatchers) {
+			return true
+		}
+	}
+	return false
+}
+
+func labelsMatchMatchers(lbls labels.Labels, matchers []*labels.Matcher) bool {
+	for _, matcher := range matchers {
+		if !matcher.Matches(lbls.Get(matcher.Name)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *scanMatcherSeriesSet[S]) At() S {
+	return s.allocatedAt
+}
+
+func (s *scanMatcherSeriesSet[S]) Err() error {
+	return s.base.Err()
+}
+
+func (s *scanMatcherSeriesSet[S]) Warnings() annotations.Annotations {
+	return s.base.Warnings()
+}
+
 // blockChunkSeriesSet allows to iterate over sorted, populated series with applied tombstones.
 // Series with all deleted chunks are still present as Labelled iterator with no chunks.
 // Chunks are also trimmed to requested [min and max] (keeping samples with min and max timestamps).
@@ -1236,6 +1313,18 @@ func (b *blockChunkSeriesSet) At() storage.ChunkSeries {
 		chunks:     b.chunks,
 		blockID:    b.blockID,
 		seriesData: b.curr,
+	}
+}
+
+// NewBlockChunkSeriesSetWithScanMatchers creates a blockChunkSeriesSet that applies scan matchers during series scanning.
+func NewBlockChunkSeriesSetWithScanMatchers(id ulid.ULID, i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings, mint, maxt int64, disableTrimming bool, scanMatchers []*labels.Matcher) storage.ChunkSeriesSet {
+	base := NewBlockChunkSeriesSet(id, i, c, t, p, mint, maxt, disableTrimming)
+	if len(scanMatchers) == 0 {
+		return base
+	}
+	return &scanMatcherSeriesSet[storage.ChunkSeries]{
+		base:         base,
+		scanMatchers: scanMatchers,
 	}
 }
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -351,7 +351,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 	seriesHashCache := hashcache.NewSeriesHashCache(1024 * 1024 * 1024)
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
+	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, &index.ScanEmptyMatchersLookupPlanner{}, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheTTL, DefaultPostingsForMatchersCacheMaxItems, DefaultPostingsForMatchersCacheMaxBytes, DefaultPostingsForMatchersCacheForce, NewPostingsForMatchersCacheMetrics(nil))
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2486,6 +2486,10 @@ func (m mockIndex) LabelNames(_ context.Context, matchers ...*labels.Matcher) ([
 	return l, nil
 }
 
+func (m mockIndex) IndexLookupPlanner() index.LookupPlanner {
+	return &index.ScanEmptyMatchersLookupPlanner{}
+}
+
 func BenchmarkQueryIterator(b *testing.B) {
 	cases := []struct {
 		numBlocks                   int
@@ -3424,6 +3428,10 @@ func (m mockMatcherIndex) PostingsForAllLabelValues(context.Context, string) ind
 	return index.ErrPostings(errors.New("PostingsForAllLabelValues called"))
 }
 
+func (m mockMatcherIndex) IndexLookupPlanner() index.LookupPlanner {
+	return &index.ScanEmptyMatchersLookupPlanner{}
+}
+
 func TestPostingsForMatcher(t *testing.T) {
 	ctx := context.Background()
 
@@ -4006,6 +4014,10 @@ func (m mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[
 
 func (m mockReaderOfLabels) Symbols() index.StringIter {
 	panic("Series called")
+}
+
+func (m mockReaderOfLabels) IndexLookupPlanner() index.LookupPlanner {
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 func (m mockReaderOfLabels) LabelValuesExcluding(index.Postings, string) storage.LabelValues {


### PR DESCRIPTION
## Summary

This PR integrates the scan matchers feature from prometheus/prometheus#16835 into our mimir-prometheus fork.


### **Background**

In the Prometheus TSDB, matchers are always used to query the index. There are some cases where skipping those matchers from the index and then applying them on the retrieved series from the block is less resource intensive. 

This is the plan we have in Mimir to solve this: https://github.com/grafana/mimir/issues/11916

### **What this PR does**

#### Interfaces

In this PR I'm introducing the concept of **scan matchers**. Unlike to **index matchers** (aka just "matchers" today), scan matchers are used to filter out series after they have been retrieved from the block.

The core of this PR adds a new method to the `IndexReader`, called `IndexLookupPlanner() index.LookupPlanner`. An `index.LookupPlanner` partitions the matchers into matchers which will be used against the inverted index and matchers which will be used in a sequential scan after retrieving the labels of the matching series.

The `LookupPlanner` is an interface so that in downstream projects can implement their own planners based on their storage characteristics and based on the target performance. They can also chain multiple planners via the `index.ChainLookupPlanners`. 

The `LookupPlan` is currently implemented as an interface because later down the road there will be a need for different kind of plans (e.g. for label names and label values; cost-based vs static).

#### `ScanEmptyMatchersLookupPlanner`

There are some matchers, which are expensive to apply on the inverted index and usually don't end up filtering any data. This PR adds one implementation of `LookupPlanner`: `ScanEmptyMatchersLookupPlanner`, which defers those matchers to scan matchers and removes some matchers when they match literally every possible value, even the unset value.

- `{label=""}` - scan matcher
- `{label=~".+"}` - scan matcher
- `{label=~".*"}` - removed matcher


### **Next steps**

The goal now is to have very basic support for this in Prometheus, which would allow experimentation with different planner algorithms. 

We already have some planner implementation which is based on sketches collected from the head block. This is another building block which we can contribute.