### PR TITLE
Support providing postings cache factory instances when opening a DB

### DIFF
--- a/tsdb/postings_for_matchers_cache.go
+++ b/tsdb/postings_for_matchers_cache.go
@@ -93,13 +93,13 @@ var DefaultPostingsForMatchersCacheFactory = NewPostingsForMatchersCacheFactory(
 //   - `force` indicates that all requests should go through cache, regardless of the `concurrent` param provided to the PostingsForMatchers method.
 //   - `metrics` the metrics that should be used by the produced caches.
 func NewPostingsForMatchersCacheFactory(shared bool, keyFunc CacheKeyFunc, invalidation bool, cacheVersions int, ttl time.Duration, maxItems int, maxBytes int64, force bool, metrics *PostingsForMatchersCacheMetrics) PostingsForMatchersCacheFactory {
-	var mv *metricVersions
-	if shared && invalidation {
-		mv = &metricVersions{
-			versions: make([]atomic.Int64, cacheVersions),
-		}
-	}
 	factoryFunc := func(tracingKV []attribute.KeyValue) *PostingsForMatchersCache {
+		var mv *metricVersions
+		if shared && invalidation {
+			mv = &metricVersions{
+				versions: make([]atomic.Int64, cacheVersions),
+			}
+		}
 		return &PostingsForMatchersCache{
 			calls:            &sync.Map{},
 			cached:           list.New(),


### PR DESCRIPTION
This change adds support for providing a postings cache factory for head and compacted blocks when opening a DB, rather than requiring them to be constructed internally. This allows the same factory to be used, if desired, across DBs.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
