### PR TITLE
Improve postings cache size calculation and metrics

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -941,6 +941,11 @@ func (c *PostingsCloner) Clone() Postings {
 	return newListPostings(c.ids...)
 }
 
+// EstimateSize returns an estimate of the size of the PostingsCloner.
+func (c *PostingsCloner) EstimateSize() int64 {
+	return int64(len(c.ids) * 8)
+}
+
 // FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,
 // if intersection is non empty, then i is added to the indexes returned.
 // Returned indexes are not sorted.

--- a/tsdb/postings_for_matchers_cache_test.go
+++ b/tsdb/postings_for_matchers_cache_test.go
@@ -83,11 +83,10 @@ func TestPostingsForMatchersCache(t *testing.T) {
 						if concurrent {
 							if shared {
 								expectedBytes = 228
-								expectedEntries = 1
 							} else {
-								expectedBytes = 0
-								expectedEntries = 0
+								expectedBytes = 199
 							}
+							expectedEntries = 1
 							expectedMisses = 1
 						} else {
 							expectedSkips = 1
@@ -152,11 +151,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP postings_for_matchers_cache_bytes_total Total number of bytes in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_bytes_total gauge
-			postings_for_matchers_cache_bytes_total 0
+			postings_for_matchers_cache_bytes_total 179
 
 			# HELP postings_for_matchers_cache_entries_total Total number of entries in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_entries_total gauge
-			postings_for_matchers_cache_entries_total 0
+			postings_for_matchers_cache_entries_total 1
 
 			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_requests_total counter
@@ -438,12 +437,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 					require.EqualError(t, p.Err(), "result from call 2")
 
 					expectedBytes := 0
-					expectedEntries := 0
+					expectedEntries := 1
 					if shared {
 						expectedBytes = 227
-						expectedEntries = 1
 					} else {
-						expectedBytes = 0
+						expectedBytes = 198
 					}
 
 					require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
@@ -544,10 +542,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 					require.EqualError(t, p.Err(), "result from call 2")
 
 					expectedBytes := 0
-					expectedEntries := 0
+					expectedEntries := 6
 					if shared {
 						expectedBytes = 1352
-						expectedEntries = 6
+					} else {
+						expectedBytes = 1178
 					}
 
 					require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
@@ -602,7 +601,7 @@ func TestPostingsForMatchersCache(t *testing.T) {
 				t.Run(fmt.Sprintf("shared=%t, invalidation=%t", shared, invalidation), func(t *testing.T) {
 					const (
 						maxItems         = 100 // Never hit it.
-						maxBytes         = 1400
+						maxBytes         = 2400
 						numMatchers      = 5
 						postingsListSize = 30 // 8 bytes per posting ref, so 30 x 8 = 240 bytes.
 					)
@@ -675,10 +674,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 					require.Equal(t, 1, callsPerMatchers[cacheKeyForMatchers(matchersLists[3])])
 
 					expectedBytes := 0
-					expectedEntries := 0
+					expectedEntries := 4
 					if shared {
-						expectedBytes = 1848
-						expectedEntries = 4
+						expectedBytes = 2808
+					} else {
+						expectedBytes = 2692
 					}
 
 					require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
@@ -855,11 +855,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP postings_for_matchers_cache_bytes_total Total number of bytes in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_bytes_total gauge
-			postings_for_matchers_cache_bytes_total 0
+			postings_for_matchers_cache_bytes_total 230
 
 			# HELP postings_for_matchers_cache_entries_total Total number of entries in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_entries_total gauge
-			postings_for_matchers_cache_entries_total 0
+			postings_for_matchers_cache_entries_total 1
 
 			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_requests_total counter
@@ -965,11 +965,11 @@ func TestPostingsForMatchersCache(t *testing.T) {
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP postings_for_matchers_cache_bytes_total Total number of bytes in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_bytes_total gauge
-			postings_for_matchers_cache_bytes_total 0
+			postings_for_matchers_cache_bytes_total 230
 
 			# HELP postings_for_matchers_cache_entries_total Total number of entries in the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_entries_total gauge
-			postings_for_matchers_cache_entries_total 0
+			postings_for_matchers_cache_entries_total 1
 
 			# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
 			# TYPE postings_for_matchers_cache_requests_total counter
@@ -1181,11 +1181,11 @@ func TestPostingsForMatchersCache_ShouldNotReturnStaleEntriesWhileAnotherGorouti
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP postings_for_matchers_cache_bytes_total Total number of bytes in the PostingsForMatchers cache.
 		# TYPE postings_for_matchers_cache_bytes_total gauge
-		postings_for_matchers_cache_bytes_total 0
+		postings_for_matchers_cache_bytes_total 193
 
 		# HELP postings_for_matchers_cache_entries_total Total number of entries in the PostingsForMatchers cache.
 		# TYPE postings_for_matchers_cache_entries_total gauge
-		postings_for_matchers_cache_entries_total 0
+		postings_for_matchers_cache_entries_total 1
 
 		# HELP postings_for_matchers_cache_requests_total Total number of requests to the PostingsForMatchers cache.
 		# TYPE postings_for_matchers_cache_requests_total counter


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

At present, the postings for matchers cache tracks bytes for entries, which consist of the key + promise, and evicts cache entries when the max bytes are exceeded. But the size of the promise is shallow and doesn't include the size of the internal `PostingsCloner`. 

This PR improves the way that the postings cache size is tracked to include `PostingsCloner` usage. This PR also exposes the recently added entries and bytes metrics for non-shared caches.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->

With the same configuration, postings cache entries are more likely to expire due to hitting the max bytes, since this will be more accurate than previously.