### PR TITLE
storage: Add metadata attribute to SearchResult 

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -354,6 +354,10 @@ type SearchResult struct {
 	// Score represents relevance, with 1.0 being a perfect match.
 	// Score range is [0.0, 1.0].
 	Score float64
+
+	// Optional metric metadata. This has been added specifically
+	// for use in Mimir.
+	Metadata *metadata.Metadata
 }
 
 // Searcher provides search capabilities with relevance scoring.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

This PR overrides the default storage.SearchResult which is used in the streaming labels/values API.

An optional Metadata attribute has been added, which will be used in the Mimir implementation of these APIs.

I have not recorded a changelog entry since this is an internal implementation change which does not affect end users.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
None
```
