### PR TITLE
Add regex optimization for simple contains alternations

### DIFF
--- a/model/labels/cost_test.go
+++ b/model/labels/cost_test.go
@@ -31,7 +31,7 @@ var matcherTestCases = []struct {
 	t    MatchType
 	v    string
 }{
-	//= matchers
+	// = matchers
 	{1, "__name__", MatchEqual, "mimir_target_series_per_ingester"},
 	{1, "__name__", MatchEqual, "cortex_partition_ring_partitions"},
 	{1, "container", MatchEqual, "distributor"},

--- a/model/labels/cost_test.go
+++ b/model/labels/cost_test.go
@@ -31,7 +31,7 @@ var matcherTestCases = []struct {
 	t    MatchType
 	v    string
 }{
-	// = matchers
+	//= matchers
 	{1, "__name__", MatchEqual, "mimir_target_series_per_ingester"},
 	{1, "__name__", MatchEqual, "cortex_partition_ring_partitions"},
 	{1, "container", MatchEqual, "distributor"},
@@ -68,7 +68,7 @@ var matcherTestCases = []struct {
 	{1.1, "namespace", MatchRegexp, "ops-service-01"},
 	{4.4, "route", MatchRegexp, "api_(v1|prom)_push|otlp_v1_metrics|api_v1_push_influx_write"},
 	{7, "route", MatchRegexp, ".*v1.*|.*prom.*"},
-	{14, "__name__", MatchRegexp, ".*foo.*|.*bar.*|.*baz.*|.*barn.*|.*bank.*"},
+	{18, "__name__", MatchRegexp, ".*foo.*|.*bar.*|.*baz.*|.*barn.*|.*bank.*"},
 	{1, "job", MatchRegexp, "(prod-service-05)/((gateway|cortex-gw.*))"},
 	{1, "job", MatchRegexp, "(ops-service-01)/((compactor.*|cortex|mimir))"},
 	{1.1, "namespace", MatchRegexp, "prod-service-06"},

--- a/model/labels/cost_test.go
+++ b/model/labels/cost_test.go
@@ -68,6 +68,7 @@ var matcherTestCases = []struct {
 	{1.1, "namespace", MatchRegexp, "ops-service-01"},
 	{4.4, "route", MatchRegexp, "api_(v1|prom)_push|otlp_v1_metrics|api_v1_push_influx_write"},
 	{7, "route", MatchRegexp, ".*v1.*|.*prom.*"},
+	{14, "__name__", MatchRegexp, ".*foo.*|.*bar.*|.*baz.*|.*barn.*|.*bank.*"},
 	{1, "job", MatchRegexp, "(prod-service-05)/((gateway|cortex-gw.*))"},
 	{1, "job", MatchRegexp, "(ops-service-01)/((compactor.*|cortex|mimir))"},
 	{1.1, "namespace", MatchRegexp, "prod-service-06"},

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -434,14 +434,14 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 			return r
 		}
 		concatSubs := sub.Sub
-		if isCaseSensitiveLiteral(concatSubs[1]) && isMatchAny(concatSubs[0]) && isMatchAny(concatSubs[2]) {
-			containsStrings = append(containsStrings, concatSubs[1].String())
-		} else {
+		if !(isCaseSensitiveLiteral(concatSubs[1]) && isMatchAny(concatSubs[0]) && isMatchAny(concatSubs[2])) {
 			return r
 		}
+		containsStrings = append(containsStrings, concatSubs[1].String())
 	}
 
-	if len(containsStrings) > 0 {
+	// Only rewrite the regex if there's more than one literal
+	if len(containsStrings) > 1 {
 		newRegex := fmt.Sprintf(".*(?:%v).*", strings.Join(containsStrings, "|"))
 		parsed, err := syntax.Parse(newRegex, syntax.Perl|syntax.DotNL)
 		if err != nil {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -442,13 +442,14 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 	// Only rewrite the regex if there's more than one literal
 	if len(containsLiterals) > 1 {
 		returnRegex := &syntax.Regexp{Op: syntax.OpConcat}
-		anyMatcher := &syntax.Regexp{Op: syntax.OpStar, Sub: []*syntax.Regexp{{Op: syntax.OpAnyChar}}, Flags: syntax.Perl | syntax.DotNL}
+		prefixAnyMatcher := &syntax.Regexp{Op: syntax.OpStar, Sub: []*syntax.Regexp{{Op: syntax.OpAnyChar}}, Flags: syntax.Perl | syntax.DotNL}
+		suffixAnyMatcher := &syntax.Regexp{Op: syntax.OpStar, Sub: []*syntax.Regexp{{Op: syntax.OpAnyChar}}, Flags: syntax.Perl | syntax.DotNL}
 		alts := &syntax.Regexp{Op: syntax.OpAlternate}
-		alts.Sub = append(alts.Sub, containsLiterals...)
+		alts.Sub = containsLiterals
 		returnRegex.Sub = []*syntax.Regexp{
-			anyMatcher,
+			prefixAnyMatcher,
 			alts,
-			anyMatcher,
+			suffixAnyMatcher,
 		}
 		return returnRegex
 	}

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -433,7 +433,7 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 			return r
 		}
 		concatSubs := sub.Sub
-		if !(isCaseSensitiveLiteral(concatSubs[1]) && isMatchAny(concatSubs[0]) && isMatchAny(concatSubs[2])) {
+		if !isCaseSensitiveLiteral(concatSubs[1]) || !isMatchAny(concatSubs[0]) || !isMatchAny(concatSubs[2]) {
 			return r
 		}
 		containsLiterals = append(containsLiterals, concatSubs[1])
@@ -444,9 +444,7 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 		returnRegex := &syntax.Regexp{Op: syntax.OpConcat}
 		anyMatcher := &syntax.Regexp{Op: syntax.OpStar, Sub: []*syntax.Regexp{{Op: syntax.OpAnyChar}}, Flags: syntax.Perl | syntax.DotNL}
 		alts := &syntax.Regexp{Op: syntax.OpAlternate}
-		for _, alt := range containsLiterals {
-			alts.Sub = append(alts.Sub, alt)
-		}
+		alts.Sub = append(alts.Sub, containsLiterals...)
 		returnRegex.Sub = []*syntax.Regexp{
 			anyMatcher,
 			alts,

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -554,7 +554,7 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"(?s)(ext.?|xfs)", orStringMatcher{&literalPrefixSensitiveStringMatcher{prefix: "ext", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}, &equalStringMatcher{s: "xfs", caseSensitive: true}}},
 		{"foo.?", &literalPrefixSensitiveStringMatcher{prefix: "foo", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}},
 		{"f.?o", nil},
-		{".*foo.*|.*bar.*|.*baz.*", &containsStringMatcher{left: trueMatcher{}, substrings: []string{"bar", "baz", "foo"}, right: trueMatcher{}}},
+		{".*foo.*|.*bar.*|.*baz.*", &containsStringMatcher{left: trueMatcher{}, substrings: []string{"foo", "bar", "baz"}, right: trueMatcher{}}},
 	} {
 		t.Run(c.pattern, func(t *testing.T) {
 			t.Parallel()

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -40,6 +40,7 @@ var (
 		"foo()",
 		"^foo",
 		"(foo|bar)",
+		".*foo.*|",
 		".*foo.*|bar.*",
 		"foo.*|.*bar.*",
 		".*foo.*|.*bar.*",
@@ -1759,15 +1760,15 @@ func visitStringMatcher(matcher StringMatcher, callback func(matcher StringMatch
 
 func TestToNormalisedLower(t *testing.T) {
 	testCases := map[string]string{
-		"foo":                      "foo",
-		"FOO":                      "foo",
-		"Foo":                      "foo",
-		"foO":                      "foo",
-		"fOo":                      "foo",
-		"AAAAAAAAAAAAAAAAAAAAAAAA": "aaaaaaaaaaaaaaaaaaaaaaaa",
-		"cccccccccccccccccccccccC": "cccccccccccccccccccccccc",
+		"foo":                       "foo",
+		"FOO":                       "foo",
+		"Foo":                       "foo",
+		"foO":                       "foo",
+		"fOo":                       "foo",
+		"AAAAAAAAAAAAAAAAAAAAAAAA":  "aaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccC":  "cccccccccccccccccccccccc",
 		"ſſſſſſſſſſſſſſſſſſſſſſſſS": "sssssssssssssssssssssssss",
-		"ſſAſſa": "ssassa",
+		"ſſAſſa":                    "ssassa",
 	}
 	for input, expectedOutput := range testCases {
 		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -1760,15 +1760,15 @@ func visitStringMatcher(matcher StringMatcher, callback func(matcher StringMatch
 
 func TestToNormalisedLower(t *testing.T) {
 	testCases := map[string]string{
-		"foo":                       "foo",
-		"FOO":                       "foo",
-		"Foo":                       "foo",
-		"foO":                       "foo",
-		"fOo":                       "foo",
-		"AAAAAAAAAAAAAAAAAAAAAAAA":  "aaaaaaaaaaaaaaaaaaaaaaaa",
-		"cccccccccccccccccccccccC":  "cccccccccccccccccccccccc",
+		"foo":                      "foo",
+		"FOO":                      "foo",
+		"Foo":                      "foo",
+		"foO":                      "foo",
+		"fOo":                      "foo",
+		"AAAAAAAAAAAAAAAAAAAAAAAA": "aaaaaaaaaaaaaaaaaaaaaaaa",
+		"cccccccccccccccccccccccC": "cccccccccccccccccccccccc",
 		"ſſſſſſſſſſſſſſſſſſſſſſſſS": "sssssssssssssssssssssssss",
-		"ſſAſſa":                    "ssassa",
+		"ſſAſſa": "ssassa",
 	}
 	for input, expectedOutput := range testCases {
 		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -40,6 +40,9 @@ var (
 		"foo()",
 		"^foo",
 		"(foo|bar)",
+		".*foo.*|bar.*",
+		"foo.*|.*bar.*",
+		".*foo.*|.*bar.*",
 		"foo.*",
 		".*foo",
 		"^.*foo$",
@@ -105,6 +108,7 @@ var (
 		"((.*))(?i:f)((.*))o((.*))o((.*))",
 		"((.*))f((.*))(?i:o)((.*))o((.*))",
 		"(.*0.*)",
+		".*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuuSoAl.*|.*qbvKMimS.*|.*IecrXtPa.*|.*seTckYqt.*|.*NxnyHkgB.*|.*fIDlOgKb.*|.*UhlWIygH.*|.*OtNoJxHG.*|.*cUTkFVIV.*|.*mTgFIHjr.*|.*jQkoIDtE.*|.*PPMKxRXl.*|.*AwMfwVkQ.*|.*CQyMrTQJ.*|.*BzrqxVSi.*|.*nTpcWuhF.*|.*PertdywG.*|.*ZZDgCtXN.*|.*WWdDPyyE.*|.*uVtNQsKk.*|.*BdeCHvPZ.*|.*wshRnFlH.*|.*aOUIitIp.*|.*RxZeCdXT.*|.*CFZMslCj.*|.*AVBZRDxl.*|.*IzIGCnhw.*|.*ythYuWiz.*|.*oztXVXhl.*|.*VbLkwqQx.*|.*qvaUgyVC.*|.*VawUjPWC.*|.*ecloYJuj.*|.*boCLTdSU.*|.*uPrKeAZx.*|.*hrMWLWBq.*|.*JOnUNHRM.*|.*rYnujkPq.*|.*dDEdZhIj.*|.*DRrfvugG.*|.*yEGfDxVV.*|.*YMYdJWuP.*|.*PHUQZNWM.*|.*AmKNrLis.*|.*zTxndVfn.*|.*FPsHoJnc.*|.*EIulZTua.*|.*KlAPhdzg.*|.*ScHJJCLt.*|.*NtTfMzME.*|.*eMCwuFdo.*|.*SEpJVJbR.*|.*cdhXZeCx.*|.*sAVtBwRh.*|.*kVFEVcMI.*|.*jzJrxraA.*|.*tGLHTell.*|.*NNWoeSaw.*|.*DcOKSetX.*|.*UXZAJyka.*|.*THpMphDP.*|.*rizheevl.*|.*kDCBRidd.*|.*pCZZRqyu.*|.*pSygkitl.*|.*SwZGkAaW.*|.*wILOrfNX.*|.*QkwVOerj.*|.*kHOMxPDr.*|.*EwOVycJv.*|.*AJvtzQFS.*|.*yEOjKYYB.*|.*LizIINLL.*|.*JBRSsfcG.*|.*YPiUqqNl.*|.*IsdEbvee.*|.*MjEpGcBm.*|.*OxXZVgEQ.*|.*xClXGuxa.*|.*UzRCGFEb.*|.*buJbvfvA.*|.*IPZQxRet.*|.*oFYShsMc.*|.*oBHffuHO.*|.*bzzKrcBR.*|.*KAjzrGCl.*|.*IPUsAVls.*|.*OGMUMbIU.*|.*gyDccHuR.*|.*bjlalnDd.*|.*ZLWjeMna.*|.*fdsuIlxQ.*|.*dVXtiomV.*|.*XxedTjNg.*|.*XWMHlNoA.*|.*nnyqArQX.*|.*opfkWGhb.*|.*wYtnhdYb.*",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
@@ -549,6 +553,7 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"(?s)(ext.?|xfs)", orStringMatcher{&literalPrefixSensitiveStringMatcher{prefix: "ext", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}, &equalStringMatcher{s: "xfs", caseSensitive: true}}},
 		{"foo.?", &literalPrefixSensitiveStringMatcher{prefix: "foo", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}},
 		{"f.?o", nil},
+		{".*foo.*|.*bar.*|.*baz.*", &containsStringMatcher{left: trueMatcher{}, substrings: []string{"bar", "baz", "foo"}, right: trueMatcher{}}},
 	} {
 		t.Run(c.pattern, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
When building the FastRegexMatcher, this PR adds a check for regexes of the form `.*foo.*|.*bar.*|.*baz.*` and, if found, rewrites them to `.*(foo|bar|baz).*` before proceeding with other regex optimizations. Using the updated benchmark, this saves us ~15-20% CPU for regexes of this form.

<details><summary>benchmark results</summary>

```
$ benchstat without_optimization_all.txt with_optimization_all.txt
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M2 Pro
                                                        │ without_optimization_all.txt │      with_optimization_all.txt      │
                                                        │            sec/op            │   sec/op     vs base                │
FastRegexMatcher/#00-10                                                    54.62n ± 2%   53.43n ± 0%   -2.18% (p=0.000 n=10)
FastRegexMatcher/()-10                                                     54.27n ± 0%   53.63n ± 0%   -1.18% (p=0.000 n=10)
FastRegexMatcher/foo-10                                                    57.02n ± 0%   56.22n ± 1%   -1.41% (p=0.000 n=10)
FastRegexMatcher/foo()-10                                                  66.54n ± 1%   66.01n ± 5%   -0.80% (p=0.027 n=10)
FastRegexMatcher/^foo-10                                                   66.60n ± 0%   66.12n ± 0%   -0.72% (p=0.000 n=10)
FastRegexMatcher/(foo|bar)-10                                              81.81n ± 2%   81.35n ± 0%        ~ (p=0.063 n=10)
FastRegexMatcher/.*foo.*|-10                                               240.4n ± 0%   240.3n ± 0%        ~ (p=0.269 n=10)
FastRegexMatcher/.*foo.*|bar.*-10                                          277.6n ± 0%   275.9n ± 2%   -0.61% (p=0.022 n=10)
FastRegexMatcher/foo.*|.*bar.*-10                                          276.4n ± 0%   274.1n ± 0%   -0.83% (p=0.000 n=10)
FastRegexMatcher/.*foo.*|.*bar.*-10                                        358.4n ± 0%   292.0n ± 2%  -18.52% (p=0.000 n=10)
FastRegexMatcher/foo.*-10                                                  95.28n ± 0%   95.88n ± 1%   +0.62% (p=0.027 n=10)
FastRegexMatcher/.*foo-10                                                  109.8n ± 0%   110.1n ± 0%   +0.32% (p=0.028 n=10)
FastRegexMatcher/^.*foo$-10                                                109.5n ± 0%   109.9n ± 0%   +0.46% (p=0.000 n=10)
FastRegexMatcher/^.+foo$-10                                                109.7n ± 0%   109.9n ± 1%        ~ (p=0.424 n=10)
FastRegexMatcher/.?-10                                                     77.46n ± 0%   77.97n ± 0%   +0.66% (p=0.001 n=10)
FastRegexMatcher/.*-10                                                     52.73n ± 0%   52.98n ± 1%   +0.46% (p=0.008 n=10)
FastRegexMatcher/().*-10                                                   52.71n ± 2%   53.76n ± 0%   +1.99% (p=0.007 n=10)
FastRegexMatcher/.*()-10                                                   53.87n ± 0%   53.68n ± 0%   -0.35% (p=0.002 n=10)
FastRegexMatcher/().*()-10                                                 53.30n ± 0%   53.42n ± 0%   +0.24% (p=0.034 n=10)
FastRegexMatcher/.+-10                                                     54.62n ± 0%   55.28n ± 0%   +1.20% (p=0.000 n=10)
FastRegexMatcher/.+()-10                                                   54.96n ± 0%   54.69n ± 0%   -0.50% (p=0.004 n=10)
FastRegexMatcher/foo.+-10                                                  95.50n ± 1%   95.98n ± 0%        ~ (p=0.138 n=10)
FastRegexMatcher/.+foo-10                                                  109.8n ± 0%   110.2n ± 0%   +0.41% (p=0.000 n=10)
FastRegexMatcher/foo_.+-10                                                 86.20n ± 0%   86.52n ± 0%   +0.36% (p=0.011 n=10)
FastRegexMatcher/foo_.*-10                                                 86.25n ± 0%   86.42n ± 0%   +0.20% (p=0.020 n=10)
FastRegexMatcher/.*foo.*-10                                                180.0n ± 0%   179.6n ± 1%        ~ (p=0.360 n=10)
FastRegexMatcher/.+foo.+-10                                                194.2n ± 0%   193.2n ± 0%   -0.54% (p=0.000 n=10)
FastRegexMatcher/(?s:.*)-10                                                53.18n ± 5%   52.75n ± 0%        ~ (p=0.342 n=10)
FastRegexMatcher/(?s:.+)-10                                                54.70n ± 0%   54.99n ± 0%   +0.54% (p=0.001 n=10)
FastRegexMatcher/(?s:^.*foo$)-10                                           110.3n ± 1%   109.8n ± 0%   -0.41% (p=0.036 n=10)
FastRegexMatcher/(?i:foo)-10                                               80.91n ± 0%   80.91n ± 0%        ~ (p=0.643 n=10)
FastRegexMatcher/(?i:(foo|bar))-10                                         169.8n ± 0%   168.9n ± 2%   -0.59% (p=0.030 n=10)
FastRegexMatcher/(?i:(foo1|foo2|bar))-10                                   308.1n ± 0%   322.0n ± 1%   +4.50% (p=0.000 n=10)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-10                                    684.7n ± 0%   689.4n ± 3%        ~ (p=0.060 n=10)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-10                       594.4n ± 0%   601.1n ± 0%   +1.12% (p=0.000 n=10)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-10                            455.4n ± 0%   457.2n ± 1%   +0.38% (p=0.022 n=10)
FastRegexMatcher/^$-10                                                     54.03n ± 1%   54.62n ± 0%   +1.10% (p=0.000 n=10)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-10                        170.0n ± 1%   168.1n ± 0%   -1.15% (p=0.000 n=10)
FastRegexMatcher/10\.0\.(1|2)\.+-10                                        86.80n ± 1%   85.92n ± 0%   -1.01% (p=0.000 n=10)
FastRegexMatcher/10\.0\.(1|2).+-10                                         86.85n ± 1%   85.89n ± 0%   -1.12% (p=0.000 n=10)
FastRegexMatcher/((fo(bar))|.+foo)-10                                      205.4n ± 0%   203.6n ± 1%   -0.85% (p=0.010 n=10)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-10                       169.8n ± 1%   167.6n ± 0%   -1.32% (p=0.000 n=10)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-10                       202.0n ± 1%   171.8n ± 1%  -14.95% (p=0.000 n=10)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-10                       605.8n ± 0%   598.8n ± 0%   -1.14% (p=0.000 n=10)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-10                       301.6n ± 0%   301.2n ± 0%        ~ (p=0.100 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-10                       266.6n ± 0%   267.0n ± 1%        ~ (p=0.341 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-10                    479.9n ± 0%   487.0n ± 0%   +1.48% (p=0.000 n=10)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-10                       7.474µ ± 0%   7.492µ ± 0%        ~ (p=0.109 n=10)
FastRegexMatcher/fo.?-10                                                   96.03n ± 0%   96.96n ± 0%   +0.96% (p=0.001 n=10)
FastRegexMatcher/foo.?-10                                                  96.14n ± 0%   96.99n ± 1%   +0.88% (p=0.003 n=10)
FastRegexMatcher/f.?o-10                                                   80.18n ± 1%   80.56n ± 0%   +0.47% (p=0.043 n=10)
FastRegexMatcher/.*foo.?-10                                                192.7n ± 0%   192.7n ± 0%        ~ (p=0.865 n=10)
FastRegexMatcher/.?foo.+-10                                                187.0n ± 0%   187.1n ± 0%        ~ (p=1.000 n=10)
FastRegexMatcher/foo.?|bar-10                                              148.9n ± 0%   150.2n ± 2%   +0.91% (p=0.000 n=10)
FastRegexMatcher/ſſs-10                                                    57.06n ± 0%   57.20n ± 1%   +0.24% (p=0.041 n=10)
FastRegexMatcher/.*-.*-.*-.*-.*-10                                         182.1n ± 0%   183.3n ± 0%   +0.66% (p=0.000 n=10)
FastRegexMatcher/.+-.*-.*-.*-.+-10                                         182.0n ± 2%   182.7n ± 1%        ~ (p=0.466 n=10)
FastRegexMatcher/-.*-.*-.*-.*-10                                           95.91n ± 1%   96.12n ± 0%        ~ (p=0.197 n=10)
FastRegexMatcher/.*-.*-.*-.*--10                                           113.2n ± 0%   112.8n ± 0%   -0.40% (p=0.004 n=10)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-10                               183.9n ± 1%   184.4n ± 3%        ~ (p=0.224 n=10)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-10                       4.287µ ± 1%   4.307µ ± 2%        ~ (p=0.085 n=10)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-10                       3.507µ ± 1%   3.533µ ± 0%   +0.73% (p=0.003 n=10)
FastRegexMatcher/(.*0.*)-10                                                137.1n ± 0%   135.8n ± 0%   -0.98% (p=0.000 n=10)
FastRegexMatcher/.*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuu-10                       15.84µ ± 1%   11.80µ ± 1%  -25.48% (p=0.000 n=10)
FastRegexMatcher_ConcatenatedPattern-10                                    125.8n ± 3%   121.3n ± 0%   -3.62% (p=0.002 n=10)
geomean                                                                    161.5n        159.9n        -1.01%

                                                        │ without_optimization_all.txt │      with_optimization_all.txt       │
                                                        │             cost             │    cost      vs base                 │
FastRegexMatcher/#00-10                                                     1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/()-10                                                      1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo-10                                                     3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo()-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/^foo-10                                                    3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(foo|bar)-10                                               7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo.*|-10                                                5.000 ± 0%    5.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo.*|bar.*-10                                           7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo.*|.*bar.*-10                                           7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo.*|.*bar.*-10                                         7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo.*-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/^.*foo$-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/^.+foo$-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.?-10                                                      1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*-10                                                      10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/().*-10                                                    10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*()-10                                                    10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/().*()-10                                                  10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.+-10                                                      1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.+()-10                                                    1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo.+-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.+foo-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo_.+-10                                                  4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo_.*-10                                                  4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo.*-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.+foo.+-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?s:.*)-10                                                 10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?s:.+)-10                                                 1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?s:^.*foo$)-10                                            3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:foo)-10                                                3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(foo|bar))-10                                          7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(foo1|foo2|bar))-10                                    9.000 ± 0%    9.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/^(?i:foo|oo)|(bar)$-10                                     12.00 ± 0%    12.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-10                        78.00 ± 0%    78.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-10                             12.00 ± 0%    12.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/^$-10                                                      1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-10                         27.00 ± 0%    27.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/10\.0\.(1|2)\.+-10                                         8.000 ± 0%    8.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/10\.0\.(1|2).+-10                                          7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/((fo(bar))|.+foo)-10                                       9.000 ± 0%    9.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-10                        783.0 ± 0%    783.0 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-10                       7.114k ± 0%   7.114k ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-10                        749.0 ± 0%    749.0 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-10                        98.00 ± 0%    98.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-10                        25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-10                     749.0 ± 0%    749.0 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-10                        801.0 ± 0%    801.0 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/fo.?-10                                                    2.000 ± 0%    2.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo.?-10                                                   3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/f.?o-10                                                    3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*foo.?-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.?foo.+-10                                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/foo.?|bar-10                                               7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/ſſs-10                                                     3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*-.*-.*-.*-.*-10                                          54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.+-.*-.*-.*-.+-10                                          34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/-.*-.*-.*-.*-10                                            34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*-.*-.*-.*--10                                            34.00 ± 0%    34.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-10                                7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-10                        23.00 ± 0%    23.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-10                        23.00 ± 0%    23.00 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/(.*0.*)-10                                                 1.000 ± 0%    1.000 ± 0%       ~ (p=1.000 n=10) ¹
FastRegexMatcher/.*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuu-10                        801.0 ± 0%    801.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                     9.169         9.169       +0.00%
¹ all samples are equal
```
</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core regex parsing/compilation and changes the generated regexp for a specific pattern class; risk is mainly subtle semantic regressions if the rewrite incorrectly matches edge-case alternations.
> 
> **Overview**
> `FastRegexMatcher` now detects regexes that are pure alternations of `.*literal.*` (case-sensitive) and rewrites them into a single `.*(literal1|literal2|...).*` syntax tree before compiling and applying other optimizations, improving execution performance for this common pattern.
> 
> Tests are extended to cover mixed/invalid alternation variants and to assert the new optimization produces a `containsStringMatcher`; the matcher cost table is updated with an example `__name__` regex using this form.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51405916c98a1b6a4502f1f74cc99c379317188f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->