### PR TITLE
tsdb: add block stat for number of series with __series_hash__

### DIFF
--- a/tsdb/async_block_writer.go
+++ b/tsdb/async_block_writer.go
@@ -109,6 +109,9 @@ func (bw *asyncBlockWriter) loop() (res asyncBlockWriterResult) {
 		ref++
 	}
 
+	// After we've completed writing all series, we know the cardinality of all labels.
+	stats.NumSeriesHash = bw.indexw.Cardinality("__series_hash__")
+
 	err := bw.closeSemaphore.Acquire(context.Background(), 1)
 	if err != nil {
 		return asyncBlockWriterResult{err: fmt.Errorf("failed to acquire semaphore before closing writers: %w", err)}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -53,6 +53,11 @@ type IndexWriter interface {
 	// that are added later.
 	AddSeries(ref storage.SeriesRef, l labels.Labels, chunks ...chunks.Meta) error
 
+	// Cardinality returns the current cardinality of a label based on the
+	// series that have been written to the index so far. This method should only
+	// be called after AddSeries calls have been completed.
+	Cardinality(lbl string) uint64
+
 	// Close writes any finalization and closes the resources associated with
 	// the underlying writer.
 	Close() error
@@ -199,6 +204,7 @@ type BlockStats struct {
 	NumFloatSamples     uint64 `json:"numFloatSamples,omitempty"`
 	NumHistogramSamples uint64 `json:"numHistogramSamples,omitempty"`
 	NumSeries           uint64 `json:"numSeries,omitempty"`
+	NumSeriesHash       uint64 `json:"numSeriesHash,omitempty"`
 	NumChunks           uint64 `json:"numChunks,omitempty"`
 	NumTombstones       uint64 `json:"numTombstones,omitempty"`
 }

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -619,6 +619,10 @@ func (w *Writer) finishSymbols() error {
 	return nil
 }
 
+func (w *Writer) Cardinality(lbl string) uint64 {
+	return w.labelNames[lbl]
+}
+
 // writePostingsOffsetTable writes the postings offset table.
 func (w *Writer) writePostingsOffsetTable() error {
 	// Ensure everything is in the temporary file.

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -51,6 +51,10 @@ func (m *mockIndexWriter) AddSeries(_ storage.SeriesRef, l labels.Labels, chks .
 	return nil
 }
 
+func (mockIndexWriter) Cardinality(_ string) uint64 {
+	return 0
+}
+
 func (mockIndexWriter) WriteLabelIndex([]string, []string) error { return nil }
 func (mockIndexWriter) Close() error                             { return nil }
 


### PR DESCRIPTION
Include the number of series that have a `__series_hash__` label in block stats. This allows consumers (Mimir compactor) to determine if the TSDB block can be used with projections.

Part grafana/mimir#13863

Alternative to #1125

