### PR TITLE
ruler: add optional failure classidier hook through manager Options

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -87,32 +87,18 @@ type Group struct {
 // DefaultEvalIterationFunc is the default implementation.
 type GroupEvalIterationFunc func(ctx context.Context, g *Group, evalTimestamp time.Time)
 
-// OperatorControllableErrorClassifier classifies whether rule evaluation errors are operator-controllable.
-type OperatorControllableErrorClassifier interface {
-	IsOperatorControllable(error) bool
-}
-
 type GroupOptions struct {
-	Name, File                          string
-	Interval                            time.Duration
-	Limit                               int
-	Rules                               []Rule
-	SourceTenants                       []string
-	ShouldRestore                       bool
-	Opts                                *ManagerOptions
-	QueryOffset                         *time.Duration
-	done                                chan struct{}
-	EvalIterationFunc                   GroupEvalIterationFunc
-	AlignEvaluationTimeOnInterval       bool
-	OperatorControllableErrorClassifier OperatorControllableErrorClassifier
-}
-
-// DefaultOperatorControllableErrorClassifier is the default implementation of
-// OperatorControllableErrorClassifier that classifies no errors as operator-controllable.
-type DefaultOperatorControllableErrorClassifier struct{}
-
-func (*DefaultOperatorControllableErrorClassifier) IsOperatorControllable(_ error) bool {
-	return false
+	Name, File                    string
+	Interval                      time.Duration
+	Limit                         int
+	Rules                         []Rule
+	SourceTenants                 []string
+	ShouldRestore                 bool
+	Opts                          *ManagerOptions
+	QueryOffset                   *time.Duration
+	done                          chan struct{}
+	EvalIterationFunc             GroupEvalIterationFunc
+	AlignEvaluationTimeOnInterval bool
 }
 
 // NewGroup makes a new Group with the given name, options, and rules.
@@ -144,11 +130,6 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc = DefaultEvalIterationFunc
 	}
 
-	operatorControllableErrorClassifier := o.OperatorControllableErrorClassifier
-	if operatorControllableErrorClassifier == nil {
-		operatorControllableErrorClassifier = &DefaultOperatorControllableErrorClassifier{}
-	}
-
 	if opts.Logger == nil {
 		opts.Logger = promslog.NewNopLogger()
 	}
@@ -172,7 +153,7 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc:                   evalIterationFunc,
 		appOpts:                             &storage.AppendOptions{DiscardOutOfOrder: true},
 		alignEvaluationTimeOnInterval:       o.AlignEvaluationTimeOnInterval,
-		operatorControllableErrorClassifier: operatorControllableErrorClassifier,
+		operatorControllableErrorClassifier: opts.OperatorControllableErrorClassifier,
 	}
 }
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -109,6 +109,19 @@ type NotifyFunc func(ctx context.Context, expr string, alerts ...*Alert)
 
 type ContextWrapFunc func(ctx context.Context, g *Group) context.Context
 
+// OperatorControllableErrorClassifier classifies whether rule evaluation errors are operator-controllable.
+type OperatorControllableErrorClassifier interface {
+	IsOperatorControllable(error) bool
+}
+
+// DefaultOperatorControllableErrorClassifier is the default implementation of
+// OperatorControllableErrorClassifier that classifies no errors as operator-controllable.
+type DefaultOperatorControllableErrorClassifier struct{}
+
+func (*DefaultOperatorControllableErrorClassifier) IsOperatorControllable(_ error) bool {
+	return false
+}
+
 // ManagerOptions bundles options for the Manager.
 type ManagerOptions struct {
 	NameValidationScheme      model.ValidationScheme
@@ -139,6 +152,10 @@ type ManagerOptions struct {
 	GroupEvaluationContextFunc ContextWrapFunc
 
 	Metrics *Metrics
+
+	// OperatorControllableErrorClassifier classifies rule evaluation errors as operator-controllable
+	// or user-controllable. If nil, defaults to treating all errors as user errors.
+	OperatorControllableErrorClassifier OperatorControllableErrorClassifier
 }
 
 // NewManager returns an implementation of Manager, ready to be started
@@ -177,6 +194,10 @@ func NewManager(o *ManagerOptions) *Manager {
 
 	if o.Logger == nil {
 		o.Logger = promslog.NewNopLogger()
+	}
+
+	if o.OperatorControllableErrorClassifier == nil {
+		o.OperatorControllableErrorClassifier = &DefaultOperatorControllableErrorClassifier{}
 	}
 
 	m := &Manager{


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Part of https://github.com/grafana/mimir-squad/issues/3255

Refactor https://github.com/grafana/mimir-prometheus/pull/988. However I missed that more things needs to be update in order to access that field OperatorControllableErrorClassifier  and set it through [GroupOptions](https://github.com/grafana/mimir/blob/d830911e03e49707bc2cb1f7723303438142e87e/vendor/github.com/prometheus/prometheus/rules/group.go#L107)

In this PR we expose the hook from ManagerOptions we can easily pass as a parameter which we can easily access [here](https://github.com/grafana/mimir/blob/d830911e03e49707bc2cb1f7723303438142e87e/vendor/github.com/prometheus/prometheus/rules/manager.go#L394) 