### PR TITLE
Fix postings cache size estimation and add postings count to spans

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -941,9 +941,8 @@ func (c *PostingsCloner) Clone() Postings {
 	return newListPostings(c.ids...)
 }
 
-// EstimateSize returns an estimate of the size of the PostingsCloner.
-func (c *PostingsCloner) EstimateSize() int64 {
-	return int64(len(c.ids) * 8)
+func (c *PostingsCloner) NumPostings() int64 {
+	return int64(len(c.ids))
 }
 
 // FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,

--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -451,11 +451,12 @@ func (c *PostingsForMatchersCache) postingsForMatchersPromise(ctx context.Contex
 	promise.callersCtxTracker.Close()
 
 	sizeBytes := int64(len(key) + size.Of(promise))
+	numPostings := int64(0)
 	if promise.cloner != nil {
-		sizeBytes += promise.cloner.EstimateSize()
+		numPostings = int64(promise.cloner.NumPostings())
 	}
 
-	c.onPromiseExecutionDone(ctx, key, promise.evaluationCompletedAt, sizeBytes, promise.err)
+	c.onPromiseExecutionDone(ctx, key, promise.evaluationCompletedAt, sizeBytes, numPostings, promise.err)
 	return promise.result
 }
 
@@ -563,7 +564,7 @@ func (c *PostingsForMatchersCache) evictHead(now time.Time) (reason int) {
 // onPromiseExecutionDone must be called once the execution of PostingsForMatchers promise has done.
 // The input err contains details about any error that could have occurred when executing it.
 // The input ts is the function call time.
-func (c *PostingsForMatchersCache) onPromiseExecutionDone(ctx context.Context, key string, completedAt time.Time, sizeBytes int64, err error) {
+func (c *PostingsForMatchersCache) onPromiseExecutionDone(ctx context.Context, key string, completedAt time.Time, sizeBytes int64, numPostings int64, err error) {
 	span := trace.SpanFromContext(ctx)
 
 	// Call the registered hook, if any. It's used only for testing purposes.
@@ -608,6 +609,7 @@ func (c *PostingsForMatchersCache) onPromiseExecutionDone(ctx context.Context, k
 		trace.WithAttributes(
 			attribute.Stringer("evaluation completed at", completedAt),
 			attribute.Int64("size in bytes", sizeBytes),
+			attribute.Int64("num postings", numPostings),
 			attribute.Int64("cached bytes", lastCachedBytes),
 		),
 		trace.WithAttributes(c.additionalAttributes...),


### PR DESCRIPTION
The `size.Of()` already returns recursive size including postings cloner, so we don't need to add `EstimateSize()`. Instead, track the actual number of postings separately and add it to spans for better observability.

Previously we incorrectly estimated postings count as size/8, but the size includes more than just postings data.

follow-up of #970