### PR TITLE
ci: update PR comment instructions in merge prometheus upstream workflow

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -263,7 +263,7 @@ jobs:
             # 5. Re-open the closed PR
 
             # 6. Post the remerge diff as a comment for reviewers:
-            gh pr comment --body "## Merge Conflict Resolution
+            gh pr comment -R grafana/mimir-prometheus --body "## Merge Conflict Resolution
 
             You can review how conflicts were resolved using:
 


### PR DESCRIPTION
This PR adds the `-R` so `gh` looks for the PR in this repository, and not upstream.