### PR TITLE
 tsdb: Memoize memChunk.len() to avoid O(n^2) from PopulateBlock 

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1474,6 +1474,51 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 	}
 }
 
+// BenchmarkCompactionFromHeadManyHeadChunks is like BenchmarkCompactionFromHead but
+// with many head chunks per series (one per sample), as can happen with native
+// histograms. This stresses the linked-list traversal in memSeries.chunk().
+func BenchmarkCompactionFromHeadManyHeadChunks(b *testing.B) {
+	nSeries := 10
+	for _, nChunks := range []int{500, 5000, 50000} {
+		b.Run(fmt.Sprintf("series=%d,chunks=%d", nSeries, nChunks), func(b *testing.B) {
+			dir := b.TempDir()
+			chunkDir := b.TempDir()
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = int64(nChunks+1) * 1000 // Wide enough so nothing gets mmapped.
+			opts.ChunkDirRoot = chunkDir
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
+			require.NoError(b, err)
+
+			app := h.Appender(context.Background())
+			for i := range nSeries {
+				lbls := labels.FromStrings("series", strconv.Itoa(i))
+				for j := range nChunks {
+					// Counter reset on every histogram forces a new head chunk per sample.
+					hist := tsdbutil.GenerateTestHistogram(int64(j))
+					hist.CounterResetHint = histogram.CounterReset
+					_, err := app.AppendHistogram(0, lbls, int64(j)*1000, hist, nil)
+					require.NoError(b, err)
+				}
+			}
+			require.NoError(b, app.Commit())
+
+			// Verify that we have as many chunks per series as expected.
+			for i := range nSeries {
+				lbls := labels.FromStrings("series", strconv.Itoa(i))
+				s := h.series.getByHash(lbls.Hash(), lbls)
+				require.Equal(b, nChunks, s.headChunks.len())
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; b.Loop(); i++ {
+				createBlockFromHead(b, filepath.Join(dir, strconv.Itoa(i)), h)
+			}
+			h.Close()
+		})
+	}
+}
+
 func BenchmarkCompactionFromOOOHead(b *testing.B) {
 	dir := b.TempDir()
 	totalSeries := 100000

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -18,10 +18,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"log/slog"
 	"math"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -320,8 +322,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		opts:   opts,
 		memChunkPool: sync.Pool{
 			New: func() any {
-				mc := newMemChunk(nil, nil)
-				return &mc
+				return &memChunk{}
 			},
 		},
 		stats:             stats,
@@ -1021,7 +1022,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// The head chunk was completed and was m-mapped after taking the snapshot.
 			// Hence remove this chunk.
 			ms.nextAt = 0
-			ms.headChunks = nil
+			ms.clearHeadChunks()
 			ms.app = nil
 		}
 		return nil
@@ -2255,9 +2256,6 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		}
 
 		chunksRemoved += len(series.mmappedChunks)
-		if series.headChunks != nil {
-			chunksRemoved += series.headChunks.len()
-		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
@@ -2312,10 +2310,7 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 			return
 		}
 
-		if series.headChunks != nil {
-			rmChunks += series.headChunks.len()
-		}
-		rmChunks += len(series.mmappedChunks)
+		rmChunks += len(series.mmappedChunks) + series.headChunksLen
 
 		// The series is gone entirely. We need to keep the series lock
 		// and make sure we have acquired the stripe locks for hash and ID of the
@@ -2485,8 +2480,9 @@ type memSeries struct {
 	// Most recent chunks in memory that are still being built or waiting to be mmapped.
 	// This is a linked list, headChunks points to the most recent chunk, headChunks.next points
 	// to older chunk and so on.
-	headChunks   *memChunk
-	firstChunkID chunks.HeadChunkID // HeadChunkID for mmappedChunks[0]
+	headChunks    *memChunk
+	headChunksLen int                // Cached length of headChunks, to avoid O(n)
+	firstChunkID  chunks.HeadChunkID // HeadChunkID for mmappedChunks[0]
 
 	ooo *memSeriesOOOFields
 
@@ -2573,15 +2569,16 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 		for chk != nil {
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
-				removedInOrder = chk.len() + len(s.mmappedChunks)
+				headChunksRemoved := s.headChunksLen - i
+				removedInOrder = headChunksRemoved + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
-					s.headChunks = nil
+					s.clearHeadChunks()
 				} else {
 					// This is NOT the first chunk, unlink it from parent.
 					nextChk.prev = nil
-					s.headChunks.listLen = i
+					s.headChunksLen -= headChunksRemoved
 				}
 				s.mmappedChunks = nil
 				break
@@ -2629,31 +2626,60 @@ func (s *memSeries) cleanupAppendIDsBelow(bound uint64) {
 	}
 }
 
-// memChunk is a node in a linked list of chunks in memory.
-//
-// Prefer building through [newMemChunk] over literals to ensure the length is
-// memoized correctly.
+func (s *memSeries) clearHeadChunks() {
+	s.headChunks = nil
+	s.headChunksLen = 0
+}
+
+func (s *memSeries) appendHeadChunk(next *memChunk) {
+	next.prev = s.headChunks
+	s.headChunks = next
+	s.headChunksLen++
+}
+
+func (s *memSeries) reverseHeadChunks() iter.Seq2[int, *memChunk] {
+	// memSeries.atOffset is O(n), so to avoid quadratic behavior when n is big,
+	// let's copy the list into a slice first and iterate from it instead.
+	const precollectThreshold = 100
+	if s.headChunksLen >= precollectThreshold {
+		tail := make([]*memChunk, 0, s.headChunksLen)
+		chk := s.headChunks
+		for chk != nil {
+			tail = append(tail, chk)
+			chk = chk.prev
+		}
+		return slices.Backward(tail)
+	}
+
+	return func(yield func(int, *memChunk) bool) {
+		for i := s.headChunksLen - 1; i >= 0; i-- {
+			chk := s.headChunks.atOffset(i)
+			if !yield(i, chk) {
+				return
+			}
+		}
+	}
+}
+
 type memChunk struct {
 	chunk            chunkenc.Chunk
 	minTime, maxTime int64
 	prev             *memChunk // Link to the previous element on the list.
-	listLen          int       // Cached length of the linked list starting from this element.
 }
 
-func newMemChunk(chunk chunkenc.Chunk, prev *memChunk) memChunk {
-	listLen := 1
-	if prev != nil {
-		listLen = prev.listLen + 1
+// len returns the length of memChunk list, including the element it was called on.
+// For memSeries.headChunks, consider using memSeries.headChunksLen instead.
+func (mc *memChunk) len() (count int) {
+	if mc.prev == nil {
+		return 1
 	}
-	return memChunk{
-		chunk:   chunk,
-		prev:    prev,
-		listLen: listLen,
-	}
-}
 
-func (mc *memChunk) len() int {
-	return mc.listLen
+	elem := mc
+	for elem != nil {
+		count++
+		elem = elem.prev
+	}
+	return count
 }
 
 // oldest returns the oldest element on the list.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2255,7 +2255,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			staleSeriesDeleted++
 		}
 
-		chunksRemoved += len(series.mmappedChunks)
+		chunksRemoved += len(series.mmappedChunks) + series.headChunksLen
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2640,7 +2640,7 @@ func (s *memSeries) appendHeadChunk(next *memChunk) {
 func (s *memSeries) reverseHeadChunks() iter.Seq2[int, *memChunk] {
 	// memSeries.atOffset is O(n), so to avoid quadratic behavior when n is big,
 	// let's copy the list into a slice first and iterate from it instead.
-	const precollectThreshold = 100
+	const precollectThreshold = 20
 	if s.headChunksLen >= precollectThreshold {
 		tail := make([]*memChunk, 0, s.headChunksLen)
 		chk := s.headChunks

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2573,9 +2573,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 		for chk != nil {
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
-				// Use cached listLen on the head minus the nodes we've already walked
-				// past (i) to get the count from chk to the end of the list.
-				removedInOrder = (s.headChunks.listLen - i) + len(s.mmappedChunks)
+				removedInOrder = chk.len() + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2572,7 +2572,9 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 		for chk != nil {
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
-				removedInOrder = chk.len() + len(s.mmappedChunks)
+				// Use cached listLen on the head minus the nodes we've already walked
+				// past (i) to get the count from chk to the end of the list.
+				removedInOrder = (s.headChunks.listLen - i) + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
@@ -2580,6 +2582,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 				} else {
 					// This is NOT the first chunk, unlink it from parent.
 					nextChk.prev = nil
+					s.headChunks.listLen = i
 				}
 				s.mmappedChunks = nil
 				break
@@ -2631,20 +2634,11 @@ type memChunk struct {
 	chunk            chunkenc.Chunk
 	minTime, maxTime int64
 	prev             *memChunk // Link to the previous element on the list.
+	listLen          int       // Cached length of the linked list starting from this element.
 }
 
-// len returns the length of memChunk list, including the element it was called on.
-func (mc *memChunk) len() (count int) {
-	if mc.prev == nil {
-		return 1
-	}
-
-	elem := mc
-	for elem != nil {
-		count++
-		elem = elem.prev
-	}
-	return count
+func (mc *memChunk) len() int {
+	return mc.listLen
 }
 
 // oldest returns the oldest element on the list.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -320,7 +320,8 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		opts:   opts,
 		memChunkPool: sync.Pool{
 			New: func() any {
-				return &memChunk{}
+				mc := newMemChunk(nil, nil)
+				return &mc
 			},
 		},
 		stats:             stats,
@@ -2630,11 +2631,27 @@ func (s *memSeries) cleanupAppendIDsBelow(bound uint64) {
 	}
 }
 
+// memChunk is a node in a linked list of chunks in memory.
+//
+// Prefer building through [newMemChunk] over literals to ensure the length is
+// memoized correctly.
 type memChunk struct {
 	chunk            chunkenc.Chunk
 	minTime, maxTime int64
 	prev             *memChunk // Link to the previous element on the list.
 	listLen          int       // Cached length of the linked list starting from this element.
+}
+
+func newMemChunk(chunk chunkenc.Chunk, prev *memChunk) memChunk {
+	listLen := 1
+	if prev != nil {
+		listLen = prev.listLen + 1
+	}
+	return memChunk{
+		chunk:   chunk,
+		prev:    prev,
+		listLen: listLen,
+	}
 }
 
 func (mc *memChunk) len() int {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1926,17 +1926,10 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 		return true, false
 	}
 
-	prevLen := 0
-	if s.headChunks != nil {
-		prevLen = s.headChunks.listLen
-	}
-	s.headChunks = &memChunk{
-		chunk:   newChunk,
-		minTime: t,
-		maxTime: t,
-		prev:    s.headChunks,
-		listLen: prevLen + 1,
-	}
+	mc := newMemChunk(newChunk, s.headChunks)
+	mc.minTime = t
+	mc.maxTime = t
+	s.headChunks = &mc
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1988,17 +1981,10 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 		return true, false
 	}
 
-	prevLen := 0
-	if s.headChunks != nil {
-		prevLen = s.headChunks.listLen
-	}
-	s.headChunks = &memChunk{
-		chunk:   newChunk,
-		minTime: t,
-		maxTime: t,
-		prev:    s.headChunks,
-		listLen: prevLen + 1,
-	}
+	mc := newMemChunk(newChunk, s.headChunks)
+	mc.minTime = t
+	mc.maxTime = t
+	s.headChunks = &mc
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -2194,16 +2180,10 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
 	// so this is a single element list most of the time.
-	prevLen := 0
-	if s.headChunks != nil {
-		prevLen = s.headChunks.listLen
-	}
-	s.headChunks = &memChunk{
-		minTime: mint,
-		maxTime: math.MinInt64,
-		prev:    s.headChunks,
-		listLen: prevLen + 1,
-	}
+	mc := newMemChunk(nil, s.headChunks)
+	mc.minTime = mint
+	mc.maxTime = math.MinInt64
+	s.headChunks = &mc
 
 	if chunkenc.IsValidEncoding(e) {
 		var err error

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1926,11 +1926,16 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 		return true, false
 	}
 
+	prevLen := 0
+	if s.headChunks != nil {
+		prevLen = s.headChunks.listLen
+	}
 	s.headChunks = &memChunk{
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
 		prev:    s.headChunks,
+		listLen: prevLen + 1,
 	}
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
@@ -1983,11 +1988,16 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 		return true, false
 	}
 
+	prevLen := 0
+	if s.headChunks != nil {
+		prevLen = s.headChunks.listLen
+	}
 	s.headChunks = &memChunk{
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
 		prev:    s.headChunks,
+		listLen: prevLen + 1,
 	}
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
@@ -2184,10 +2194,15 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
 	// so this is a single element list most of the time.
+	prevLen := 0
+	if s.headChunks != nil {
+		prevLen = s.headChunks.listLen
+	}
 	s.headChunks = &memChunk{
 		minTime: mint,
 		maxTime: math.MinInt64,
 		prev:    s.headChunks,
+		listLen: prevLen + 1,
 	}
 
 	if chunkenc.IsValidEncoding(e) {
@@ -2280,6 +2295,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 
 	// Once we've written out all chunks except s.headChunks we need to unlink these from s.headChunk.
 	s.headChunks.prev = nil
+	s.headChunks.listLen = 1
 
 	return count
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1926,10 +1926,11 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 		return true, false
 	}
 
-	mc := newMemChunk(newChunk, s.headChunks)
-	mc.minTime = t
-	mc.maxTime = t
-	s.headChunks = &mc
+	s.appendHeadChunk(&memChunk{
+		chunk:   newChunk,
+		minTime: t,
+		maxTime: t,
+	})
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1981,10 +1982,11 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 		return true, false
 	}
 
-	mc := newMemChunk(newChunk, s.headChunks)
-	mc.minTime = t
-	mc.maxTime = t
-	s.headChunks = &mc
+	s.appendHeadChunk(&memChunk{
+		chunk:   newChunk,
+		minTime: t,
+		maxTime: t,
+	})
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -2180,10 +2182,10 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
 	// so this is a single element list most of the time.
-	mc := newMemChunk(nil, s.headChunks)
-	mc.minTime = mint
-	mc.maxTime = math.MinInt64
-	s.headChunks = &mc
+	s.appendHeadChunk(&memChunk{
+		minTime: mint,
+		maxTime: math.MinInt64,
+	})
 
 	if chunkenc.IsValidEncoding(e) {
 		var err error
@@ -2261,8 +2263,10 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 	// Write chunks starting from the oldest one and stop before we get to current s.headChunks.
 	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
 	// then we need to write chunks t0 to t3, but skip s.headChunks.
-	for i := s.headChunks.len() - 1; i > 0; i-- {
-		chk := s.headChunks.atOffset(i)
+	for i, chk := range s.reverseHeadChunks() {
+		if i == 0 { // skip s.headChunks
+			break
+		}
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
@@ -2275,7 +2279,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 
 	// Once we've written out all chunks except s.headChunks we need to unlink these from s.headChunk.
 	s.headChunks.prev = nil
-	s.headChunks.listLen = 1
+	s.headChunksLen = 1
 
 	return count
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -338,9 +338,8 @@ func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta) []ch
 
 	if s.headChunks != nil {
 		var maxTime int64
-		var i, j int
-		for i = s.headChunks.len() - 1; i >= 0; i-- {
-			chk := s.headChunks.atOffset(i)
+		var j int
+		for i, chk := range s.reverseHeadChunks() {
 			if i == 0 {
 				// Set the head chunk as open (being appended to) for the first headChunk.
 				maxTime = math.MaxInt64
@@ -558,12 +557,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	// }
 	ix := int(id) - int(s.firstChunkID)
 
-	var headChunksLen int
-	if s.headChunks != nil {
-		headChunksLen = s.headChunks.len()
-	}
-
-	if ix < 0 || ix > len(s.mmappedChunks)+headChunksLen-1 {
+	if ix < 0 || ix > len(s.mmappedChunks)+s.headChunksLen-1 {
 		return nil, false, false, storage.ErrNotFound
 	}
 
@@ -585,7 +579,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 
 	ix -= len(s.mmappedChunks)
 
-	offset := headChunksLen - ix - 1
+	offset := s.headChunksLen - ix - 1
 	// headChunks is a linked list where first element is the most recent one and the last one is the oldest.
 	// This order is reversed when compared with mmappedChunks, since mmappedChunks[0] is the oldest chunk,
 	// while headChunk.atOffset(0) would give us the most recent chunk.
@@ -651,15 +645,13 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
 			// Iterate all head chunks from the oldest to the newest.
-			headChunksLen := s.headChunks.len()
-			for j := headChunksLen - 1; j >= 0; j-- {
-				chk := s.headChunks.atOffset(j)
+			for j, chk := range s.reverseHeadChunks() {
 				chkSamples := chk.chunk.NumSamples()
 				totalSamples += chkSamples
 				// Chunk ID is len(s.mmappedChunks) + $(headChunks list position).
 				// Where $(headChunks list position) is zero for the oldest chunk and $(s.headChunks.len() - 1)
 				// for the newest (open) chunk.
-				if headChunksLen-1-j < ix {
+				if s.headChunksLen-1-j < ix {
 					previousSamples += chkSamples
 				}
 			}

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -370,8 +370,7 @@ func TestMemSeries_chunk(t *testing.T) {
 
 	memChunkPool := &sync.Pool{
 		New: func() any {
-			mc := newMemChunk(nil, nil)
-			return &mc
+			return &memChunk{}
 		},
 	}
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -370,7 +370,8 @@ func TestMemSeries_chunk(t *testing.T) {
 
 	memChunkPool := &sync.Pool{
 		New: func() any {
-			return &memChunk{}
+			mc := newMemChunk(nil, nil)
+			return &mc
 		},
 	}
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -166,7 +166,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.clearHeadChunks()
 			},
 			inputID:  0,
 			expected: outMmappedChunk,
@@ -180,7 +180,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.clearHeadChunks()
 			},
 			inputID:  2,
 			expected: outMmappedChunk,
@@ -194,7 +194,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.clearHeadChunks()
 			},
 			inputID:  3,
 			expected: outErr,

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1516,7 +1516,8 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 
 	memChunkPool := sync.Pool{
 		New: func() any {
-			return &memChunk{}
+			mc := newMemChunk(nil, nil)
+			return &mc
 		},
 	}
 
@@ -3867,7 +3868,8 @@ func TestIteratorSeekIntoBuffer(t *testing.T) {
 
 	c, _, _, err := s.chunk(0, chunkDiskMapper, &sync.Pool{
 		New: func() any {
-			return &memChunk{}
+			mc := newMemChunk(nil, nil)
+			return &mc
 		},
 	})
 	require.NoError(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1516,8 +1516,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 
 	memChunkPool := sync.Pool{
 		New: func() any {
-			mc := newMemChunk(nil, nil)
-			return &mc
+			return &memChunk{}
 		},
 	}
 
@@ -3868,8 +3867,7 @@ func TestIteratorSeekIntoBuffer(t *testing.T) {
 
 	c, _, _, err := s.chunk(0, chunkDiskMapper, &sync.Pool{
 		New: func() any {
-			mc := newMemChunk(nil, nil)
-			return &mc
+			return &memChunk{}
 		},
 	})
 	require.NoError(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1680,7 +1680,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			}
 
 			if tc.headChunks == 0 {
-				series.headChunks = nil
+				series.clearHeadChunks()
 			} else {
 				for i := headStart; i < chunkRange*(tc.mmappedChunks+tc.headChunks); i += chunkStep {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -638,7 +638,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	// We do not reset oooHeadChunk because that is being replayed from a different WAL
 	// and has not been replayed here.
 	mSeries.nextAt = 0
-	mSeries.headChunks = nil
+	mSeries.clearHeadChunks()
 	mSeries.app = nil
 	return overlapped
 }
@@ -1313,10 +1313,9 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 		return csr, err
 	}
 
-	mc := newMemChunk(nil, nil)
-	mc.minTime = dec.Be64int64()
-	mc.maxTime = dec.Be64int64()
-	csr.mc = &mc
+	csr.mc = &memChunk{}
+	csr.mc.minTime = dec.Be64int64()
+	csr.mc.maxTime = dec.Be64int64()
 	enc := chunkenc.Encoding(dec.Byte())
 
 	// The underlying bytes gets re-used later, so make a copy.
@@ -1328,7 +1327,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	if err != nil {
 		return csr, fmt.Errorf("chunk from data: %w", err)
 	}
-	mc.chunk = chk
+	csr.mc.chunk = chk
 
 	switch enc {
 	case chunkenc.EncXOR, chunkenc.EncXOR2:
@@ -1726,6 +1725,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				series.headChunks = csr.mc
+				series.headChunksLen = csr.mc.len()
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1313,9 +1313,10 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 		return csr, err
 	}
 
-	csr.mc = &memChunk{listLen: 1}
-	csr.mc.minTime = dec.Be64int64()
-	csr.mc.maxTime = dec.Be64int64()
+	mc := newMemChunk(nil, nil)
+	mc.minTime = dec.Be64int64()
+	mc.maxTime = dec.Be64int64()
+	csr.mc = &mc
 	enc := chunkenc.Encoding(dec.Byte())
 
 	// The underlying bytes gets re-used later, so make a copy.
@@ -1327,7 +1328,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	if err != nil {
 		return csr, fmt.Errorf("chunk from data: %w", err)
 	}
-	csr.mc.chunk = chk
+	mc.chunk = chk
 
 	switch enc {
 	case chunkenc.EncXOR, chunkenc.EncXOR2:

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1313,7 +1313,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 		return csr, err
 	}
 
-	csr.mc = &memChunk{}
+	csr.mc = &memChunk{listLen: 1}
 	csr.mc.minTime = dec.Be64int64()
 	csr.mc.maxTime = dec.Be64int64()
 	enc := chunkenc.Encoding(dec.Byte())

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -108,10 +108,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 
 		if encoding != prevEncoding { // For the first sample, this will always be true as EncNone != EncXOR | EncHistogram | EncFloatHistogram
 			if prevEncoding != chunkenc.EncNone {
-				mc := newMemChunk(chunk, nil)
-				mc.minTime = cmint
-				mc.maxTime = cmaxt
-				chks = append(chks, mc)
+				chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
 			}
 			cmint = s.t
 			chunk, err = chunkenc.NewEmptyChunk(encoding)
@@ -139,10 +136,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, s.st, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					mc := newMemChunk(chunk, nil)
-					mc.minTime = cmint
-					mc.maxTime = cmaxt
-					chks = append(chks, mc)
+					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -158,10 +152,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, s.st, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					mc := newMemChunk(chunk, nil)
-					mc.minTime = cmint
-					mc.maxTime = cmaxt
-					chks = append(chks, mc)
+					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -171,10 +162,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 		prevEncoding = encoding
 	}
 	if prevEncoding != chunkenc.EncNone {
-		mc := newMemChunk(chunk, nil)
-		mc.minTime = cmint
-		mc.maxTime = cmaxt
-		chks = append(chks, mc)
+		chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
 	}
 	return chks, nil
 }

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -108,7 +108,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 
 		if encoding != prevEncoding { // For the first sample, this will always be true as EncNone != EncXOR | EncHistogram | EncFloatHistogram
 			if prevEncoding != chunkenc.EncNone {
-				chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
+				mc := newMemChunk(chunk, nil)
+				mc.minTime = cmint
+				mc.maxTime = cmaxt
+				chks = append(chks, mc)
 			}
 			cmint = s.t
 			chunk, err = chunkenc.NewEmptyChunk(encoding)
@@ -136,7 +139,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, s.st, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
+					mc := newMemChunk(chunk, nil)
+					mc.minTime = cmint
+					mc.maxTime = cmaxt
+					chks = append(chks, mc)
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -152,7 +158,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, s.st, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
+					mc := newMemChunk(chunk, nil)
+					mc.minTime = cmint
+					mc.maxTime = cmaxt
+					chks = append(chks, mc)
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -162,7 +171,10 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 		prevEncoding = encoding
 	}
 	if prevEncoding != chunkenc.EncNone {
-		chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
+		mc := newMemChunk(chunk, nil)
+		mc.minTime = cmint
+		mc.maxTime = cmaxt
+		chks = append(chks, mc)
 	}
 	return chks, nil
 }

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -108,7 +108,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 
 		if encoding != prevEncoding { // For the first sample, this will always be true as EncNone != EncXOR | EncHistogram | EncFloatHistogram
 			if prevEncoding != chunkenc.EncNone {
-				chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
+				chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
 			}
 			cmint = s.t
 			chunk, err = chunkenc.NewEmptyChunk(encoding)
@@ -136,7 +136,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, s.st, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
+					chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -152,7 +152,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, s.st, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
-					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
+					chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
 					cmint = s.t
 				}
 				chunk = newChunk
@@ -162,7 +162,7 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 		prevEncoding = encoding
 	}
 	if prevEncoding != chunkenc.EncNone {
-		chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
+		chks = append(chks, memChunk{chunk: chunk, minTime: cmint, maxTime: cmaxt})
 	}
 	return chks, nil
 }


### PR DESCRIPTION
We're seeing some native histograms having a single chunk per sample. This causes performance issues on some places that go quadratic over the head chunks count, assuming it's always small enough.

Particularly, on head compaction after WAL replay, profiling shows a huge amount of time is spent on `memChunk.len`, which walks a linked list.

```
goroutine 5480776 [runnable]:
github.com/prometheus/prometheus/tsdb.(*memChunk).len(...)
	/tsdb/head.go:2639
github.com/prometheus/prometheus/tsdb.(*memSeries).chunk(0x40c5808900?, 0x7?, 0x4104e94b68?, 0x407aedbb78?)
	/tsdb/head_read.go:563 +0x290
github.com/prometheus/prometheus/tsdb.(*Head).chunkFromSeries(0x407aedb808, 0x40c5808900, 0x31241, 0xf4?, 0x19d67d05600, 0x19d683e32ff, 0x0, 0x1)
	/tsdb/head_read.go:502 +0x68
github.com/prometheus/prometheus/tsdb.(*headChunkReader).chunk(0x42380694a0, {0x39a1031241, {0x0, 0x0}, 0x19d682125b6, 0x19d682125b6}, 0x1)
	/tsdb/head_read.go:488 +0xe0
github.com/prometheus/prometheus/tsdb.(*headChunkReader).ChunkOrIterableWithCopy(0x42a4380000?, {0x39a1031241, {0x0, 0x0}, 0x19d682125b6, 0x19d682125b6})
	/tsdb/head_read.go:470 +0x30
github.com/prometheus/prometheus/tsdb.(*populateWithDelGenericSeriesIterator).next(0x417683f320, 0x1)
	/tsdb/querier.go:799 +0x1a4
github.com/prometheus/prometheus/tsdb.(*populateWithDelChunkSeriesIterator).Next(0x417683f320)
	/tsdb/querier.go:1006 +0xb8
github.com/prometheus/prometheus/tsdb.DefaultBlockPopulator.PopulateBlock({}, {0x4a1adf0, 0x40a08d12c0}, 0x40a7dbb8f0, 0x4027087a20, {0x49faf58, 0x40aa74c880}, 0x4027728610, {0x20?, 0x35c1520?, ...}, ...)
	/tsdb/compact.go:1194 +0x119c
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).write(0x40447ff400, {0x407ba7a570, 0x12}, {0x419093afa0, 0x1, 0x1}, {0x49d3000, 0x7da6680}, {0x41cdbd01a0, 0x1, ...})
	/tsdb/compact.go:916 +0x77c
```

`PopulateBlock` iterates chunks one by one via `Next()`. For each chunk, it calls `memSeries.chunk(id)`, which calls `s.headChunks.len()`.

We can avoid this quadratic behavior by materializing the length of `s.headChunks` (at the risk of a bug introducing a desync).