### PR TITLE
github: trigger-mimir-update needs different permission set depending on head

### DIFF
--- a/.github/workflows/trigger-mimir-update.yml
+++ b/.github/workflows/trigger-mimir-update.yml
@@ -19,6 +19,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
           github_app: mimir-github-bot
+          permission_set: ${{ github.ref == 'refs/heads/main' && 'main' || 'release' }}
 
       - name: Send repository_dispatch to grafana/mimir
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0


### PR DESCRIPTION
Follow up to https://github.com/grafana/mimir-prometheus/pull/1163

The current version in the `main`, fails with status 400 ([example](https://github.com/grafana/mimir-prometheus/actions/runs/26046615104/job/76595536660)):

```
Vault auth failed (HTTP 400)
{"errors":["role \"mimir-prometheus-49ae13537d03923bd3c8f1f1f01525d6e82edbcfdd53a94895b2e3162474e589-default\" could not be found"]}
```

This workflow needs a special permission set, depending on the head. This was already implemented in `grafana/mimir` (ref https://github.com/grafana/mimir/blob/53c04e858f532536f3bf976c7d26307e97f9ce8a/.github/workflows/trigger-backend-enterprise-update.yml#L22C11-L22C88).