### PR TITLE
Add IndexLookupPlannerFunc to TSDB Options

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -347,11 +347,11 @@ type Block struct {
 // OpenBlock opens the block in the directory. It can be passed a chunk pool, which is used
 // to instantiate chunk structs.
 func OpenBlock(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory) (pb *Block, err error) {
-	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, func(*index.Reader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }, nil, DefaultPostingsForMatchersCacheFactory)
+	return OpenBlockWithOptions(logger, dir, pool, postingsDecoderFactory, func(BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }, nil, DefaultPostingsForMatchersCacheFactory)
 }
 
 // OpenBlockWithOptions is like OpenBlock but allows to pass a cache provider and sharding function.
-func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, plannerFunc index.IndexLookupPlannerFunc, cache index.ReaderCacheProvider, postingsCacheFactory PostingsForMatchersCacheFactory) (pb *Block, err error) {
+func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, plannerFunc IndexLookupPlannerFunc, cache index.ReaderCacheProvider, postingsCacheFactory PostingsForMatchersCacheFactory) (pb *Block, err error) {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -376,7 +376,7 @@ func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, p
 	if postingsDecoderFactory != nil {
 		decoder = postingsDecoderFactory(meta)
 	}
-	indexReader, err := index.NewFileReaderWithOptions(filepath.Join(dir, indexFilename), decoder, plannerFunc, cache)
+	indexReader, err := index.NewFileReaderWithOptions(filepath.Join(dir, indexFilename), decoder, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -403,6 +403,13 @@ func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, p
 		numBytesTombstone: sizeTomb,
 		numBytesMeta:      sizeMeta,
 	}
+
+	// Set the lookup planner on the index reader using the block
+	if plannerFunc != nil {
+		planner := plannerFunc(pb)
+		indexReader.SetLookupPlanner(planner)
+	}
+
 	return pb, nil
 }
 

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -404,10 +404,8 @@ func OpenBlockWithOptions(logger *slog.Logger, dir string, pool chunkenc.Pool, p
 		numBytesMeta:      sizeMeta,
 	}
 
-	// Set the lookup planner on the index reader using the block
 	if plannerFunc != nil {
-		planner := plannerFunc(pb)
-		indexReader.SetLookupPlanner(planner)
+		indexReader.SetLookupPlanner(plannerFunc(pb))
 	}
 
 	return pb, nil

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1118,11 +1118,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		return nil, err
 	}
 	db.head.writeNotified = db.writeNotified
-	if opts.IndexLookupPlannerFunc != nil {
-		db.head.opts.IndexLookupPlanner = opts.IndexLookupPlannerFunc(db.head)
-	} else {
-		db.head.opts.IndexLookupPlanner = &index.ScanEmptyMatchersLookupPlanner{}
-	}
+	db.head.opts.IndexLookupPlannerFunc = opts.IndexLookupPlannerFunc
 
 	// Register metrics after assigning the head block.
 	db.metrics = newDBMetrics(db, r)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -95,6 +95,7 @@ func DefaultOptions() *Options {
 		CompactionDelayMaxPercent:                DefaultCompactionDelayMaxPercent,
 		CompactionDelay:                          time.Duration(0),
 		PostingsDecoderFactory:                   DefaultPostingsDecoderFactory,
+		IndexLookupPlannerFunc:                   DefaultIndexLookupPlannerFunc,
 		HeadChunksEndTimeVariance:                0,
 		HeadPostingsForMatchersCacheInvalidation: DefaultPostingsForMatchersCacheInvalidation,
 		HeadPostingsForMatchersCacheVersions:     DefaultPostingsForMatchersCacheVersions,

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -317,7 +317,7 @@ type Options struct {
 	// IndexLookupPlannerFunc is a function to return index.LookupPlanner from a BlockReader.
 	// Similar to BlockChunkQuerierFunc, this allows per-block planner creation.
 	// For on-disk blocks, IndexLookupPlannerFunc is invoked once when they are opened.
-	// For in-memory blocks IndexLookupPlannerFunc is invoked every time statistics are genearted, which happens according to HeadStatisticsCollectionFrequency.
+	// For in-memory blocks IndexLookupPlannerFunc is invoked every time statistics are generated, which happens according to HeadStatisticsCollectionFrequency.
 	IndexLookupPlannerFunc IndexLookupPlannerFunc
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -919,7 +919,7 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 		opts.OutOfOrderTimeWindow = 0
 	}
 	if opts.IndexLookupPlannerFunc == nil {
-		opts.IndexLookupPlannerFunc = func(b BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }
+		opts.IndexLookupPlannerFunc = func(BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }
 	}
 	if opts.PostingsForMatchersCacheKeyFunc == nil {
 		opts.PostingsForMatchersCacheKeyFunc = DefaultPostingsForMatchersCacheKeyFunc

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1891,17 +1891,7 @@ func openBlocks(l *slog.Logger, dir string, loaded []*Block, chunkPool chunkenc.
 				cacheProvider = cache.GetBlockCacheProvider(meta.ULID.String())
 			}
 
-			// First open the block temporarily to get a BlockReader for plannerFunc
-			tempBlock, err := OpenBlockWithOptions(l, bDir, chunkPool, postingsDecoderFactory, &index.ScanEmptyMatchersLookupPlanner{}, cacheProvider, postingsCacheFactory)
-			if err != nil {
-				corrupted[meta.ULID] = err
-				continue
-			}
-			blockPlanner := plannerFunc(tempBlock)
-			// Close the temporary block since we'll reopen with the correct planner
-			tempBlock.Close()
-
-			block, err = OpenBlockWithOptions(l, bDir, chunkPool, postingsDecoderFactory, blockPlanner, cacheProvider, postingsCacheFactory)
+			block, err = OpenBlockWithOptions(l, bDir, chunkPool, postingsDecoderFactory, plannerFunc, cacheProvider, postingsCacheFactory)
 			if err != nil {
 				corrupted[meta.ULID] = err
 				continue

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -195,8 +195,8 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
-	// IndexLookupPlanner can be optionally used when querying the index of the Head.
-	IndexLookupPlanner index.LookupPlanner
+	// IndexLookupPlannerFunc can be optionally used when querying the index of the Head.
+	IndexLookupPlannerFunc IndexLookupPlannerFunc
 
 	// Timely compaction allows head compaction to happen when min block range can no longer be appended,
 	// without requiring 1.5x the chunk range worth of data in the head.
@@ -231,7 +231,7 @@ func DefaultHeadOptions() *HeadOptions {
 		IsolationDisabled:               defaultIsolationDisabled,
 		PostingsForMatchersCacheFactory: DefaultPostingsForMatchersCacheFactory,
 		WALReplayConcurrency:            defaultWALReplayConcurrency,
-		IndexLookupPlanner:              &index.ScanEmptyMatchersLookupPlanner{},
+		IndexLookupPlannerFunc:          func(BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} },
 	}
 	ho.OutOfOrderCapMax.Store(DefaultOutOfOrderCapMax)
 	return ho

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -117,6 +117,7 @@ type Head struct {
 	postings      *index.MemPostings // Postings lists for terms.
 	postingsStats atomic.Pointer[index.Statistics]
 	pfmc          *PostingsForMatchersCache
+	planner       atomic.Pointer[index.LookupPlanner]
 
 	tombstones *tombstones.MemTombstones
 
@@ -400,7 +401,9 @@ func (h *Head) resetWLReplayResources() {
 func (h *Head) updateHeadStatistics() {
 	start := time.Now()
 	stats := index.Statistics(newFullHeadStatistics(h))
+	planner := h.opts.IndexLookupPlannerFunc(h)
 	h.postingsStats.Store(&stats)
+	h.planner.Store(&planner)
 	h.metrics.headStatisticsTimeToUpdate.Set(time.Since(start).Seconds())
 	h.metrics.headStatisticsLastUpdate.Set(float64(time.Now().Unix()))
 	h.logger.Info("successfully updated head statistics",

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -401,8 +401,8 @@ func (h *Head) resetWLReplayResources() {
 func (h *Head) updateHeadStatistics() {
 	start := time.Now()
 	stats := index.Statistics(newFullHeadStatistics(h))
-	planner := h.opts.IndexLookupPlannerFunc(h)
 	h.postingsStats.Store(&stats)
+	planner := h.opts.IndexLookupPlannerFunc(h)
 	h.planner.Store(&planner)
 	h.metrics.headStatisticsTimeToUpdate.Set(time.Since(start).Seconds())
 	h.metrics.headStatisticsLastUpdate.Set(float64(time.Now().Unix()))

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -324,7 +324,10 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return h.head.opts.IndexLookupPlanner
+	if h.head.opts.IndexLookupPlannerFunc != nil {
+		return h.head.opts.IndexLookupPlannerFunc(h.head)
+	}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 // Chunks returns a ChunkReader against the block.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -324,8 +324,8 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	if h.head.opts.IndexLookupPlannerFunc != nil {
-		return h.head.opts.IndexLookupPlannerFunc(h.head)
+	if p := h.head.planner.Load(); p != nil {
+		return *p
 	}
 	return &index.ScanEmptyMatchersLookupPlanner{}
 }

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -120,6 +120,8 @@ type PostingsEncoder func(*encoding.Encbuf, []uint32) error
 
 type PostingsDecoder func(encoding.Decbuf) (int, Postings, error)
 
+type LookupPlannerFunc func(*Reader) LookupPlanner
+
 // Writer implements the IndexWriter interface for the standard
 // serialization format.
 type Writer struct {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -120,7 +120,7 @@ type PostingsEncoder func(*encoding.Encbuf, []uint32) error
 
 type PostingsDecoder func(encoding.Decbuf) (int, Postings, error)
 
-type IndexLookupPlannerFunc func(*Reader) LookupPlanner
+type LookupPlannerFunc func(*Reader) LookupPlanner
 
 // Writer implements the IndexWriter interface for the standard
 // serialization format.

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -994,6 +994,10 @@ func (r *Reader) IndexLookupPlanner() LookupPlanner {
 	return r.lookupPlanner
 }
 
+func (r *Reader) SetLookupPlanner(planner LookupPlanner) {
+	r.lookupPlanner = planner
+}
+
 type postingOffset struct {
 	value string
 	off   int
@@ -1032,11 +1036,11 @@ func NewReaderWithCache(b ByteSlice, decoder PostingsDecoder, cacheProvider Read
 
 // NewFileReader returns a new index reader against the given index file.
 func NewFileReader(path string, decoder PostingsDecoder) (*Reader, error) {
-	return NewFileReaderWithOptions(path, decoder, func(*Reader) LookupPlanner { return &ScanEmptyMatchersLookupPlanner{} }, nil)
+	return NewFileReaderWithOptions(path, decoder, nil)
 }
 
 // NewFileReaderWithOptions is like NewFileReader but allows to pass a cache provider.
-func NewFileReaderWithOptions(path string, decoder PostingsDecoder, plannerFunc IndexLookupPlannerFunc, cacheProvider ReaderCacheProvider) (*Reader, error) {
+func NewFileReaderWithOptions(path string, decoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
 		return nil, err
@@ -1048,9 +1052,6 @@ func NewFileReaderWithOptions(path string, decoder PostingsDecoder, plannerFunc 
 			f.Close(),
 		).Err()
 	}
-
-	// Call the planner function with the reader and set the resulting planner
-	r.lookupPlanner = plannerFunc(r)
 
 	return r, nil
 }

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -120,8 +120,6 @@ type PostingsEncoder func(*encoding.Encbuf, []uint32) error
 
 type PostingsDecoder func(encoding.Decbuf) (int, Postings, error)
 
-type LookupPlannerFunc func(*Reader) LookupPlanner
-
 // Writer implements the IndexWriter interface for the standard
 // serialization format.
 type Writer struct {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -994,10 +994,6 @@ func (r *Reader) IndexLookupPlanner() LookupPlanner {
 	return r.lookupPlanner
 }
 
-func (r *Reader) SetLookupPlanner(planner LookupPlanner) {
-	r.lookupPlanner = planner
-}
-
 type postingOffset struct {
 	value string
 	off   int
@@ -1023,29 +1019,31 @@ func (b realByteSlice) Sub(start, end int) ByteSlice {
 	return b[start:end]
 }
 
+var defaultLookupPlannerFunc = func(*Reader) LookupPlanner { return &ScanEmptyMatchersLookupPlanner{} }
+
 // NewReader returns a new index reader on the given byte slice. It automatically
 // handles different format versions.
 func NewReader(b ByteSlice, decoder PostingsDecoder) (*Reader, error) {
-	return newReader(b, io.NopCloser(nil), decoder, &ScanEmptyMatchersLookupPlanner{}, nil)
+	return newReader(b, io.NopCloser(nil), decoder, defaultLookupPlannerFunc, nil)
 }
 
 // NewReaderWithCache is like NewReader but allows to pass a cache provider.
 func NewReaderWithCache(b ByteSlice, decoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
-	return newReader(b, io.NopCloser(nil), decoder, &ScanEmptyMatchersLookupPlanner{}, cacheProvider)
+	return newReader(b, io.NopCloser(nil), decoder, defaultLookupPlannerFunc, cacheProvider)
 }
 
 // NewFileReader returns a new index reader against the given index file.
 func NewFileReader(path string, decoder PostingsDecoder) (*Reader, error) {
-	return NewFileReaderWithOptions(path, decoder, nil)
+	return NewFileReaderWithOptions(path, decoder, defaultLookupPlannerFunc, nil)
 }
 
 // NewFileReaderWithOptions is like NewFileReader but allows to pass a cache provider.
-func NewFileReaderWithOptions(path string, decoder PostingsDecoder, cacheProvider ReaderCacheProvider) (*Reader, error) {
+func NewFileReaderWithOptions(path string, decoder PostingsDecoder, plannerFunc LookupPlannerFunc, cacheProvider ReaderCacheProvider) (*Reader, error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(realByteSlice(f.Bytes()), f, decoder, &ScanEmptyMatchersLookupPlanner{}, cacheProvider)
+	r, err := newReader(realByteSlice(f.Bytes()), f, decoder, plannerFunc, cacheProvider)
 	if err != nil {
 		return nil, tsdb_errors.NewMulti(
 			err,
@@ -1056,14 +1054,13 @@ func NewFileReaderWithOptions(path string, decoder PostingsDecoder, cacheProvide
 	return r, nil
 }
 
-func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder, planner LookupPlanner, cacheProvider ReaderCacheProvider) (*Reader, error) {
+func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder, plannerFunc LookupPlannerFunc, cacheProvider ReaderCacheProvider) (*Reader, error) {
 	r := &Reader{
 		b:             b,
 		c:             c,
 		postings:      map[string][]postingOffset{},
 		cacheProvider: cacheProvider,
 		st:            labels.NewSymbolTable(),
-		lookupPlanner: planner,
 	}
 
 	// Verify header.
@@ -1158,6 +1155,7 @@ func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder, planne
 	}
 
 	r.dec = &Decoder{LookupSymbol: r.lookupSymbol, DecodePostings: postingsDecoder}
+	r.lookupPlanner = plannerFunc(r)
 
 	return r, nil
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -716,7 +716,7 @@ func createFileReaderWithOptions(ctx context.Context, tb testing.TB, input index
 
 	var ir *Reader
 	if withCache {
-		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
+		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, defaultLookupPlannerFunc, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
 	} else {
 		ir, err = NewFileReader(fn, DecodePostingsRaw)
 	}

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -716,7 +716,7 @@ func createFileReaderWithOptions(ctx context.Context, tb testing.TB, input index
 
 	var ir *Reader
 	if withCache {
-		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, &ScanEmptyMatchersLookupPlanner{}, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
+		ir, err = NewFileReaderWithOptions(fn, DecodePostingsRaw, hashcache.NewSeriesHashCache(1024*1024*1024).GetBlockCacheProvider("test"))
 	} else {
 		ir, err = NewFileReader(fn, DecodePostingsRaw)
 	}

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -196,8 +196,8 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	if oh.head.opts.IndexLookupPlannerFunc != nil {
-		return oh.head.opts.IndexLookupPlannerFunc(oh.head)
+	if p := oh.head.planner.Load(); p != nil {
+		return *p
 	}
 	return &index.ScanEmptyMatchersLookupPlanner{}
 }
@@ -538,8 +538,8 @@ func (*OOOCompactionHeadIndexReader) Close() error {
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	if ir.ch.head.opts.IndexLookupPlannerFunc != nil {
-		return ir.ch.head.opts.IndexLookupPlannerFunc(ir.ch.head)
+	if p := ir.ch.head.planner.Load(); p != nil {
+		return *p
 	}
 	return &index.ScanEmptyMatchersLookupPlanner{}
 }

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -196,7 +196,10 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return oh.head.opts.IndexLookupPlanner
+	if oh.head.opts.IndexLookupPlannerFunc != nil {
+		return oh.head.opts.IndexLookupPlannerFunc(oh.head)
+	}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
@@ -535,7 +538,10 @@ func (*OOOCompactionHeadIndexReader) Close() error {
 
 // IndexLookupPlanner returns the index lookup planner for this reader.
 func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return ir.ch.head.opts.IndexLookupPlanner
+	if ir.ch.head.opts.IndexLookupPlannerFunc != nil {
+		return ir.ch.head.opts.IndexLookupPlannerFunc(ir.ch.head)
+	}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 // HeadAndOOOQuerier queries both the head and the out-of-order head.

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -359,7 +359,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 	seriesHashCache := hashcache.NewSeriesHashCache(1024 * 1024 * 1024)
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, func(BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheFactory)
+	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, DefaultIndexLookupPlannerFunc, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheFactory)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -359,7 +359,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 	seriesHashCache := hashcache.NewSeriesHashCache(1024 * 1024 * 1024)
 	blockdir := createBlockFromHead(b, tmpdir, h)
-	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, &index.ScanEmptyMatchersLookupPlanner{}, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheFactory)
+	block, err := OpenBlockWithOptions(nil, blockdir, nil, nil, func(BlockReader) index.LookupPlanner { return &index.ScanEmptyMatchersLookupPlanner{} }, seriesHashCache.GetBlockCacheProvider("test"), DefaultPostingsForMatchersCacheFactory)
 	require.NoError(b, err)
 	defer func() {
 		require.NoError(b, block.Close())


### PR DESCRIPTION
Refactor index lookup planner to use function-based approach instead of static planners.

### Changes

- Replace `IndexLookupPlanner` with `IndexLookupPlannerFunc` in `Options` and `HeadOptions` 
- `OpenBlockWithOptions` takes function, calls it once when block opens, caches result
- Head calls function periodically during stats updates, stores in atomic pointer


### Use Case


1. Create specialized planners based on block metadata (ULID, time range, etc.)
2. Use different statistics for different blocks when making query planning decisions
3. Optimize query execution on a per-block basis rather than using global statistics

Related to https://github.com/grafana/mimir/issues/12432