### PR TITLE
tsdb: add head-only querier for projections

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -59,6 +59,9 @@ const (
 	// DefaultCompactionDelayMaxPercent in percentage.
 	DefaultCompactionDelayMaxPercent = 10
 
+	// SeriesHashLabel is the label used for unique per-series IDs to support the projections optimization.
+	SeriesHashLabel = "__series_hash__"
+
 	// Block dir suffixes to make deletion and creation operations atomic.
 	// We decided to do suffixes instead of creating meta.json as last (or delete as first) one,
 	// because in error case you still can recover meta.json from the block content within local TSDB dir.
@@ -72,6 +75,8 @@ const (
 
 // ErrNotReady is returned if the underlying storage is not ready yet.
 var ErrNotReady = errors.New("TSDB not ready")
+
+var ErrInvalidTimeRangeForProjections = errors.New("time range cannot be used with projections")
 
 // DefaultOptions used for the DB. They are reasonable for setups using
 // millisecond precision timestamps.
@@ -92,6 +97,7 @@ func DefaultOptions() *Options {
 		OutOfOrderCapMax:                         DefaultOutOfOrderCapMax,
 		EnableOverlappingCompaction:              true,
 		EnableSharding:                           false,
+		EnableSeriesHash:                         false,
 		EnableDelayedCompaction:                  false,
 		CompactionDelayMaxPercent:                DefaultCompactionDelayMaxPercent,
 		CompactionDelay:                          time.Duration(0),
@@ -234,6 +240,9 @@ type Options struct {
 
 	// EnableSharding enables query sharding support in TSDB.
 	EnableSharding bool
+
+	// EnableSeriesHash enables support for the projections optimization in TSDB via a unique per-series ID.
+	EnableSeriesHash bool
 
 	// EnableDelayedCompaction, when set to true, assigns a random value to CompactionDelay during DB opening.
 	// When set to false, delayed compaction is disabled, unless CompactionDelay is set directly.
@@ -1227,6 +1236,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.OutOfOrderTimeWindow.Store(opts.OutOfOrderTimeWindow)
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	headOpts.EnableSharding = opts.EnableSharding
+	headOpts.EnableSeriesHash = opts.EnableSeriesHash
 	headOpts.TimelyCompaction = opts.TimelyCompaction
 	if opts.HeadPostingsForMatchersCacheFactory != nil {
 		headOpts.PostingsForMatchersCacheFactory = opts.HeadPostingsForMatchersCacheFactory
@@ -2672,6 +2682,54 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 	}
 
 	return blockQueriers, nil
+}
+
+func (db *DB) ChunkQuerierForProjections(mint, maxt int64) (storage.ChunkQuerier, error) {
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
+
+	for _, b := range db.blocks {
+		if b.OverlapsClosedInterval(mint, maxt) {
+			return nil, fmt.Errorf("%w: existing block overlaps the range. mint: %d, maxt: %d", ErrInvalidTimeRangeForProjections, mint, maxt)
+		}
+	}
+
+	// We can only use the projections optimization (including __series_hash__  unique ID) when
+	// the query touches only the head since we need to ensure results are sorted correctly based
+	// on the labels returned. This is only possible for the in-memory head.
+	headMinT := db.head.MinTime()
+	if mint < headMinT {
+		return nil, fmt.Errorf("%w: range mint %d precedes head mint %d", ErrInvalidTimeRangeForProjections, mint, headMinT)
+	}
+
+	rh := NewProjectionsRangeHead(db.head, mint, maxt)
+	headQuerier, err := db.blockChunkQuerierFunc(rh, mint, maxt)
+	if err != nil {
+		return nil, fmt.Errorf("open querier for head %s: %w", rh, err)
+	}
+
+	// Getting the querier above registers itself in the queue that the truncation waits on.
+	// If the querier is currently not colliding with any truncation, we can continue to use it
+	// for this projections optimized query. If it _is_ colliding return an error since we would
+	// rather not block truncation. In the normal query path, we adjust the range queried from
+	// the head but, we can't do that with projections since we need to be able to sort the entire
+	// result based on labels returned.
+	if shouldClose, _, _ := db.head.IsQuerierCollidingWithTruncation(mint, maxt); shouldClose {
+		if err = headQuerier.Close(); err != nil {
+			return nil, fmt.Errorf("closing head querier %s: %w", rh, err)
+		}
+
+		return nil, fmt.Errorf("%w: range mint %d to maxt %d overlaps truncation", ErrInvalidTimeRangeForProjections, mint, maxt)
+	}
+
+	overlapsOOO := overlapsClosedInterval(mint, maxt, db.head.MinOOOTime(), db.head.MaxOOOTime())
+	if overlapsOOO {
+		// We need to fetch from in-order and out-of-order chunks: wrap the headQuerier.
+		isoState := db.head.oooIso.TrackReadAfter(db.lastGarbageCollectedMmapRef)
+		headQuerier = NewHeadAndOOOChunkQuerier(headMinT, mint, maxt, db.head, isoState, headQuerier)
+	}
+
+	return headQuerier, nil
 }
 
 // ChunkQuerier returns a new chunk querier over the data partition for the given time range.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -208,6 +208,9 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
+	// EnableSeriesHash enables support for the projections optimization in the Head via a unique per-series ID.
+	EnableSeriesHash bool
+
 	// IndexLookupPlannerFunc can be optionally used when querying the index of the Head.
 	IndexLookupPlannerFunc IndexLookupPlannerFunc
 
@@ -1616,7 +1619,7 @@ func NewRangeHeadWithIsolationDisabled(head *Head, mint, maxt int64) *RangeHead 
 }
 
 func (h *RangeHead) Index() (IndexReader, error) {
-	return h.head.indexRange(h.mint, h.maxt), nil
+	return h.head.indexRange(h.mint, h.maxt, false), nil
 }
 
 func (h *RangeHead) Chunks() (ChunkReader, error) {
@@ -1672,6 +1675,27 @@ func (h *RangeHead) String() string {
 	return fmt.Sprintf("range head (mint: %d, maxt: %d)", h.MinTime(), h.MaxTime())
 }
 
+// ProjectionsRangeHead allows querying Head via an IndexReader, ChunkReader and tombstones.Reader
+// but only within a restricted range. Used for queries that have requested the projections optimization,
+// adding a __series_hash__ unique ID to each series so that a subset of other labels may be returned.
+type ProjectionsRangeHead struct {
+	RangeHead
+}
+
+func NewProjectionsRangeHead(head *Head, mint, maxt int64) *ProjectionsRangeHead {
+	return &ProjectionsRangeHead{
+		RangeHead: RangeHead{
+			head: head,
+			mint: mint,
+			maxt: maxt,
+		},
+	}
+}
+
+func (h *ProjectionsRangeHead) Index() (IndexReader, error) {
+	return h.head.indexRange(h.mint, h.maxt, true), nil
+}
+
 // StaleHead allows querying the stale series in the Head via an IndexReader, ChunkReader and tombstones.Reader.
 // Used only for compactions.
 type StaleHead struct {
@@ -1725,7 +1749,7 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	// Do not delete anything beyond the currently valid range.
 	mint, maxt = clampInterval(mint, maxt, h.MinTime(), h.MaxTime())
 
-	ir := h.indexRange(mint, maxt)
+	ir := h.indexRange(mint, maxt, false)
 
 	p, err := ir.PostingsForMatchers(ctx, false, ms...)
 	if err != nil {
@@ -1956,6 +1980,7 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	if h.opts.EnableSharding {
 		shardHash = labels.StableHash(lset)
 	}
+
 	optimisticallyCreatedSeries := newMemSeries(lset, id, shardHash, h.secondaryHashFunc(lset), h.opts.ChunkEndTimeVariance, h.opts.IsolationDisabled, pendingCommit)
 
 	s, created := h.series.setUnlessAlreadySet(hash, lset, optimisticallyCreatedSeries)

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -1201,7 +1201,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange_AppenderV2(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			headIdxReader := head.indexRange(tt.mint, tt.maxt)
+			headIdxReader := head.indexRange(tt.mint, tt.maxt, false)
 			actualLabelNames, err := headIdxReader.LabelNames(ctx)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedNames, actualLabelNames)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -35,19 +35,20 @@ func (h *Head) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, er
 
 // Index returns an IndexReader against the block.
 func (h *Head) Index() (IndexReader, error) {
-	return h.indexRange(math.MinInt64, math.MaxInt64), nil
+	return h.indexRange(math.MinInt64, math.MaxInt64, false), nil
 }
 
-func (h *Head) indexRange(mint, maxt int64) *headIndexReader {
+func (h *Head) indexRange(mint, maxt int64, includeSeriesHash bool) *headIndexReader {
 	if hmin := h.MinTime(); hmin > mint {
 		mint = hmin
 	}
-	return &headIndexReader{head: h, mint: mint, maxt: maxt}
+	return &headIndexReader{head: h, mint: mint, maxt: maxt, includeSeriesHash: includeSeriesHash}
 }
 
 type headIndexReader struct {
-	head       *Head
-	mint, maxt int64
+	head              *Head
+	mint, maxt        int64
+	includeSeriesHash bool
 }
 
 func (*headIndexReader) Close() error {
@@ -139,9 +140,16 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))
 	}
 
-	slices.SortFunc(series, func(a, b *memSeries) int {
-		return labels.Compare(a.labels(), b.labels())
-	})
+	// If the memSeries have a series hash label set and we haven't been
+	// told to include it in the output (when projections aren't being used)
+	// then we need to remove it from the label sets before sorting them.
+	// Otherwise, the label sets don't have the series hash or, we should
+	// include it so we don't remove anything.
+	if h.head.opts.EnableSeriesHash && !h.includeSeriesHash {
+		slices.SortFunc(series, compareWithoutSeriesHash)
+	} else {
+		slices.SortFunc(series, compareWithSeriesHash)
+	}
 
 	// Convert back to list.
 	ep := make([]storage.SeriesRef, 0, len(series))
@@ -149,6 +157,22 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		ep = append(ep, storage.SeriesRef(p.ref))
 	}
 	return index.NewListPostings(ep)
+}
+
+func compareWithSeriesHash(a, b *memSeries) int {
+	return labels.Compare(a.labels(), b.labels())
+}
+
+func compareWithoutSeriesHash(a, b *memSeries) int {
+	lsetA := a.labels().DropReserved(func(name string) bool {
+		return name == SeriesHashLabel
+	})
+
+	lsetB := b.labels().DropReserved(func(name string) bool {
+		return name == SeriesHashLabel
+	})
+
+	return labels.Compare(lsetA, lsetB)
 }
 
 // ShardedPostings implements IndexReader. This function returns an failing postings list if sharding
@@ -202,7 +226,14 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 		h.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	builder.Assign(s.labels())
+
+	if h.head.opts.EnableSeriesHash && !h.includeSeriesHash {
+		builder.Assign(s.labels().DropReserved(func(name string) bool {
+			return name == SeriesHashLabel
+		}))
+	} else {
+		builder.Assign(s.labels())
+	}
 
 	if chks == nil {
 		return nil
@@ -219,7 +250,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 
 func (h *Head) staleIndex(mint, maxt int64, staleSeriesRefs []storage.SeriesRef) (*headStaleIndexReader, error) {
 	return &headStaleIndexReader{
-		headIndexReader: h.indexRange(mint, maxt),
+		headIndexReader: h.indexRange(mint, maxt, false),
 		staleSeriesRefs: staleSeriesRefs,
 	}, nil
 }

--- a/tsdb/head_read_mimir.go
+++ b/tsdb/head_read_mimir.go
@@ -13,8 +13,10 @@
 
 package tsdb
 
-import "math"
+import (
+	"math"
+)
 
 func (h *Head) MustIndex() IndexReader {
-	return h.indexRange(math.MinInt64, math.MaxInt64)
+	return h.indexRange(math.MinInt64, math.MaxInt64, false)
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2573,7 +2573,7 @@ func TestGCChunkAccess(t *testing.T) {
 	require.True(t, ok, "series append failed")
 	require.False(t, chunkCreated, "chunks was created")
 
-	idx := h.indexRange(0, 1500)
+	idx := h.indexRange(0, 1500, false)
 	var (
 		chnks   []chunks.Meta
 		builder labels.ScratchBuilder
@@ -2629,7 +2629,7 @@ func TestGCSeriesAccess(t *testing.T) {
 	require.True(t, ok, "series append failed")
 	require.False(t, chunkCreated, "chunks was created")
 
-	idx := h.indexRange(0, 2000)
+	idx := h.indexRange(0, 2000, false)
 	var (
 		chunks  []chunks.Meta
 		builder labels.ScratchBuilder
@@ -3513,7 +3513,7 @@ func TestHeadLabelNamesValuesWithMinMaxRange(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			headIdxReader := head.indexRange(tt.mint, tt.maxt)
+			headIdxReader := head.indexRange(tt.mint, tt.maxt, false)
 			actualLabelNames, err := headIdxReader.LabelNames(ctx)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedNames, actualLabelNames)
@@ -3589,7 +3589,7 @@ func TestHeadLabelValuesWithMatchers(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			headIdxReader := head.indexRange(0, 200)
+			headIdxReader := head.indexRange(0, 200, false)
 
 			actualValues, err := headIdxReader.SortedLabelValues(ctx, tt.labelName, nil, tt.matchers...)
 			require.NoError(t, err)
@@ -3659,7 +3659,7 @@ func TestHeadLabelNamesWithMatchers(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			headIdxReader := head.indexRange(0, 200)
+			headIdxReader := head.indexRange(0, 200, false)
 
 			actualNames, err := headIdxReader.LabelNames(context.Background(), tt.matchers...)
 			require.NoError(t, err)
@@ -3683,7 +3683,7 @@ func TestHeadShardedPostings(t *testing.T) {
 	}
 	require.NoError(t, app.Commit())
 
-	ir := head.indexRange(0, 200)
+	ir := head.indexRange(0, 200, false)
 
 	// List all postings for a given label value. This is what we expect to get
 	// in output from all shards.
@@ -3905,7 +3905,7 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	}
 	require.NoError(b, app.Commit())
 
-	headIdxReader := head.indexRange(0, 200)
+	headIdxReader := head.indexRange(0, 200, false)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "c_ninety", "value0")}
 
 	b.ReportAllocs()


### PR DESCRIPTION
Add a method for getting a ChunkQuerier for use with projections that only operates on the TSDB head. Based on configuration it will take `__series_hash__` into account when sorting postings and populating series.
