### PR TITLE
merge upstream/main at 291e2ae090ec15971025af985fff81b33c0d5bd2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main / unreleased
 
 * [BUGFIX] OTLP receiver: Generate `target_info` samples between the earliest and latest samples per resource. #16737
+* [BUGFIX] Config: Infer escaping scheme when scrape config validation scheme is set.
 
 ## 3.5.0 / 2025-07-14
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2801,29 +2801,40 @@ func TestScrapeConfigDisableCompression(t *testing.T) {
 
 func TestScrapeConfigNameValidationSettings(t *testing.T) {
 	tests := []struct {
-		name         string
-		inputFile    string
-		expectScheme model.ValidationScheme
+		name           string
+		inputFile      string
+		expectScheme   model.ValidationScheme
+		expectEscaping model.EscapingScheme
 	}{
 		{
-			name:         "blank config implies default",
-			inputFile:    "scrape_config_default_validation_mode",
-			expectScheme: model.UTF8Validation,
+			name:           "blank config implies default",
+			inputFile:      "scrape_config_default_validation_mode",
+			expectScheme:   model.UTF8Validation,
+			expectEscaping: model.NoEscaping,
 		},
 		{
-			name:         "global setting implies local settings",
-			inputFile:    "scrape_config_global_validation_mode",
-			expectScheme: model.LegacyValidation,
+			name:           "global setting implies local settings",
+			inputFile:      "scrape_config_global_validation_mode",
+			expectScheme:   model.LegacyValidation,
+			expectEscaping: model.DotsEscaping,
 		},
 		{
-			name:         "local setting",
-			inputFile:    "scrape_config_local_validation_mode",
-			expectScheme: model.LegacyValidation,
+			name:           "local setting",
+			inputFile:      "scrape_config_local_validation_mode",
+			expectScheme:   model.LegacyValidation,
+			expectEscaping: model.ValueEncodingEscaping,
 		},
 		{
-			name:         "local setting overrides global setting",
-			inputFile:    "scrape_config_local_global_validation_mode",
-			expectScheme: model.UTF8Validation,
+			name:           "local setting overrides global setting",
+			inputFile:      "scrape_config_local_global_validation_mode",
+			expectScheme:   model.UTF8Validation,
+			expectEscaping: model.DotsEscaping,
+		},
+		{
+			name:           "local validation implies underscores escaping",
+			inputFile:      "scrape_config_local_infer_escaping",
+			expectScheme:   model.LegacyValidation,
+			expectEscaping: model.UnderscoreEscaping,
 		},
 	}
 
@@ -2839,6 +2850,10 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 			require.NoError(t, yaml.UnmarshalStrict(out, got))
 
 			require.Equal(t, tc.expectScheme, got.ScrapeConfigs[0].MetricNameValidationScheme)
+
+			escaping, err := model.ToEscapingScheme(got.ScrapeConfigs[0].MetricNameEscapingScheme)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectEscaping, escaping)
 		})
 	}
 }

--- a/config/testdata/scrape_config_local_infer_escaping.yml
+++ b/config/testdata/scrape_config_local_infer_escaping.yml
@@ -1,0 +1,3 @@
+scrape_configs:
+  - job_name: prometheus
+    metric_name_validation_scheme: legacy

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2896,7 +2896,7 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 							},
 							PosRange: posrange.PositionRange{
 								Start: 29,
-								End:   51,
+								End:   52, // TODO(krajorama): this should be 51. https://github.com/prometheus/prometheus/issues/16053
 							},
 						},
 					},

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -244,23 +244,9 @@ expr            :
  */
 
 aggregate_expr  : aggregate_op aggregate_modifier function_call_body
-                        {
-                        // Need to consume the position of the first RIGHT_PAREN. It might not exist on garbage input
-                        // like 'sum (some_metric) by test'
-                        if len(yylex.(*parser).closingParens) > 1 {
-                                yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
-                        }
-                        $$ = yylex.(*parser).newAggregateExpr($1, $2, $3)
-                        }
+                        { $$ = yylex.(*parser).newAggregateExpr($1, $2, $3) }
                 | aggregate_op function_call_body aggregate_modifier
-                        {
-                        // Need to consume the position of the first RIGHT_PAREN. It might not exist on garbage input
-                        // like 'sum by test (some_metric)'
-                        if len(yylex.(*parser).closingParens) > 1 {
-                                yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
-                        }
-                        $$ = yylex.(*parser).newAggregateExpr($1, $3, $2)
-                        }
+                        { $$ = yylex.(*parser).newAggregateExpr($1, $3, $2) }
                 | aggregate_op function_call_body
                         { $$ = yylex.(*parser).newAggregateExpr($1, &AggregateExpr{}, $2) }
                 | aggregate_op error
@@ -414,10 +400,9 @@ function_call   : IDENTIFIER function_call_body
                                 Args: $2.(Expressions),
                                 PosRange: posrange.PositionRange{
                                         Start: $1.Pos,
-                                        End:   yylex.(*parser).closingParens[0],
+                                        End:   yylex.(*parser).lastClosing,
                                 },
                         }
-                        yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
                         }
                 ;
 
@@ -443,10 +428,7 @@ function_call_args: function_call_args COMMA expr
  */
 
 paren_expr      : LEFT_PAREN expr RIGHT_PAREN
-                        {
-                        $$ = &ParenExpr{Expr: $2.(Expr), PosRange: mergeRanges(&$1, &$3)}
-                        yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
-                        }
+                        { $$ = &ParenExpr{Expr: $2.(Expr), PosRange: mergeRanges(&$1, &$3)} }
                 ;
 
 /*

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1122,21 +1122,11 @@ yydefault:
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
-			// Need to consume the position of the first RIGHT_PAREN. It might not exist on garbage input
-			// like 'sum (some_metric) by test'
-			if len(yylex.(*parser).closingParens) > 1 {
-				yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
-			}
 			yyVAL.node = yylex.(*parser).newAggregateExpr(yyDollar[1].item, yyDollar[2].node, yyDollar[3].node)
 		}
 	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
-			// Need to consume the position of the first RIGHT_PAREN. It might not exist on garbage input
-			// like 'sum by test (some_metric)'
-			if len(yylex.(*parser).closingParens) > 1 {
-				yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
-			}
 			yyVAL.node = yylex.(*parser).newAggregateExpr(yyDollar[1].item, yyDollar[3].node, yyDollar[2].node)
 		}
 	case 23:
@@ -1364,10 +1354,9 @@ yydefault:
 				Args: yyDollar[2].node.(Expressions),
 				PosRange: posrange.PositionRange{
 					Start: yyDollar[1].item.Pos,
-					End:   yylex.(*parser).closingParens[0],
+					End:   yylex.(*parser).lastClosing,
 				},
 			}
-			yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
 		}
 	case 63:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -1399,7 +1388,6 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.node = &ParenExpr{Expr: yyDollar[2].node.(Expr), PosRange: mergeRanges(&yyDollar[1].item, &yyDollar[3].item)}
-			yylex.(*parser).closingParens = yylex.(*parser).closingParens[1:]
 		}
 	case 69:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -59,13 +59,6 @@ type parser struct {
 	// Everytime an Item is lexed that could be the end
 	// of certain expressions its end position is stored here.
 	lastClosing posrange.Pos
-	// Keep track of closing parentheses in addition, because sometimes the
-	// parser needs to read past a closing parenthesis to find the end of an
-	// expression, e.g. reading ony '(sum(foo)' cannot tell the end of the
-	// aggregation expression, since it could continue with either
-	// '(sum(foo))' or '(sum(foo) by (bar))' by which time we set lastClosing
-	// to the last paren.
-	closingParens []posrange.Pos
 
 	yyParser yyParserImpl
 
@@ -89,7 +82,7 @@ func NewParser(input string, opts ...Opt) *parser { //nolint:revive // unexporte
 	p.injecting = false
 	p.parseErrors = nil
 	p.generatedParserResult = nil
-	p.closingParens = make([]posrange.Pos, 0)
+	p.lastClosing = posrange.Pos(0)
 
 	// Clear lexer struct before reusing.
 	p.lex = Lexer{
@@ -179,11 +172,6 @@ func EnrichParseError(err error, enrich func(parseErr *ParseErr)) {
 func ParseExpr(input string) (expr Expr, err error) {
 	p := NewParser(input)
 	defer p.Close()
-
-	if len(p.closingParens) > 0 {
-		return nil, fmt.Errorf("internal parser error, not all closing parens consumed: %v", p.closingParens)
-	}
-
 	return p.ParseExpr()
 }
 
@@ -387,10 +375,7 @@ func (p *parser) Lex(lval *yySymType) int {
 	case EOF:
 		lval.item.Typ = EOF
 		p.InjectItem(0)
-	case RIGHT_PAREN:
-		p.closingParens = append(p.closingParens, lval.item.Pos+posrange.Pos(len(lval.item.Val)))
-		fallthrough
-	case RIGHT_BRACE, RIGHT_BRACKET, DURATION, NUMBER:
+	case RIGHT_BRACE, RIGHT_PAREN, RIGHT_BRACKET, DURATION, NUMBER:
 		p.lastClosing = lval.item.Pos + posrange.Pos(len(lval.item.Val))
 	}
 
@@ -451,16 +436,10 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
 	ret = modifier.(*AggregateExpr)
 	arguments := args.(Expressions)
 
-	if len(p.closingParens) == 0 {
-		// Prevents invalid array accesses.
-		// The error is already captured by the parser.
-		return
-	}
 	ret.PosRange = posrange.PositionRange{
 		Start: op.Pos,
-		End:   p.closingParens[0],
+		End:   p.lastClosing,
 	}
-	p.closingParens = p.closingParens[1:]
 
 	ret.Op = op.Typ
 

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -4776,7 +4776,7 @@ var testExpr = []struct {
 						End:   8,
 					},
 				},
-				PosRange: posrange.PositionRange{Start: 1, End: 9},
+				PosRange: posrange.PositionRange{Start: 1, End: 10}, // TODO(krajorama): this should be 9. https://github.com/prometheus/prometheus/issues/16053
 			},
 			PosRange: posrange.PositionRange{Start: 0, End: 10},
 		},

--- a/tsdb/fileutil/dir.go
+++ b/tsdb/fileutil/dir.go
@@ -22,6 +22,10 @@ func DirSize(dir string) (int64, error) {
 	var size int64
 	err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Ignore missing files that may have been deleted during the walk.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		if !info.IsDir() {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -15,7 +15,6 @@ package index
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -142,8 +141,7 @@ type Writer struct {
 	lastSymbol  string
 	symbolCache map[string]uint32 // From symbol to index in table.
 
-	labelIndexes []labelIndexHashEntry // Label index offsets.
-	labelNames   map[string]uint64     // Label names, and their usage.
+	labelNames map[string]uint64 // Label names, and their usage.
 
 	// Hold last series to validate that clients insert new series in order.
 	lastSeries    labels.Labels
@@ -393,9 +391,6 @@ func (w *Writer) ensureStage(s indexWriterStage) error {
 		if err := w.writePostingsToTmpFiles(); err != nil {
 			return err
 		}
-		if err := w.writeLabelIndices(); err != nil {
-			return err
-		}
 
 		w.toc.Postings = w.f.pos
 		if err := w.writePostings(); err != nil {
@@ -403,9 +398,6 @@ func (w *Writer) ensureStage(s indexWriterStage) error {
 		}
 
 		w.toc.LabelIndicesTable = w.f.pos
-		if err := w.writeLabelIndexesOffsetTable(); err != nil {
-			return err
-		}
 
 		w.toc.PostingsTable = w.f.pos
 		if err := w.writePostingsOffsetTable(); err != nil {
@@ -588,147 +580,6 @@ func (w *Writer) finishSymbols() error {
 	w.symbols, err = NewSymbols(realByteSlice(w.symbolFile.Bytes()), FormatV2, int(w.toc.Symbols))
 	if err != nil {
 		return fmt.Errorf("read symbols: %w", err)
-	}
-	return nil
-}
-
-func (w *Writer) writeLabelIndices() error {
-	if err := w.fPO.Flush(); err != nil {
-		return err
-	}
-
-	// Find all the label values in the tmp posting offset table.
-	f, err := fileutil.OpenMmapFile(w.fPO.name)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
-	cnt := w.cntPO
-	current := []byte{}
-	values := []uint32{}
-	for d.Err() == nil && cnt > 0 {
-		cnt--
-		d.Uvarint()               // Keycount.
-		name := d.UvarintBytes()  // Label name.
-		value := d.UvarintBytes() // Label value.
-		d.Uvarint64()             // Offset.
-		if len(name) == 0 {
-			continue // All index is ignored.
-		}
-
-		if !bytes.Equal(name, current) && len(values) > 0 {
-			// We've reached a new label name.
-			if err := w.writeLabelIndex(string(current), values); err != nil {
-				return err
-			}
-			values = values[:0]
-		}
-		current = name
-		sid, ok := w.symbolCache[string(value)]
-		if !ok {
-			return fmt.Errorf("symbol entry for %q does not exist", string(value))
-		}
-		values = append(values, sid)
-	}
-	if d.Err() != nil {
-		return d.Err()
-	}
-
-	// Handle the last label.
-	if len(values) > 0 {
-		if err := w.writeLabelIndex(string(current), values); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (w *Writer) writeLabelIndex(name string, values []uint32) error {
-	// Align beginning to 4 bytes for more efficient index list scans.
-	if err := w.addPadding(4); err != nil {
-		return err
-	}
-
-	w.labelIndexes = append(w.labelIndexes, labelIndexHashEntry{
-		keys:   []string{name},
-		offset: w.f.pos,
-	})
-
-	startPos := w.f.pos
-	// Leave 4 bytes of space for the length, which will be calculated later.
-	if err := w.write([]byte("alen")); err != nil {
-		return err
-	}
-	w.crc32.Reset()
-
-	w.buf1.Reset()
-	w.buf1.PutBE32int(1) // Number of names.
-	w.buf1.PutBE32int(len(values))
-	w.buf1.WriteToHash(w.crc32)
-	if err := w.write(w.buf1.Get()); err != nil {
-		return err
-	}
-
-	for _, v := range values {
-		w.buf1.Reset()
-		w.buf1.PutBE32(v)
-		w.buf1.WriteToHash(w.crc32)
-		if err := w.write(w.buf1.Get()); err != nil {
-			return err
-		}
-	}
-
-	// Write out the length.
-	w.buf1.Reset()
-	l := w.f.pos - startPos - 4
-	if l > math.MaxUint32 {
-		return fmt.Errorf("label index size exceeds 4 bytes: %d", l)
-	}
-	w.buf1.PutBE32int(int(l))
-	if err := w.writeAt(w.buf1.Get(), startPos); err != nil {
-		return err
-	}
-
-	w.buf1.Reset()
-	w.buf1.PutHashSum(w.crc32)
-	return w.write(w.buf1.Get())
-}
-
-// writeLabelIndexesOffsetTable writes the label indices offset table.
-func (w *Writer) writeLabelIndexesOffsetTable() error {
-	startPos := w.f.pos
-	// Leave 4 bytes of space for the length, which will be calculated later.
-	if err := w.write([]byte("alen")); err != nil {
-		return err
-	}
-	w.crc32.Reset()
-
-	w.buf1.Reset()
-	w.buf1.PutBE32int(len(w.labelIndexes))
-	w.buf1.WriteToHash(w.crc32)
-	if err := w.write(w.buf1.Get()); err != nil {
-		return err
-	}
-
-	for _, e := range w.labelIndexes {
-		w.buf1.Reset()
-		w.buf1.PutUvarint(len(e.keys))
-		for _, k := range e.keys {
-			w.buf1.PutUvarintStr(k)
-		}
-		w.buf1.PutUvarint64(e.offset)
-		w.buf1.WriteToHash(w.crc32)
-		if err := w.write(w.buf1.Get()); err != nil {
-			return err
-		}
-	}
-
-	// Write out the length.
-	err := w.writeLengthAndHash(startPos)
-	if err != nil {
-		return fmt.Errorf("label indexes offset table length/crc32 write error: %w", err)
 	}
 	return nil
 }
@@ -1047,11 +898,6 @@ func (w *Writer) writePostings() error {
 	}
 	w.fP = nil
 	return nil
-}
-
-type labelIndexHashEntry struct {
-	keys   []string
-	offset uint64
 }
 
 func (w *Writer) Close() error {

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -186,37 +186,6 @@ func TestIndexRW_Postings(t *testing.T) {
 	}
 	require.NoError(t, p.Err())
 
-	// The label indices are no longer used, so test them by hand here.
-	labelValuesOffsets := map[string]uint64{}
-	d := encoding.NewDecbufAt(ir.b, int(ir.toc.LabelIndicesTable), castagnoliTable)
-	cnt := d.Be32()
-
-	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
-		require.Equal(t, 1, d.Uvarint(), "Unexpected number of keys for label indices table")
-		lbl := d.UvarintStr()
-		off := d.Uvarint64()
-		labelValuesOffsets[lbl] = off
-		cnt--
-	}
-	require.NoError(t, d.Err())
-
-	labelIndices := map[string][]string{}
-	for lbl, off := range labelValuesOffsets {
-		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
-		require.Equal(t, 1, d.Be32int(), "Unexpected number of label indices table names")
-		for i := d.Be32(); i > 0 && d.Err() == nil; i-- {
-			v, err := ir.lookupSymbol(ctx, d.Be32())
-			require.NoError(t, err)
-			labelIndices[lbl] = append(labelIndices[lbl], v)
-		}
-		require.NoError(t, d.Err())
-	}
-
-	require.Equal(t, map[string][]string{
-		"a": {"1"},
-		"b": {"1", "2", "3", "4"},
-	}, labelIndices)
-
 	t.Run("ShardedPostings()", func(t *testing.T) {
 		ir, err := NewFileReader(fn, DecodePostingsRaw)
 		require.NoError(t, err)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -620,18 +620,22 @@ func (it *intersectPostings) At() storage.SeriesRef {
 }
 
 func (it *intersectPostings) doNext() bool {
-Loop:
 	for {
+		allEqual := true
 		for _, p := range it.arr {
 			if !p.Seek(it.cur) {
 				return false
 			}
 			if p.At() > it.cur {
 				it.cur = p.At()
-				continue Loop
+				allEqual = false
 			}
 		}
-		return true
+
+		// if all p.At() are all equal, we found an intersection.
+		if allEqual {
+			return true
+		}
 	}
 }
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -47,6 +47,7 @@ func BenchmarkQuerier(b *testing.B) {
 	}
 
 	for n := 0; n < 10; n++ {
+		addSeries(labels.FromStrings("a", strconv.Itoa(n)+postingsBenchSuffix))
 		for i := 0; i < 100000; i++ {
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
 			// Have some series that won't be matched, to properly test inverted matches.
@@ -101,7 +102,9 @@ func BenchmarkQuerier(b *testing.B) {
 func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	ctx := context.Background()
 
+	a1 := labels.MustNewMatcher(labels.MatchEqual, "a", "1"+postingsBenchSuffix)
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	n0_1 := labels.MustNewMatcher(labels.MatchEqual, "n", "0_1"+postingsBenchSuffix)
 	nX := labels.MustNewMatcher(labels.MatchEqual, "n", "X"+postingsBenchSuffix)
 
 	jFoo := labels.MustNewMatcher(labels.MatchEqual, "j", "foo")
@@ -137,6 +140,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`j="foo",n="1"`, []*labels.Matcher{jFoo, n1}},
 		{`n="1",j!="foo"`, []*labels.Matcher{n1, jNotFoo}},
 		{`n="1",i!="2"`, []*labels.Matcher{n1, iNot2}},
+		{`n="0_1",j="foo,a="1"`, []*labels.Matcher{n0_1, jFoo, a1}},
 		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}},
 		{`i=~"1[0-9]",j=~"foo|bar"`, []*labels.Matcher{iCharSet, jFooBar}},
 		{`j=~"foo|bar"`, []*labels.Matcher{jFooBar}},
@@ -176,8 +180,12 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := PostingsForMatchers(ctx, ir, c.matchers...)
+				p, err := PostingsForMatchers(ctx, ir, c.matchers...)
 				require.NoError(b, err)
+				// Iterate over the postings
+				for p.Next() {
+					// Do nothing
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Merge at [`291e2ae090ec15971025af985fff81b33c0d5bd2`](https://github.com/prometheus/prometheus/commit/291e2ae090ec15971025af985fff81b33c0d5bd2)

- https://github.com/prometheus/prometheus/pull/16923 related to scrape (can ignore)
- https://github.com/prometheus/prometheus/pull/16996 fixes in promql parser, reverts some PRs
- https://github.com/prometheus/prometheus/pull/13971 improve postings intersect speed
- https://github.com/prometheus/prometheus/pull/16968 remove some useless code
- https://github.com/prometheus/prometheus/pull/17006 bugfix

Resolution:
```
commit 4bddf86efc6674aab3fd738734ea411fc7bc02c8
Merge: 9ea5cc5e9 291e2ae09
Author: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
Date:   Fri Aug 8 13:15:27 2025 +0200

    Merge branch 'source' into krajo/update-main-part
    
    # Conflicts:
    #       tsdb/index/index.go
    #       tsdb/index/index_test.go

diff --git a/tsdb/index/index.go b/tsdb/index/index.go
remerge CONFLICT (content): Merge conflict in tsdb/index/index.go
index 8f72b90be..215ef64ca 100644
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -603,150 +603,6 @@ func (w *Writer) finishSymbols() error {
 	return nil
 }
 
-<<<<<<< 9ea5cc5e9 (Merge pull request #944 from jhalterman/global-pfmc2)
-func (w *Writer) writeLabelIndices() error {
-	if err := w.fPO.Flush(); err != nil {
-		return err
-	}
-
-	// Find all the label values in the tmp posting offset table.
-	f, err := fileutil.OpenMmapFile(w.fPO.name)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
-	cnt := w.cntPO
-	current := []byte{}
-	values := []uint32{}
-	for d.Err() == nil && cnt > 0 {
-		cnt--
-		d.Uvarint()                           // Keycount.
-		name := d.UvarintBytes()              // Label name.
-		value := yoloString(d.UvarintBytes()) // Label value.
-		d.Uvarint64()                         // Offset.
-		if len(name) == 0 {
-			continue // All index is ignored.
-		}
-
-		if !bytes.Equal(name, current) && len(values) > 0 {
-			// We've reached a new label name.
-			if err := w.writeLabelIndex(string(current), values); err != nil {
-				return err
-			}
-			values = values[:0]
-		}
-		current = name
-		sid, err := w.symbols.ReverseLookup(value)
-		if err != nil {
-			return err
-		}
-		values = append(values, sid)
-	}
-	if d.Err() != nil {
-		return d.Err()
-	}
-
-	// Handle the last label.
-	if len(values) > 0 {
-		if err := w.writeLabelIndex(string(current), values); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (w *Writer) writeLabelIndex(name string, values []uint32) error {
-	// Align beginning to 4 bytes for more efficient index list scans.
-	if err := w.addPadding(4); err != nil {
-		return err
-	}
-
-	w.labelIndexes = append(w.labelIndexes, labelIndexHashEntry{
-		keys:   []string{name},
-		offset: w.f.pos,
-	})
-
-	startPos := w.f.pos
-	// Leave 4 bytes of space for the length, which will be calculated later.
-	if err := w.write([]byte("alen")); err != nil {
-		return err
-	}
-	w.crc32.Reset()
-
-	w.buf1.Reset()
-	w.buf1.PutBE32int(1) // Number of names.
-	w.buf1.PutBE32int(len(values))
-	w.buf1.WriteToHash(w.crc32)
-	if err := w.write(w.buf1.Get()); err != nil {
-		return err
-	}
-
-	for _, v := range values {
-		w.buf1.Reset()
-		w.buf1.PutBE32(v)
-		w.buf1.WriteToHash(w.crc32)
-		if err := w.write(w.buf1.Get()); err != nil {
-			return err
-		}
-	}
-
-	// Write out the length.
-	w.buf1.Reset()
-	l := w.f.pos - startPos - 4
-	if l > math.MaxUint32 {
-		return fmt.Errorf("label index size exceeds 4 bytes: %d", l)
-	}
-	w.buf1.PutBE32int(int(l))
-	if err := w.writeAt(w.buf1.Get(), startPos); err != nil {
-		return err
-	}
-
-	w.buf1.Reset()
-	w.buf1.PutHashSum(w.crc32)
-	return w.write(w.buf1.Get())
-}
-
-// writeLabelIndexesOffsetTable writes the label indices offset table.
-func (w *Writer) writeLabelIndexesOffsetTable() error {
-	startPos := w.f.pos
-	// Leave 4 bytes of space for the length, which will be calculated later.
-	if err := w.write([]byte("alen")); err != nil {
-		return err
-	}
-	w.crc32.Reset()
-
-	w.buf1.Reset()
-	w.buf1.PutBE32int(len(w.labelIndexes))
-	w.buf1.WriteToHash(w.crc32)
-	if err := w.write(w.buf1.Get()); err != nil {
-		return err
-	}
-
-	for _, e := range w.labelIndexes {
-		w.buf1.Reset()
-		w.buf1.PutUvarint(len(e.keys))
-		for _, k := range e.keys {
-			w.buf1.PutUvarintStr(k)
-		}
-		w.buf1.PutUvarint64(e.offset)
-		w.buf1.WriteToHash(w.crc32)
-		if err := w.write(w.buf1.Get()); err != nil {
-			return err
-		}
-	}
-
-	// Write out the length.
-	err := w.writeLengthAndHash(startPos)
-	if err != nil {
-		return fmt.Errorf("label indexes offset table length/crc32 write error: %w", err)
-	}
-	return nil
-}
-
-=======
->>>>>>> 291e2ae09 (Merge pull request #17006 from sujalshah-bit/fix_wal_dir_bug)
 // writePostingsOffsetTable writes the postings offset table.
 func (w *Writer) writePostingsOffsetTable() error {
 	// Ensure everything is in the temporary file.
diff --git a/tsdb/index/index_test.go b/tsdb/index/index_test.go
remerge CONFLICT (content): Merge conflict in tsdb/index/index_test.go
index ad241c327..aa1ed651c 100644
--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -186,50 +186,10 @@ func TestIndexRW_Postings(t *testing.T) {
 	}
 	require.NoError(t, p.Err())
 
-<<<<<<< 9ea5cc5e9 (Merge pull request #944 from jhalterman/global-pfmc2)
-	// The label indices are no longer used, so test them by hand here.
-	labelValuesOffsets := map[string]uint64{}
-	d := encoding.NewDecbufAt(ir.b, int(ir.toc.LabelIndicesTable), castagnoliTable)
-	cnt := d.Be32()
-
-	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
-		require.Equal(t, 1, d.Uvarint(), "Unexpected number of keys for label indices table")
-		lbl := d.UvarintStr()
-		off := d.Uvarint64()
-		labelValuesOffsets[lbl] = off
-		cnt--
-	}
-	require.NoError(t, d.Err())
-
-	labelIndices := map[string][]string{}
-	for lbl, off := range labelValuesOffsets {
-		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
-		require.Equal(t, 1, d.Be32int(), "Unexpected number of label indices table names")
-		for i := d.Be32(); i > 0 && d.Err() == nil; i-- {
-			v, err := ir.lookupSymbol(ctx, d.Be32())
-			require.NoError(t, err)
-			labelIndices[lbl] = append(labelIndices[lbl], v)
-		}
-		require.NoError(t, d.Err())
-	}
-
-	require.Equal(t, map[string][]string{
-		"a": {"1"},
-		"b": {"1", "2", "3", "4"},
-	}, labelIndices)
-
 	// Test ShardedPostings() with and without series hash cache.
 	for _, cacheEnabled := range []bool{false, true} {
 		t.Run(fmt.Sprintf("ShardedPostings() cache enabled: %v", cacheEnabled), func(t *testing.T) {
 			ir, _, _ = createFileReaderWithOptions(ctx, t, input, cacheEnabled)
-=======
-	t.Run("ShardedPostings()", func(t *testing.T) {
-		ir, err := NewFileReader(fn, DecodePostingsRaw)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, ir.Close())
-		})
->>>>>>> 291e2ae09 (Merge pull request #17006 from sujalshah-bit/fix_wal_dir_bug)
 
 			// List all postings for a given label value. This is what we expect to get
 			// in output from all shards.
```