### PR TITLE
Add function to fsync all segments until the current one

### DIFF
--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -1046,3 +1046,32 @@ func (r *segmentBufReader) Read(b []byte) (n int, err error) {
 func (w *WL) Size() (int64, error) {
 	return fileutil.DirSize(w.Dir())
 }
+
+func (w *WL) FsyncSegmentsUntilCurrent() error {
+	var err error
+	w.mtx.Lock()
+	// fsync current segment within mutex to avoid race conditions where the segment could be updated or closed
+	if w.closed {
+		w.mtx.Unlock()
+		return errors.New("unable to fsync segments: write log is closed")
+	}
+	if w.segment != nil {
+		err = w.fsync(w.segment)
+	}
+	w.mtx.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{})
+	// all previous segments before w.segment should either have been fsynced and closed or still in the actorc queue
+	// waiting for all previous segments to complete fsync before marking as done
+	select {
+	case w.actorc <- func() { close(done) }:
+		<-done
+		return nil
+	default:
+		return errors.New("skipping fsync previous segments confirmation: actor channel full")
+	}
+}

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -591,23 +591,6 @@ func TestSyncSegmentsUntilCurrent(t *testing.T) {
 		require.NoError(t, w.FsyncSegmentsUntilCurrent())
 	})
 
-	t.Run("sync fails when channel is full", func(t *testing.T) {
-		dir := t.TempDir()
-		w, err := NewSize(nil, nil, dir, pageSize, compression.None)
-		require.NoError(t, err)
-		defer w.Close()
-
-		// Fill actor channel with blocked functions so we can ensure it's full when calling FsyncSegmentsUntilCurrent()
-		block := make(chan struct{})
-		defer close(block)
-		for i := 0; i <= cap(w.actorc); i++ {
-			w.actorc <- func() { <-block }
-		}
-
-		err = w.FsyncSegmentsUntilCurrent()
-		require.EqualError(t, err, "skipping fsync previous segments confirmation: actor channel full")
-	})
-
 	t.Run("sync fails when WAL is closed", func(t *testing.T) {
 		dir := t.TempDir()
 		w, err := NewSize(nil, nil, dir, pageSize, compression.None)


### PR DESCRIPTION
fsyncs for the WAL/WBL do not happen every time a record is logged, see: https://github.com/prometheus/prometheus/issues/5869

This means that if Mimir is shut down uncleanly, it's possible for there to be WAL corruption errors due to not all data being written to disk before shutdown.

Adding a `FsyncSegmentsUntilCurrent()` function which will ensure all segments up until the current one have been fsycned before returning. Also added a corresponding function for the tsdb head, so it can be called from Mimir code.