### PR TITLE
labels: Adjust cost estimates

### DIFF
--- a/model/labels/cost.go
+++ b/model/labels/cost.go
@@ -16,17 +16,14 @@ package labels
 import "github.com/grafana/regexp/syntax"
 
 const (
-	// TODO verify relative magnitude of these costs.
 	estimatedStringEqualityCost          = 1.0
-	estimatedStringHasPrefixCost         = 0.5
-	estimatedSliceContainsCostPerElement = 1.0
-	estimatedMapContainsCostPerElement   = 0.01
-	estimatedRegexMatchCost              = 10.0
+	estimatedStringHasPrefixCost         = 1.0
+	estimatedSliceContainsCostPerElement = 1.1
+	estimatedMapContainsCost             = 4.0
 )
 
 // SingleMatchCost returns the fixed cost of running this matcher against an arbitrary label value..
 // TODO benchmark relative cost of different matchers.
-// TODO use the complexity of the regex string as a cost.
 func (m *Matcher) SingleMatchCost() float64 {
 	switch m.Type {
 	case MatchEqual, MatchNotEqual:
@@ -39,8 +36,8 @@ func (m *Matcher) SingleMatchCost() float64 {
 		}
 
 		// If we have a string matcher with a map, use that
-		if mm, ok := m.re.stringMatcher.(*equalMultiStringMapMatcher); ok {
-			return estimatedMapContainsCostPerElement*float64(len(mm.values)) + estimatedStringEqualityCost
+		if _, ok := m.re.stringMatcher.(*equalMultiStringMapMatcher); ok {
+			return estimatedMapContainsCost
 		}
 
 		// If we have a prefix optimization, use that

--- a/model/labels/postings_bench_test.go
+++ b/model/labels/postings_bench_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Grafana Labs
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+// Benchmark iterating over postings lists of different sizes
+func BenchmarkIteratePostings(b *testing.B) {
+	// Helper function to create a slice of SeriesRef with given size
+	createSeriesRefs := func(size int) []storage.SeriesRef {
+		refs := make([]storage.SeriesRef, size)
+		for i := 0; i < size; i++ {
+			refs[i] = storage.SeriesRef(i + 1) // SeriesRef 0 is invalid, start from 1
+		}
+		return refs
+	}
+
+	benchmarks := []struct {
+		name string
+		size int
+	}{
+		{"Size_1", 1},
+		{"Size_32", 32},
+		{"Size_128", 128},
+		{"Size_512", 512},
+		{"Size_2048", 2048},
+		{"Size_32K", 32 * 1024},
+		{"Size_64K", 64 * 1024},
+		{"Size_128K", 128 * 1024},
+		{"Size_256K", 256 * 1024},
+		{"Size_512K", 512 * 1024},
+		{"Size_1M", 1024 * 1024},
+	}
+
+	for _, bm := range benchmarks {
+		refs := createSeriesRefs(bm.size)
+
+		b.Run(bm.name, func(b *testing.B) {
+			b.ResetTimer()
+			var count int
+			for i := 0; i < b.N; i++ {
+				// Reset postings for each iteration
+				p := index.NewListPostings(refs)
+				count = 0
+				for p.Next() {
+					_ = p.At() // Access the current value
+					count++
+				}
+			}
+			if count != bm.size {
+				b.Fatalf("unexpected count: got %d, want %d", count, bm.size)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Updated the cost model to use a fixed cost for map operations rather than per-element cost. Also added benchmarks to help compare the cost of these with each other.


<details><summary>apple silicon arm64 benchmarks</summary>
<p>

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M1 Pro
                                                    │ StringEquality │  StringHasPrefix   │   SliceContains    │    MapContains     │
                                                    │     sec/op     │   sec/op     vs base   │   sec/op     vs base   │   sec/op     vs base   │
CostEstimation/flavour=Equal_8chars-10                   2.056n ± 1%
CostEstimation/flavour=Equal_32chars-10                  2.728n ± 0%
CostEstimation/flavour=Equal_64chars-10                  2.565n ± 0%
CostEstimation/flavour=NotEqual_8chars-10                2.222n ± 0%
CostEstimation/flavour=NotEqual_32chars-10               2.064n ± 1%
CostEstimation/flavour=NotEqual_64chars-10               2.252n ± 0%
CostEstimation/flavour=ShortPrefix_8chars_Match-10                     2.158n ± 0%
CostEstimation/flavour=LongPrefix_32chars_Match-10                     2.720n ± 1%
CostEstimation/flavour=NearMiss_LastChar_32times-10                    2.400n ± 1%
CostEstimation/flavour=Size_1-10                                                            2.239n ± 0%
CostEstimation/flavour=Size_2-10                                                            3.175n ± 1%          7.053n ± 2%
CostEstimation/flavour=Size_8-10                                                            5.050n ± 0%
CostEstimation/flavour=Size_16-10                                                           7.557n ± 1%          9.596n ± 6%
CostEstimation/flavour=Size_32-10                                                                                9.556n ± 6%
CostEstimation/flavour=Size_128-10                                                                               9.791n ± 7%
CostEstimation/flavour=Size_256-10                                                                               9.631n ± 8%
geomean                                                  2.301n        2.415n       ? ¹ ²   4.058n       ? ¹ ²   9.058n       ? ¹ ²
¹ benchmark set differs from baseline; geomeans may not be comparable
```

</p>
</details> 