### PR TITLE
Cherry-pick new fields in `stats.QuerySamples` from upstream #18081

### DIFF
--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -245,6 +245,15 @@ type QuerySamples struct {
 	// range query engine that reduce the actual work that happens.
 	TotalSamplesPerStep []int64
 
+	// SamplesRead is the number of samples read (I/O). For range-vector functions
+	// in range queries, only new points per step are counted; elsewhere it
+	// equals TotalSamples.
+	SamplesRead int64
+
+	// SamplesReadPerStep is the number of samples read per step. For
+	// range-vector functions, step 0 is the full window, later steps only new points.
+	SamplesReadPerStep []int64
+
 	EnablePerStepStats bool
 	StartTimestamp     int64
 	Interval           int64


### PR DESCRIPTION
This PR cherry-picks the two new fields added to `stats.QuerySamples` in https://github.com/prometheus/prometheus/pull/18081 to make it easier to implement the equivalent logic in Mimir's MQE.

The other changes in that PR are not included here, and adding these fields should have no impact on the existing logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2ae18a5308236f5a90b805cfa09581f30e5f9bfa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->