### PR TITLE
labels: take into account case-insensitive prefixes when optimizing concat regexes

### DIFF
--- a/model/labels/cost_test.go
+++ b/model/labels/cost_test.go
@@ -75,6 +75,8 @@ var matcherTestCases = []struct {
 	{279, "route", MatchRegexp, "(base.Ruler/Rules|indexgatewaypb.IndexGateway/GetChunkRef|indexgatewaypb.IndexGateway/GetSeries|indexgatewaypb.IndexGateway/GetShards|indexgatewaypb.IndexGateway/GetStats|indexgatewaypb.IndexGateway/GetVolume|indexgatewaypb.IndexGateway/LabelNamesForMetricName|indexgatewaypb.IndexGateway/LabelValuesForMetricName|indexgatewaypb.IndexGateway/QueryIndex|logproto.BloomGateway/FilterChunkRefs|logproto.Pattern/Query|logproto.Querier/GetChunkIDs|logproto.Querier/GetDetectedLabels|logproto.Querier/GetStats|logproto.Querier/GetVolume|logproto.Querier/Label|logproto.Querier/Query|logproto.Querier/QuerySample|logproto.Querier/Series|logproto.StreamData/GetStreamRates)"},
 	{4, "namespace", MatchRegexp, ".*prod.*"},
 	{2, "namespace", MatchRegexp, ".*-.*-.*"},
+	{1, "pod", MatchRegexp, "(?i)report.scheduled.job_runscheduledreports"},
+	{1, "pod", MatchRegexp, "report.scheduled.job_runscheduledreports"},
 
 	// != matchers
 	{1, "job", MatchNotEqual, "integrations/db-o11y"},

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -161,6 +161,13 @@ func (m *Matcher) Prefix() string {
 	return m.re.prefix
 }
 
+func (m *Matcher) IsCaseInsensitivePrefix() bool {
+	if m.re == nil {
+		return false
+	}
+	return m.re.caseInsensitivePrefix
+}
+
 // IsRegexOptimized returns whether regex is optimized.
 func (m *Matcher) IsRegexOptimized() bool {
 	if m.re == nil {

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -137,8 +137,9 @@ func TestInverse(t *testing.T) {
 
 func TestPrefix(t *testing.T) {
 	for i, tc := range []struct {
-		matcher *Matcher
-		prefix  string
+		matcher               *Matcher
+		prefix                string
+		caseInsensitivePrefix bool
 	}{
 		{
 			matcher: mustNewMatcher(t, MatchEqual, "abc"),
@@ -181,12 +182,14 @@ func TestPrefix(t *testing.T) {
 			prefix:  "",
 		},
 		{
-			matcher: mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
-			prefix:  "ABC",
+			matcher:               mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
+			prefix:                "ABC",
+			caseInsensitivePrefix: true,
 		},
 	} {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())
+			require.Equal(t, tc.caseInsensitivePrefix, tc.matcher.IsCaseInsensitivePrefix())
 		})
 	}
 }

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -180,6 +180,10 @@ func TestPrefix(t *testing.T) {
 			matcher: mustNewMatcher(t, MatchRegexp, ".+def"),
 			prefix:  "",
 		},
+		{
+			matcher: mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
+			prefix:  "ABC",
+		},
 	} {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -65,6 +65,9 @@ type FastRegexMatcher struct {
 	suffix        string
 	contains      []string
 
+	// true if prefix should be a case-insensitive match
+	caseInsensitivePrefix bool
+
 	// matchString is the "compiled" function to run by MatchString().
 	matchString func(string) bool
 	parsedRe    *syntax.Regexp
@@ -117,7 +120,7 @@ func newFastRegexMatcherWithoutCache(v string) (*FastRegexMatcher, error) {
 		clearCapture(parsed)
 
 		if parsed.Op == syntax.OpConcat {
-			m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
+			m.caseInsensitivePrefix, m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
 		}
 		if matches, caseSensitive := findSetMatches(parsed); caseSensitive {
 			m.setMatches = matches
@@ -146,6 +149,12 @@ func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 	// If the only optimization available is the string matcher, then we can just run it.
 	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
 		return m.stringMatcher.Matches
+	}
+
+	if m.caseInsensitivePrefix && m.prefix != "" {
+		return func(s string) bool {
+			return hasPrefixCaseInsensitive(s, m.prefix)
+		}
 	}
 
 	return func(s string) bool {
@@ -458,7 +467,7 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 
 // optimizeConcatRegex returns literal prefix/suffix text that can be safely
 // checked against the label value before running the regexp matcher.
-func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []string) {
+func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, suffix string, contains []string) {
 	sub := r.Sub
 	clearCapture(sub...)
 
@@ -472,14 +481,16 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []st
 	}
 
 	if len(sub) == 0 {
-		return prefix, suffix, contains
+		return caseInsensitivePrefix, prefix, suffix, contains
 	}
 
 	// Given Prometheus regex matchers are always anchored to the begin/end
 	// of the text, if the first/last operations are literals, we can safely
 	// treat them as prefix/suffix.
-	if sub[0].Op == syntax.OpLiteral && (sub[0].Flags&syntax.FoldCase) == 0 {
+	if sub[0].Op == syntax.OpLiteral {
 		prefix = string(sub[0].Rune)
+		caseInsensitivePrefix = (sub[0].Flags & syntax.FoldCase) != 0
+
 	}
 	if last := len(sub) - 1; sub[last].Op == syntax.OpLiteral && (sub[last].Flags&syntax.FoldCase) == 0 {
 		suffix = string(sub[last].Rune)
@@ -493,7 +504,7 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []st
 		}
 	}
 
-	return prefix, suffix, contains
+	return caseInsensitivePrefix, prefix, suffix, contains
 }
 
 // StringMatcher is a matcher that matches a string in place of a regular expression.

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -493,8 +493,8 @@ func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, 
 	if sub[0].Op == syntax.OpLiteral {
 		prefix = string(sub[0].Rune)
 		caseInsensitivePrefix = (sub[0].Flags & syntax.FoldCase) != 0
-
 	}
+
 	if last := len(sub) - 1; sub[last].Op == syntax.OpLiteral && (sub[last].Flags&syntax.FoldCase) == 0 {
 		suffix = string(sub[last].Rune)
 	}

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -153,7 +153,10 @@ func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 
 	if m.caseInsensitivePrefix && m.prefix != "" {
 		return func(s string) bool {
-			return hasPrefixCaseInsensitive(s, m.prefix)
+			if !hasPrefixCaseInsensitive(s, m.prefix) {
+				return false
+			}
+			return m.re.MatchString(s)
 		}
 	}
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -281,10 +281,11 @@ func readable(s string) string {
 
 func TestOptimizeConcatRegex(t *testing.T) {
 	cases := []struct {
-		regex    string
-		prefix   string
-		suffix   string
-		contains []string
+		regex                   string
+		prefix                  string
+		isCaseInsensitivePrefix bool
+		suffix                  string
+		contains                []string
 	}{
 		{regex: "foo(hello|bar)", prefix: "foo", suffix: "", contains: nil},
 		{regex: "foo(hello|bar)world", prefix: "foo", suffix: "world", contains: nil},
@@ -298,12 +299,12 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		{regex: ".*[abc].*", prefix: "", suffix: "", contains: nil},
 		{regex: ".*((?i)abc).*", prefix: "", suffix: "", contains: nil},
 		{regex: ".*(?i:abc).*", prefix: "", suffix: "", contains: nil},
-		{regex: "(?i:abc).*", prefix: "", suffix: "", contains: nil},
+		{regex: "(?i:abc).*", prefix: "ABC", isCaseInsensitivePrefix: true, suffix: "", contains: nil},
 		{regex: ".*(?i:abc)", prefix: "", suffix: "", contains: nil},
 		{regex: ".*(?i:abc)def.*", prefix: "", suffix: "", contains: []string{"def"}},
 		{regex: "(?i).*(?-i:abc)def", prefix: "", suffix: "", contains: []string{"abc"}},
 		{regex: ".*(?msU:abc).*", prefix: "", suffix: "", contains: []string{"abc"}},
-		{regex: "[aA]bc.*", prefix: "", suffix: "", contains: []string{"bc"}},
+		{regex: "[aA]bc.*", prefix: "A", isCaseInsensitivePrefix: true, suffix: "", contains: []string{"bc"}},
 		{regex: "^5..$", prefix: "5", suffix: "", contains: nil},
 		{regex: "^release.*", prefix: "release", suffix: "", contains: nil},
 		{regex: "^env-[0-9]+laio[1]?[^0-9].*", prefix: "env-", suffix: "", contains: []string{"laio"}},
@@ -311,13 +312,16 @@ func TestOptimizeConcatRegex(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
-		require.NoError(t, err)
+		t.Run(c.regex, func(t *testing.T) {
+			parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
+			require.NoError(t, err)
 
-		_, prefix, suffix, contains := optimizeConcatRegex(parsed)
-		require.Equal(t, c.prefix, prefix)
-		require.Equal(t, c.suffix, suffix)
-		require.Equal(t, c.contains, contains)
+			caseInsensitivePrefix, prefix, suffix, contains := optimizeConcatRegex(parsed)
+			require.Equal(t, c.prefix, prefix)
+			require.Equal(t, c.isCaseInsensitivePrefix, caseInsensitivePrefix)
+			require.Equal(t, c.suffix, suffix)
+			require.Equal(t, c.contains, contains)
+		})
 	}
 }
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -56,6 +56,7 @@ var (
 		"foo\n.+",
 		"foo\n.*",
 		".*foo.*",
+		"(?i).*foo.*",
 		".+foo.+",
 		".*foo.*|",
 		".*foo.*|bar.*",
@@ -139,6 +140,7 @@ var (
 
 		"report.scheduled.job_runscheduledreports",
 		"Report.Scheduled.JobRunScheduledReports",
+		"Report.Scheduled.Job_RunScheduledReports",
 	}
 )
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -72,6 +72,8 @@ var (
 		"(?i:(foo1|foo2|bar))",
 		"^(?i:foo|oo)|(bar)$",
 		"(?i:(foo1|foo2|aaa|bbb|ccc|ddd|eee|fff|ggg|hhh|iii|lll|mmm|nnn|ooo|ppp|qqq|rrr|sss|ttt|uuu|vvv|www|xxx|yyy|zzz))",
+		"(?i)report.scheduled.job_runscheduledreports",
+		"report.scheduled.job_runscheduledreports",
 		"((.*)(bar|b|buzz)(.+)|foo)$",
 		"^$",
 		"(prometheus|api_prom)_api_v1_.+",
@@ -134,6 +136,9 @@ var (
 		"foo\xfe",
 		"\xfd",
 		"\xff\xff",
+
+		"report.scheduled.job_runscheduledreports",
+		"Report.Scheduled.JobRunScheduledReports",
 	}
 )
 
@@ -307,7 +312,7 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
 		require.NoError(t, err)
 
-		prefix, suffix, contains := optimizeConcatRegex(parsed)
+		_, prefix, suffix, contains := optimizeConcatRegex(parsed)
 		require.Equal(t, c.prefix, prefix)
 		require.Equal(t, c.suffix, suffix)
 		require.Equal(t, c.contains, contains)
@@ -559,6 +564,8 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"foo.?", &literalPrefixSensitiveStringMatcher{prefix: "foo", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}},
 		{"f.?o", nil},
 		{".*foo.*|.*bar.*|.*baz.*", &containsStringMatcher{left: trueMatcher{}, substrings: []string{"foo", "bar", "baz"}, right: trueMatcher{}}},
+		{"(?i)zeyt.report.scheduled.joblocalprocessor_impl_runscheduledreportsperiodic", nil},
+		{"zeyt.report.scheduled.joblocalprocessor_impl_runscheduledreportsperiodic", nil},
 	} {
 		t.Run(c.pattern, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Introduces flag for `FastRegexMatcher`s with case-insensitive prefixes, so that we can use `strings.EqualFold` to match such prefixes.

<details><summary>BenchmarkFastRegexMatcher results</summary>
Just the new tests:

```
% benchstat original_no_case_insensitive_prefix.txt with_case_insensitive_prefix.txt
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M2 Pro
                                                     │ original_no_case_insensitive_prefix.txt │  with_case_insensitive_prefix.txt   │
                                                     │                 sec/op                  │   sec/op     vs base                │
FastRegexMatcher/(?i)report.scheduled.job_runsche-10                               85.00n ± 2%   72.55n ± 5%  -14.65% (p=0.000 n=10)
FastRegexMatcher/report.scheduled.job_runschedule-10                               84.18n ± 0%   87.91n ± 6%   +4.43% (p=0.000 n=10)
geomean                                                                            84.59n        79.86n        -5.59%
```

All tests:

```
% benchstat original_no_case_insensitive_prefix.txt with_case_insensitive_prefix.txt
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M2 Pro
                                                        │ original_no_case_insensitive_prefix.txt │   with_case_insensitive_prefix.txt   │
                                                        │                 sec/op                  │    sec/op     vs base                │
FastRegexMatcher/#00-10                                                              55.29n ±  2%   53.42n ±  1%   -3.37% (p=0.000 n=10)
FastRegexMatcher/()-10                                                               55.69n ±  1%   53.74n ±  4%   -3.48% (p=0.011 n=10)
FastRegexMatcher/foo-10                                                              59.22n ±  4%   56.94n ±  1%   -3.85% (p=0.000 n=10)
FastRegexMatcher/foo()-10                                                            67.97n ±  1%   66.38n ±  3%        ~ (p=0.054 n=10)
FastRegexMatcher/^foo-10                                                             67.50n ±  4%   66.57n ±  3%        ~ (p=0.324 n=10)
FastRegexMatcher/(foo|bar)-10                                                        82.53n ±  1%   81.80n ±  2%        ~ (p=0.138 n=10)
FastRegexMatcher/foo.*-10                                                            95.70n ±  1%   96.05n ±  3%        ~ (p=0.143 n=10)
FastRegexMatcher/.*foo-10                                                            111.0n ±  1%   110.9n ±  2%        ~ (p=0.467 n=10)
FastRegexMatcher/^.*foo$-10                                                          112.7n ±  2%   111.3n ±  1%   -1.20% (p=0.001 n=10)
FastRegexMatcher/^.+foo$-10                                                          113.6n ±  1%   110.5n ±  1%   -2.73% (p=0.000 n=10)
FastRegexMatcher/.?-10                                                               78.99n ±  1%   77.92n ±  1%   -1.35% (p=0.002 n=10)
FastRegexMatcher/.*-10                                                               54.97n ±  9%   53.68n ±  2%   -2.35% (p=0.022 n=10)
FastRegexMatcher/().*-10                                                             54.41n ± 11%   53.06n ±  1%   -2.50% (p=0.000 n=10)
FastRegexMatcher/.*()-10                                                             53.88n ±  1%   53.16n ±  1%   -1.35% (p=0.014 n=10)
FastRegexMatcher/().*()-10                                                           54.09n ±  9%   53.36n ±  2%   -1.34% (p=0.005 n=10)
FastRegexMatcher/.+-10                                                               55.84n ±  1%   55.30n ±  2%        ~ (p=0.128 n=10)
FastRegexMatcher/.+()-10                                                             55.54n ±  9%   55.04n ±  3%        ~ (p=0.063 n=10)
FastRegexMatcher/foo.+-10                                                            96.76n ±  3%   95.34n ±  3%        ~ (p=0.051 n=10)
FastRegexMatcher/.+foo-10                                                            111.6n ±  4%   110.8n ±  1%        ~ (p=0.119 n=10)
FastRegexMatcher/foo_.+-10                                                           87.04n ±  3%   87.41n ±  2%        ~ (p=0.393 n=10)
FastRegexMatcher/foo_.*-10                                                           86.84n ±  1%   87.64n ±  2%   +0.92% (p=0.029 n=10)
FastRegexMatcher/.*foo.*-10                                                          181.7n ±  1%   182.7n ±  1%   +0.52% (p=0.037 n=10)
FastRegexMatcher/(?i).*foo.*-10                                                      7.675µ ±  1%   7.721µ ±  2%        ~ (p=0.197 n=10)
FastRegexMatcher/.+foo.+-10                                                          196.5n ±  4%   197.7n ±  2%        ~ (p=0.210 n=10)
FastRegexMatcher/.*foo.*|-10                                                         243.9n ±  1%   246.0n ±  2%   +0.86% (p=0.011 n=10)
FastRegexMatcher/.*foo.*|bar.*-10                                                    280.9n ±  4%   283.5n ±  2%        ~ (p=0.118 n=10)
FastRegexMatcher/foo.*|.*bar.*-10                                                    279.9n ±  2%   282.1n ±  2%        ~ (p=0.050 n=10)
FastRegexMatcher/.*foo.*|.*bar.*-10                                                  294.3n ±  2%   294.9n ±  2%        ~ (p=0.698 n=10)
FastRegexMatcher/.*foo.*bar.*|.*hello.*-10                                           13.91µ ±  2%   13.61µ ±  3%   -2.18% (p=0.009 n=10)
FastRegexMatcher/.*foo.*|.*bar.*|.*hello.*-10                                        467.8n ±  1%   485.9n ±  1%   +3.87% (p=0.000 n=10)
FastRegexMatcher/.+.*foo.*|.*bar.*-10                                                16.21µ ±  2%   16.26µ ±  2%        ~ (p=0.739 n=10)
FastRegexMatcher/(?s:.*)-10                                                          53.79n ±  1%   53.35n ±  1%        ~ (p=0.086 n=10)
FastRegexMatcher/(?s:.+)-10                                                          56.02n ±  1%   56.06n ±  2%        ~ (p=0.617 n=10)
FastRegexMatcher/(?s:^.*foo$)-10                                                     110.6n ±  2%   111.0n ±  1%        ~ (p=0.955 n=10)
FastRegexMatcher/(?i:foo)-10                                                         82.16n ±  2%   81.25n ±  1%        ~ (p=0.190 n=10)
FastRegexMatcher/(?i:(foo|bar))-10                                                   171.9n ±  2%   170.1n ±  3%        ~ (p=0.239 n=10)
FastRegexMatcher/(?i:(foo1|foo2|bar))-10                                             313.9n ±  5%   317.3n ±  2%        ~ (p=0.306 n=10)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-10                                              697.5n ±  3%   697.2n ±  4%        ~ (p=0.753 n=10)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-10                                 610.1n ±  4%   613.4n ±  4%        ~ (p=0.256 n=10)
FastRegexMatcher/(?i)report.scheduled.job_runsche-10                                 88.07n ±  1%   78.33n ±  3%  -11.06% (p=0.000 n=10)
FastRegexMatcher/report.scheduled.job_runschedule-10                                 87.64n ±  1%   88.89n ±  2%   +1.43% (p=0.025 n=10)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-10                                      465.2n ±  1%   463.1n ±  1%        ~ (p=0.342 n=10)
FastRegexMatcher/^$-10                                                               55.23n ±  2%   55.73n ±  2%        ~ (p=0.128 n=10)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-10                                  171.0n ±  1%   172.4n ±  3%   +0.88% (p=0.003 n=10)
FastRegexMatcher/10\.0\.(1|2)\.+-10                                                  87.65n ±  1%   88.95n ±  2%   +1.48% (p=0.029 n=10)
FastRegexMatcher/10\.0\.(1|2).+-10                                                   88.17n ±  1%   87.77n ±  2%        ~ (p=0.469 n=10)
FastRegexMatcher/((fo(bar))|.+foo)-10                                                211.8n ±  2%   210.9n ±  3%        ~ (p=0.447 n=10)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-10                                 188.9n ±  1%   181.9n ±  1%   -3.70% (p=0.000 n=10)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-10                                 176.8n ±  1%   179.6n ±  2%   +1.64% (p=0.000 n=10)
FastRegexMatcher/.*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuu-10                                 12.09µ ±  2%   11.90µ ±  2%   -1.56% (p=0.043 n=10)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-10                                 631.4n ±  3%   627.6n ±  2%        ~ (p=0.315 n=10)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-10                                 304.9n ±  1%   306.2n ±  0%        ~ (p=0.342 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-10                                 275.8n ±  6%   269.8n ±  1%   -2.14% (p=0.002 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-10                              489.9n ±  1%   473.0n ±  0%   -3.45% (p=0.000 n=10)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-10                                 7.542µ ±  2%   7.511µ ±  2%        ~ (p=0.225 n=10)
FastRegexMatcher/fo.?-10                                                             98.66n ±  1%   97.95n ±  1%        ~ (p=0.138 n=10)
FastRegexMatcher/foo.?-10                                                            98.48n ±  1%   97.33n ±  2%        ~ (p=0.148 n=10)
FastRegexMatcher/f.?o-10                                                             81.41n ±  1%   81.85n ±  2%        ~ (p=0.494 n=10)
FastRegexMatcher/.*foo.?-10                                                          197.0n ±  1%   196.1n ±  3%        ~ (p=0.425 n=10)
FastRegexMatcher/.?foo.+-10                                                          191.8n ±  1%   189.7n ±  0%   -1.10% (p=0.001 n=10)
FastRegexMatcher/foo.?|bar-10                                                        154.0n ±  1%   148.7n ±  2%   -3.41% (p=0.000 n=10)
FastRegexMatcher/ſſs-10                                                              58.50n ±  2%   56.83n ±  2%   -2.86% (p=0.000 n=10)
FastRegexMatcher/.*-.*-.*-.*-.*-10                                                   182.2n ±  0%   181.5n ±  3%        ~ (p=0.468 n=10)
FastRegexMatcher/.+-.*-.*-.*-.+-10                                                   181.5n ±  1%   184.8n ±  3%   +1.82% (p=0.000 n=10)
FastRegexMatcher/-.*-.*-.*-.*-10                                                     94.77n ±  1%   97.27n ±  2%   +2.63% (p=0.000 n=10)
FastRegexMatcher/.*-.*-.*-.*--10                                                     112.0n ±  0%   114.4n ±  3%   +2.14% (p=0.000 n=10)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-10                                         181.4n ±  0%   184.6n ±  5%   +1.79% (p=0.006 n=10)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-10                                 4.258µ ±  0%   4.300µ ±  4%   +0.99% (p=0.004 n=10)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-10                                 3.479µ ±  0%   3.608µ ±  3%   +3.72% (p=0.000 n=10)
FastRegexMatcher/(.*0.*)-10                                                          135.1n ±  0%   140.6n ± 13%   +4.03% (p=0.000 n=10)
geomean                                                                              195.6n         194.6n         -0.52%
```


</details>

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
