### PR TITLE
Fix formatting of Slack message for test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,5 +159,5 @@ jobs:
           channel-id: C04AF91LPFX #mimir-ci-notifications
           payload: |
             {
-              "text": ":warning: *Test failed for upstream merge PR*\n\n**test (stringlabels)** failed for upstream merge PR: <${{ env.PR_URL || format('{0}/{1}/tree/{2}', env.SERVER_URL, env.REPOSITORY, env.BRANCH_NAME) }}|${{ env.PR_NUMBER && format('PR #{0}', env.PR_NUMBER) || format('Branch {0}', env.BRANCH_NAME) }}>\n\nWorkflow run: <${{ env.SERVER_URL }}/${{ env.REPOSITORY }}/actions/runs/${{ env.RUN_ID }}|View failure details>"
+              "text": ":warning: *Test failed for upstream merge PR*\n\n`test (stringlabels)` failed for upstream merge PR: <${{ env.PR_URL || format('{0}/{1}/tree/{2}', env.SERVER_URL, env.REPOSITORY, env.BRANCH_NAME) }}|${{ env.PR_NUMBER && format('PR #{0}', env.PR_NUMBER) || format('Branch {0}', env.BRANCH_NAME) }}>\n\nWorkflow run: <${{ env.SERVER_URL }}/${{ env.REPOSITORY }}/actions/runs/${{ env.RUN_ID }}|View failure details>"
             }


### PR DESCRIPTION
This PR fixes an issue with the Slack notification messages sent after a failed CI run, where the message contains `**test (stringlabels)**` instead of `test (stringlabels)` appearing in bold.