### PR TITLE
ci: align backport workflow with mimir

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
+        uses: grafana/grafana-github-actions-go/backport@f2ff9dbe233e961f553cb7738b114b039ec26e8b
         with:
           token: ${{ steps.app-token.outputs.token }}
           # If triggered by being labelled, only backport that label.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,5 @@
 name: Backport PR Creator
+run-name: "Backport for ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"
 
 on:
   pull_request:
@@ -9,7 +10,6 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
   main:
@@ -18,34 +18,37 @@ jobs:
     # We don't run the backporting for PRs from forks because those can't access "mimir-github-bot" secrets in vault.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
     # Also only run if the PR is merged, as an extra safe-guard.
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
+    # On 'labeled' events, require that the label just added is itself a backport label, otherwise
+    # adding an unrelated label to an already-backported PR would re-trigger the job with the wrong label.
+    if: |
+      !github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport ')) ||
+        (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ','), 'backport '))
+      )
 
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
-          # pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
-          # we don't want to have the same strict rules for PR labels
-          # We also use our own version which works with merge commits since a lot of the commits in this repo are merge commits.
-          ref: ea415d5eaa70337430db7ae7782f28dd14a15525
-          persist-credentials: false
-
-      # --ignore-scripts blocks transitive lifecycle scripts; id-token: write
-      # is in scope on the App-token step below, so install must not run code.
-      - name: Install Actions
-        run: npm install --production --prefix ./actions --ignore-scripts
-
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
           github_app: mimir-github-bot
 
+      - name: Checkout Mimir
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 2
+          persist-credentials: false
+
       - name: Run backport
-        uses: ./actions/backport
+        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
         with:
           token: ${{ steps.app-token.outputs.token }}
-          labelsToAdd: "backport"
-          title: "[{{base}}] {{originalTitle}}"
+          # If triggered by being labelled, only backport that label.
+          # Otherwise, the action will backport all labels.
+          pr_label: ${{ github.event.action == 'labeled' && github.event.label.name || '' }}
+          pr_number: ${{ github.event.pull_request.number }}
+          repo_owner: ${{ github.repository_owner }}
+          repo_name: ${{ github.event.repository.name }}


### PR DESCRIPTION
## what
mirror the backport workflow from [grafana/mimir's `backport.yaml`](https://github.com/grafana/mimir/blob/b719d34b9e2214c7d0afeb79fed99ae7ba8b740d/.github/workflows/backport.yaml): switch to the Go-based `grafana/grafana-github-actions-go/backport` action, drop the npm install step, and tighten the trigger condition. while here, bump the action to the latest SHA (`f2ff9db`).

## why
keeping the two repos in sync on tooling. the Go-based action is what mimir uses now, and produces signed/verified commits.

## notes
- kept the filename as `backport.yml` (mimir uses `.yaml`) to avoid churn.
- dropped `pull-requests: write` from top-level permissions — the app token covers it.
- this lands on a newer action SHA than mimir is currently pinned to; happy to align them in a follow-up on the mimir side, it's mostly deps bumps and a minor bug fix for PRs without any label