### PR TITLE
fix(tsdb): backport zero sample schema optimization from pr 17071 

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -788,6 +788,10 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 		zeroHistogram := &histogram.Histogram{
 			// The CTZeroSample represents a counter reset by definition.
 			CounterResetHint: histogram.CounterReset,
+			// Replicate other fields to avoid needless chunk creation.
+			Schema:        h.Schema,
+			ZeroThreshold: h.ZeroThreshold,
+			CustomValues:  h.CustomValues,
 		}
 		s.Lock()
 
@@ -829,6 +833,10 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 		zeroFloatHistogram := &histogram.FloatHistogram{
 			// The CTZeroSample represents a counter reset by definition.
 			CounterResetHint: histogram.CounterReset,
+			// Replicate other fields to avoid needless chunk creation.
+			Schema:        fh.Schema,
+			ZeroThreshold: fh.ZeroThreshold,
+			CustomValues:  fh.CustomValues,
 		}
 		s.Lock()
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7055,7 +7055,27 @@ func TestHeadAppender_AppendFloatWithSameTimestampAsPreviousHistogram(t *testing
 
 func TestHeadAppender_AppendCT(t *testing.T) {
 	testHistogram := tsdbutil.GenerateTestHistogram(1)
+	testHistogram.CounterResetHint = histogram.NotCounterReset
 	testFloatHistogram := tsdbutil.GenerateTestFloatHistogram(1)
+	testFloatHistogram.CounterResetHint = histogram.NotCounterReset
+	// TODO(beorn7): Once issue #15346 is fixed, the CounterResetHint of the
+	// following two zero histograms should be histogram.CounterReset.
+	testZeroHistogram := &histogram.Histogram{
+		Schema:          testHistogram.Schema,
+		ZeroThreshold:   testHistogram.ZeroThreshold,
+		PositiveSpans:   testHistogram.PositiveSpans,
+		NegativeSpans:   testHistogram.NegativeSpans,
+		PositiveBuckets: []int64{0, 0, 0, 0},
+		NegativeBuckets: []int64{0, 0, 0, 0},
+	}
+	testZeroFloatHistogram := &histogram.FloatHistogram{
+		Schema:          testFloatHistogram.Schema,
+		ZeroThreshold:   testFloatHistogram.ZeroThreshold,
+		PositiveSpans:   testFloatHistogram.PositiveSpans,
+		NegativeSpans:   testFloatHistogram.NegativeSpans,
+		PositiveBuckets: []float64{0, 0, 0, 0},
+		NegativeBuckets: []float64{0, 0, 0, 0},
+	}
 	type appendableSamples struct {
 		ts      int64
 		fSample float64
@@ -7087,12 +7107,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, h: testHistogram, ct: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
-				hNoCounterReset := *testHistogram
-				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, h: &histogram.Histogram{}},
+					sample{t: 1, h: testZeroHistogram},
 					sample{t: 100, h: testHistogram},
-					sample{t: 101, h: &hNoCounterReset},
+					sample{t: 101, h: testHistogram},
 				}
 			}(),
 		},
@@ -7103,12 +7121,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, fh: testFloatHistogram, ct: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
-				fhNoCounterReset := *testFloatHistogram
-				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, fh: &histogram.FloatHistogram{}},
+					sample{t: 1, fh: testZeroFloatHistogram},
 					sample{t: 100, fh: testFloatHistogram},
-					sample{t: 101, fh: &fhNoCounterReset},
+					sample{t: 101, fh: testFloatHistogram},
 				}
 			}(),
 		},
@@ -7131,12 +7147,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, h: testHistogram, ct: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
-				hNoCounterReset := *testHistogram
-				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, h: &histogram.Histogram{}},
+					sample{t: 1, h: testZeroHistogram},
 					sample{t: 100, h: testHistogram},
-					sample{t: 101, h: &hNoCounterReset},
+					sample{t: 101, h: testHistogram},
 				}
 			}(),
 		},
@@ -7147,12 +7161,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, fh: testFloatHistogram, ct: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
-				fhNoCounterReset := *testFloatHistogram
-				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, fh: &histogram.FloatHistogram{}},
+					sample{t: 1, fh: testZeroFloatHistogram},
 					sample{t: 100, fh: testFloatHistogram},
-					sample{t: 101, fh: &fhNoCounterReset},
+					sample{t: 101, fh: testFloatHistogram},
 				}
 			}(),
 		},
@@ -7176,9 +7188,9 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 102, h: testHistogram, ct: 101},
 			},
 			expectedSamples: []chunks.Sample{
-				sample{t: 1, h: &histogram.Histogram{}},
+				sample{t: 1, h: testZeroHistogram},
 				sample{t: 100, h: testHistogram},
-				sample{t: 101, h: &histogram.Histogram{CounterResetHint: histogram.UnknownCounterReset}},
+				sample{t: 101, h: testZeroHistogram},
 				sample{t: 102, h: testHistogram},
 			},
 		},
@@ -7189,9 +7201,9 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 102, fh: testFloatHistogram, ct: 101},
 			},
 			expectedSamples: []chunks.Sample{
-				sample{t: 1, fh: &histogram.FloatHistogram{}},
+				sample{t: 1, fh: testZeroFloatHistogram},
 				sample{t: 100, fh: testFloatHistogram},
-				sample{t: 101, fh: &histogram.FloatHistogram{CounterResetHint: histogram.UnknownCounterReset}},
+				sample{t: 101, fh: testZeroFloatHistogram},
 				sample{t: 102, fh: testFloatHistogram},
 			},
 		},
@@ -7214,12 +7226,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, h: testHistogram, ct: 100},
 			},
 			expectedSamples: func() []chunks.Sample {
-				hNoCounterReset := *testHistogram
-				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, h: &histogram.Histogram{}},
+					sample{t: 1, h: testZeroHistogram},
 					sample{t: 100, h: testHistogram},
-					sample{t: 101, h: &hNoCounterReset},
+					sample{t: 101, h: testHistogram},
 				}
 			}(),
 		},
@@ -7230,12 +7240,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 				{ts: 101, fh: testFloatHistogram, ct: 100},
 			},
 			expectedSamples: func() []chunks.Sample {
-				fhNoCounterReset := *testFloatHistogram
-				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
-					sample{t: 1, fh: &histogram.FloatHistogram{}},
+					sample{t: 1, fh: testZeroFloatHistogram},
 					sample{t: 100, fh: testFloatHistogram},
-					sample{t: 101, fh: &fhNoCounterReset},
+					sample{t: 101, fh: testFloatHistogram},
 				}
 			}(),
 		},


### PR DESCRIPTION
Cherry pick of #1000 from r360.

* fix(tsdb): backport zero sample schema optimization from pr 17071

There is an optimization in
https://github.com/prometheus/prometheus/pull/17071 that ensures that the injected zero histogram sample has the same schema as the next sample.

It turns out that if there are at least three samples: a normal sample (schema>0), zero sample(schema=0), normal sample (schema>0) then the histogram rate function will find the lowest schema and normalize all to that, meaning that the normal samples will be downscaled to schema 0. In dashboards it will look like as if we lost the resolution.

See https://github.com/prometheus/prometheus/blob/9e4d23ddafcdc00021cd8630e78bb819e84ccac9/promql/functions.go#L344

So the optimization is actually needed to not loose resolution on read back. Alternatively we should use per sample CT as metadata instead, but that would be a big rewrite of TSDB and PromQL.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
