### PR TITLE
tsdb: add block stat for number of series with __series_hash__

### DIFF
--- a/tsdb/async_block_writer.go
+++ b/tsdb/async_block_writer.go
@@ -90,6 +90,10 @@ func (bw *asyncBlockWriter) loop() (res asyncBlockWriterResult) {
 
 		stats.NumChunks += uint64(len(sw.chks))
 		stats.NumSeries++
+		if sw.lbls.Has("__series_hash__") {
+			stats.NumSeriesHash++
+		}
+
 		for _, chk := range sw.chks {
 			samples := uint64(chk.Chunk.NumSamples())
 			stats.NumSamples += samples

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -199,6 +199,7 @@ type BlockStats struct {
 	NumFloatSamples     uint64 `json:"numFloatSamples,omitempty"`
 	NumHistogramSamples uint64 `json:"numHistogramSamples,omitempty"`
 	NumSeries           uint64 `json:"numSeries,omitempty"`
+	NumSeriesHash       uint64 `json:"numSeriesHash,omitempty"`
 	NumChunks           uint64 `json:"numChunks,omitempty"`
 	NumTombstones       uint64 `json:"numTombstones,omitempty"`
 }


### PR DESCRIPTION
Include the number of series that have a `__series_hash__` label in block stats. This allows consumers (Mimir compactor) to determine if the TSDB block can be used with projections.

Part https://github.com/grafana/mimir/issues/13863

