### PR TITLE
gha: Address recommendations from supply chain GHA audit

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,8 +32,10 @@ jobs:
           ref: ea415d5eaa70337430db7ae7782f28dd14a15525
           persist-credentials: false
 
+      # --ignore-scripts blocks transitive lifecycle scripts; id-token: write
+      # is in scope on the App-token step below, so install must not run code.
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: npm install --production --prefix ./actions --ignore-scripts
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,23 +427,19 @@ jobs:
         run: |
           echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
           echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-      # github.ref scopes caches per branch/PR so a malicious PR cannot poison
-      # main; restore-keys lets PRs warm-start from main's cache read-only.
       - name: Cache dependencies
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.gopaths.outputs.GOMODCACHE }}
-          key: ci-fuzz-dependencies-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ci-fuzz-dependencies-${{ runner.os }}-refs/heads/main-${{ hashFiles('**/go.sum') }}
+          # Use the same dependencies cache for all instances of this 'fuzz' job, given each will use the same dependencies.
+          key: ci-fuzz-dependencies-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
       - name: Cache build cache
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.gopaths.outputs.GOCACHE }}
-          key: ci-fuzz-build-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ci-fuzz-build-cache-${{ runner.os }}-refs/heads/main-${{ hashFiles('**/go.sum') }}
+          # Use the same build cache for each instance of this 'fuzz' job, given each will build the same package (model/labels) with the same build tags.
+          key: ci-fuzz-build-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
       - name: Set -fuzztime=10m for 'main' branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,10 +414,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: '~1.23.0'
           cache: false # We do this ourselves below to avoid conflicts between the different jobs.
@@ -427,19 +427,23 @@ jobs:
         run: |
           echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
           echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+      # github.ref scopes caches per branch/PR so a malicious PR cannot poison
+      # main; restore-keys lets PRs warm-start from main's cache read-only.
       - name: Cache dependencies
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.gopaths.outputs.GOMODCACHE }}
-          # Use the same dependencies cache for all instances of this 'fuzz' job, given each will use the same dependencies.
-          key: ci-fuzz-dependencies-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: ci-fuzz-dependencies-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ci-fuzz-dependencies-${{ runner.os }}-refs/heads/main-${{ hashFiles('**/go.sum') }}
 
       - name: Cache build cache
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.gopaths.outputs.GOCACHE }}
-          # Use the same build cache for each instance of this 'fuzz' job, given each will build the same package (model/labels) with the same build tags.
-          key: ci-fuzz-build-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: ci-fuzz-build-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ci-fuzz-build-cache-${{ runner.os }}-refs/heads/main-${{ hashFiles('**/go.sum') }}
 
       - name: Set -fuzztime=10m for 'main' branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Bot branch: $BOT_BRANCH"
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ steps.set-branches.outputs.local_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
       merge_result: ${{ steps.merge-attempt.outputs.merge_result }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.check-merge.outputs.local_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -135,21 +135,25 @@ jobs:
           set-safe-directory: "*"
 
       - name: Add prometheus/prometheus remote and fetch
+        env:
+          UPSTREAM_COMMIT: ${{ needs.check-merge.outputs.upstream_commit }}
         run: |
           git remote add prometheus https://github.com/prometheus/prometheus.git
-          git fetch prometheus ${{ needs.check-merge.outputs.upstream_commit }}
+          git fetch prometheus "$UPSTREAM_COMMIT"
 
       - name: Attempt merge
         id: merge-attempt
+        env:
+          UPSTREAM_COMMIT: ${{ needs.check-merge.outputs.upstream_commit }}
         run: |
           # Configure git for the merge
           git config user.name "mimir-github-bot[bot]"
           git config user.email "mimir-github-bot[bot]@users.noreply.github.com"
 
-          echo "Attempting to merge ${{ needs.check-merge.outputs.upstream_commit }}..."
+          echo "Attempting to merge $UPSTREAM_COMMIT..."
 
           # Attempt the merge
-          if git merge ${{ needs.check-merge.outputs.upstream_commit }} --no-edit; then
+          if git merge "$UPSTREAM_COMMIT" --no-edit; then
             echo "merge_result=success" >> $GITHUB_OUTPUT
             echo "Merge successful!"
             git log --oneline -1
@@ -158,7 +162,7 @@ jobs:
             git merge --abort
 
             # Check if conflicts exist
-            git merge ${{ needs.check-merge.outputs.upstream_commit }} --no-commit --no-ff || true
+            git merge "$UPSTREAM_COMMIT" --no-commit --no-ff || true
 
             if git diff --name-only --diff-filter=U | grep -q .; then
               echo "merge_result=conflicts" >> $GITHUB_OUTPUT
@@ -184,7 +188,7 @@ jobs:
       pr_url: ${{ steps.create-conflict-pr.outputs.pull-request-url }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.check-merge.outputs.local_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -284,10 +288,13 @@ jobs:
             ```
 
       - name: Close PR by force-pushing to HEAD~1
+        env:
+          LOCAL_BRANCH: ${{ needs.check-merge.outputs.local_branch }}
+          BOT_BRANCH: ${{ needs.check-merge.outputs.bot_branch }}
         run: |
           # Force-push to the same commit as the base branch (removes the empty commit, leaving no commits in the PR).
           # This closes the PR while keeping the branch and instructions as a placeholder
-          git push --force origin ${{needs.check-merge.outputs.local_branch}}:${{ needs.check-merge.outputs.bot_branch }}
+          git push --force origin "${LOCAL_BRANCH}:${BOT_BRANCH}"
 
       - name: Send Slack notification for merge conflicts
         uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
@@ -327,7 +334,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.check-merge.outputs.local_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -335,16 +342,18 @@ jobs:
           set-safe-directory: "*"
 
       - name: Add prometheus/prometheus remote and perform merge
+        env:
+          UPSTREAM_COMMIT: ${{ needs.check-merge.outputs.upstream_commit }}
         run: |
           git remote add prometheus https://github.com/prometheus/prometheus.git
-          git fetch prometheus ${{ needs.check-merge.outputs.upstream_commit }}
+          git fetch prometheus "$UPSTREAM_COMMIT"
 
           # Configure git
           git config user.name "mimir-github-bot[bot]"
           git config user.email "mimir-github-bot[bot]@users.noreply.github.com"
 
           # Perform the merge (we know it will succeed)
-          git merge ${{ needs.check-merge.outputs.upstream_commit }} --no-edit
+          git merge "$UPSTREAM_COMMIT" --no-edit
 
       # This job uses "mimir-github-bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,3 +31,5 @@
 # /discovery/aliyun               @prometheus/default-maintainers @KeyOfSpectator
 # https://github.com/prometheus/prometheus/pull/14108#issuecomment-2639515421
 # /discovery/nomad                @prometheus/default-maintainers @jaloren @jrasell
+
+/.github/  @prometheus/default-maintainers @grafana/mimir-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,34 +2,32 @@
 # Please keep this file in sync with the MAINTAINERS.md file!
 #
 
-# Prometheus team members are members of the "default maintainers" github team.
-# They are code owners by default for the whole repo.
-* @prometheus/default-maintainers
+# Note that mimir-maintainers have been added to the default list to reflect that
+# they own this fork.
+* @prometheus/default-maintainers @grafana/mimir-maintainers
 
 # Subsystems.
-/Makefile                       @prometheus/default-maintainers @simonpasquier @SuperQ
-/cmd/promtool                   @prometheus/default-maintainers @dgl
-/documentation/prometheus-mixin @prometheus/default-maintainers @metalmatze
-/model/histogram                @prometheus/default-maintainers @beorn7 @krajorama
-/web/ui                         @prometheus/default-maintainers @juliusv
-/web/ui/module                  @prometheus/default-maintainers @juliusv @nexucis
-/promql                         @prometheus/default-maintainers @roidelapluie
-/storage/remote                 @prometheus/default-maintainers @cstyan @bwplotka @tomwilkie @alexgreenbank
-/storage/remote/otlptranslator  @prometheus/default-maintainers @aknuds1 @jesusvazquez @ArthurSens
-/tsdb                           @prometheus/default-maintainers @jesusvazquez @codesome @bwplotka @krajorama
-/tsdb/agent                     @prometheus/default-maintainers @jesusvazquez @codesome @bwplotka @krajorama @kgeckhart
+/Makefile                       @prometheus/default-maintainers @grafana/mimir-maintainers @simonpasquier @SuperQ
+/cmd/promtool                   @prometheus/default-maintainers @grafana/mimir-maintainers @dgl
+/documentation/prometheus-mixin @prometheus/default-maintainers @grafana/mimir-maintainers @metalmatze
+/model/histogram                @prometheus/default-maintainers @grafana/mimir-maintainers @beorn7 @krajorama
+/web/ui                         @prometheus/default-maintainers @grafana/mimir-maintainers @juliusv
+/web/ui/module                  @prometheus/default-maintainers @grafana/mimir-maintainers @juliusv @nexucis
+/promql                         @prometheus/default-maintainers @grafana/mimir-maintainers @roidelapluie
+/storage/remote                 @prometheus/default-maintainers @grafana/mimir-maintainers @cstyan @bwplotka @tomwilkie @alexgreenbank
+/storage/remote/otlptranslator  @prometheus/default-maintainers @grafana/mimir-maintainers @aknuds1 @jesusvazquez @ArthurSens
+/tsdb                           @prometheus/default-maintainers @grafana/mimir-maintainers @jesusvazquez @codesome @bwplotka @krajorama
+/tsdb/agent                     @prometheus/default-maintainers @grafana/mimir-maintainers @jesusvazquez @codesome @bwplotka @krajorama @kgeckhart
 
 # Service discovery.
-/discovery/kubernetes           @prometheus/default-maintainers @brancz @rexagod
-/discovery/stackit              @prometheus/default-maintainers @jkroepke
-/discovery/aws/                 @prometheus/default-maintainers @matt-gp @sysadmind
-/discovery/consul               @prometheus/default-maintainers @mrvarmazyar
-/discovery/hetzner              @prometheus/default-maintainers @jooola @apricote
-/discovery/scaleway             @prometheus/default-maintainers @remyleone
+/discovery/kubernetes           @prometheus/default-maintainers @grafana/mimir-maintainers @brancz @rexagod
+/discovery/stackit              @prometheus/default-maintainers @grafana/mimir-maintainers @jkroepke
+/discovery/aws/                 @prometheus/default-maintainers @grafana/mimir-maintainers @matt-gp @sysadmind
+/discovery/consul               @prometheus/default-maintainers @grafana/mimir-maintainers @mrvarmazyar
+/discovery/hetzner              @prometheus/default-maintainers @grafana/mimir-maintainers @jooola @apricote
+/discovery/scaleway             @prometheus/default-maintainers @grafana/mimir-maintainers @remyleone
 # Pending
 # https://github.com/prometheus/prometheus/pull/15212#issuecomment-3575225179
 # /discovery/aliyun               @prometheus/default-maintainers @KeyOfSpectator
 # https://github.com/prometheus/prometheus/pull/14108#issuecomment-2639515421
 # /discovery/nomad                @prometheus/default-maintainers @jaloren @jrasell
-
-/.github/  @prometheus/default-maintainers @grafana/mimir-maintainers


### PR DESCRIPTION
This PR addresses recommendations made through a GitHub actions audit/review.

Changes include;

* include `--ignore-scripts` on npm invocations
* pin actions to a sha version
* move variables evaluations into `env` (env evaluates ${{ … }} and pastes the raw result into the YAML before handing it to the runner, vs evaluating in the runner then runs the resulting run: block as a shell script
* add mimir-maintainers to the .github CODEOWNERS

#### Which issue(s) does the PR fix:

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

NONE

```release-notes

```
