### PR TITLE
ci: add workflow to remind user about unmerged upstream-sync PRs

### DIFF
--- a/.github/workflows/remind-upstream-merge.yml
+++ b/.github/workflows/remind-upstream-merge.yml
@@ -1,0 +1,67 @@
+name: Remind about pending upstream merge PRs
+
+on:
+  schedule:
+    # Run at 9am UTC, Tuesday through Friday (cron days 2-5).
+    # Exclude Mondays (upstream merge PRs are created that day, so reminders start Tuesday) and weekends.
+    - cron: "0 9 * * 2-5"
+  workflow_dispatch:
+
+jobs:
+  check-pending-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Find open upstream merge PRs
+        id: find-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # List open PRs whose head branch matches the bot merge pattern.
+          set -euo pipefail
+          if ! PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,title,url,headRefName,createdAt \
+            --jq '[.[] | select(.headRefName | test("^bot/.*/merge-upstream-"))]'); then
+            echo "::error::gh pr list failed -- check token permissions and API availability"
+            exit 1
+          fi
+          if ! COUNT=$(echo "$PRS" | jq 'length'); then
+            echo "::error::Failed to parse gh pr list output as JSON"
+            exit 1
+          fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$COUNT" -gt 0 ]; then
+            # Build the full Slack payload using jq so all special characters
+            # (quotes, backslashes, newlines) are properly JSON-escaped.
+            PAYLOAD=$(echo "$PRS" | jq '{
+              text: (
+                ":wave: *Reminder: there are open upstream merge PRs waiting for resolution*\n\n"
+                + ([.[] | "- <\(.url)|\(.title)> (opened \(.createdAt | split("T")[0]))"] | join("\n"))
+                + "\n\n<!subteam^S03C2P8659U> please review and merge."
+              )
+            }')
+            if [ -z "$PAYLOAD" ]; then
+              echo "::error::Slack payload is empty after jq processing"
+              exit 1
+            fi
+            DELIMITER="EOF_$(date +%s)"
+            {
+              echo "payload<<$DELIMITER"
+              echo "$PAYLOAD"
+              echo "$DELIMITER"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Found $COUNT open upstream merge PR(s)"
+
+      - name: Send Slack reminder
+        if: steps.find-prs.outputs.payload != ''
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        with:
+          channel-id: C04AF91LPFX #mimir-ci-notifications
+          payload: ${{ steps.find-prs.outputs.payload }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new scheduled GitHub Actions workflow that only reads PR metadata and posts a Slack message; main failure modes are missed/extra notifications due to query/payload formatting.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`remind-upstream-merge.yml`) that runs on a Tue–Fri schedule (and manually) to detect open `bot/*/merge-upstream-*` PRs via `gh pr list` and `jq`.
> 
> When any are found, it posts a formatted reminder to the `mimir-ci-notifications` Slack channel (tagging the specified subteam), with basic error handling around GitHub CLI and JSON parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6135ae09f6b9e1d23421f04fe78e848faa034648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->