### PR TITLE
vendor_reviewer.yml: choose "--merge" merge

### DIFF
--- a/.github/workflows/vendor_reviewer.yml
+++ b/.github/workflows/vendor_reviewer.yml
@@ -43,7 +43,7 @@ jobs:
             --approve -b "**I'm approving** this upstream merge PR.
             This PR merges changes from prometheus/prometheus upstream repository.
             Related GitHub action is defined [here](https://github.com/grafana/mimir-prometheus/tree/main/.github/workflows/vendor_reviewer.yml)."
-          gh pr merge --auto "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ steps.approve-app-token.outputs.token }}


### PR DESCRIPTION
apparently we need to be explicit. follow-up of #927 

https://github.com/grafana/mimir-prometheus/actions/runs/16645042297/job/47103599261?pr=951

```
--merge, --rebase, or --squash required when not running interactively
```

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
