### PR TITLE
tsdb: add benchmarks for CompactSelectedSeries and filterSeriesAndSortPostings

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1516,6 +1516,150 @@ func BenchmarkCompactionFromOOOHead(b *testing.B) {
 	}
 }
 
+// setupDBForSelectedSeriesBenchmark opens a fresh DB whose head contains
+// totalSeries series, each with samplesPerSeries in-order samples confined to
+// a single 1s head chunk range. It returns the DB and the head series
+// refs in append order.
+//
+// Auto-compaction is disabled so the benchmark observes exactly the state
+// produced by this helper. The caller owns the returned DB and must close it.
+//
+// The helper is shared by BenchmarkCompactSelectedSeries and the upcoming
+// filterSeriesAndSortPostings benchmark, so it does not assume which entry
+// point will use the setup.
+func setupDBForSelectedSeriesBenchmark(tb testing.TB, totalSeries, samplesPerSeries int) (*DB, []storage.SeriesRef) {
+	require.Positive(tb, samplesPerSeries, "samplesPerSeries must be > 0")
+	require.LessOrEqual(tb, samplesPerSeries, 1000, "samples must fit one head chunk range (1000 ms)")
+
+	opts := DefaultOptions()
+	opts.MinBlockDuration = 1000
+	opts.MaxBlockDuration = 1000
+	db, err := Open(tb.TempDir(), nil, nil, opts, nil)
+	require.NoError(tb, err)
+	db.DisableCompactions()
+
+	const appendBatch = 10_000
+	refs := make([]storage.SeriesRef, 0, totalSeries)
+	app := db.Appender(context.Background())
+	for i := range totalSeries {
+		lbls := labels.FromStrings("__name__", "metric", "instance", strconv.Itoa(i))
+		var ref storage.SeriesRef
+		for ts := int64(0); ts < int64(samplesPerSeries); ts++ {
+			ref, err = app.Append(ref, lbls, ts, float64(ts))
+			require.NoError(tb, err)
+		}
+		refs = append(refs, ref)
+		if (i+1)%appendBatch == 0 {
+			require.NoError(tb, app.Commit())
+			app = db.Appender(context.Background())
+		}
+	}
+	require.NoError(tb, app.Commit())
+	return db, refs
+}
+
+// pickRefsEvenly returns count refs sampled at approximately even intervals
+// across refs. This distributes the selected refs over the full input range
+// rather than clustering them, which is useful for benchmarks that want
+// postings intersections to scan most of the postings list.
+func pickRefsEvenly(refs []storage.SeriesRef, count int) []storage.SeriesRef {
+	if count >= len(refs) {
+		out := make([]storage.SeriesRef, len(refs))
+		copy(out, refs)
+		return out
+	}
+	out := make([]storage.SeriesRef, 0, count)
+	step := float64(len(refs)) / float64(count)
+	for i := range count {
+		out = append(out, refs[int(float64(i)*step)])
+	}
+	return out
+}
+
+// BenchmarkCompactSelectedSeries measures the end-to-end cost of compacting a
+// selected subset of head series into blocks and evicting them from the head.
+//
+// The benchmark keeps the head size fixed and varies the selected fraction
+// (100%, 50%, 30%, 10%, 1%, and 0.1%). A 100% selection approximates the
+// workload of CompactStaleHead, while smaller fractions measure how much work
+// is avoided when SelectedSeriesHead restricts compaction to a small subset of
+// series.
+//
+// Each iteration rebuilds the DB because CompactSelectedSeries is destructive:
+// selected series are evicted from the head and cannot be reused by subsequent
+// iterations.
+//
+// Each series contains DefaultSamplesPerChunk samples, matching the TSDB's
+// target chunk size so chunk-writing costs are representative of production
+// workloads rather than degenerate single-sample chunks.
+func BenchmarkCompactSelectedSeries(b *testing.B) {
+	const (
+		totalSeries      = 100_000
+		samplesPerSeries = DefaultSamplesPerChunk
+	)
+	fractions := []float64{1.0, 0.5, 0.3, 0.1, 0.01, 0.001}
+
+	for _, fraction := range fractions {
+		selectedCount := max(1, int(float64(totalSeries)*fraction))
+		b.Run(fmt.Sprintf("totalSeries=%d/selectedSeries=%d", totalSeries, selectedCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				db, allRefs := setupDBForSelectedSeriesBenchmark(b, totalSeries, samplesPerSeries)
+				selectedRefs := pickRefsEvenly(allRefs, selectedCount)
+				b.StartTimer()
+
+				require.NoError(b, db.CompactSelectedSeries(selectedRefs))
+
+				b.StopTimer()
+				require.NoError(b, db.Close())
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// BenchmarkFilterSeriesAndSortPostings measures the cost of
+// Head.filterSeriesAndSortPostings under the isSeriesWithoutOOO predicate.
+// This is the filtering step performed by CompactSelectedSeries while holding
+// db.cmtx, before invoking compactHeadViewLocked.
+//
+// The operation is O(N log N) in the number of candidate refs and is a likely
+// contributor to the fixed-cost floor observed at low selectivity in
+// BenchmarkCompactSelectedSeries.
+//
+// The benchmark varies the input size as a fraction of a fixed head size,
+// mirroring BenchmarkCompactSelectedSeries so the results can be compared
+// directly. The head is built once per sub-benchmark because the function is
+// non-destructive.
+//
+// samplesPerSeries matches BenchmarkCompactSelectedSeries for setup
+// consistency, although the filter only examines series-level state and is
+// insensitive to its value.
+func BenchmarkFilterSeriesAndSortPostings(b *testing.B) {
+	const (
+		totalSeries      = 100_000
+		samplesPerSeries = DefaultSamplesPerChunk
+	)
+	fractions := []float64{1.0, 0.5, 0.3, 0.1, 0.01, 0.001}
+
+	for _, fraction := range fractions {
+		inputCount := max(1, int(float64(totalSeries)*fraction))
+		b.Run(fmt.Sprintf("totalSeries=%d/inputSeries=%d", totalSeries, inputCount), func(b *testing.B) {
+			db, allRefs := setupDBForSelectedSeriesBenchmark(b, totalSeries, samplesPerSeries)
+			b.Cleanup(func() { require.NoError(b, db.Close()) })
+			inputRefs := pickRefsEvenly(allRefs, inputCount)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err := db.head.filterSeriesAndSortPostings(index.NewListPostings(inputRefs), isSeriesWithoutOOO)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
 // TestDisableAutoCompactions checks that we can
 // disable and enable the auto compaction.
 // This is needed for unit tests that rely on


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### What this PR does

Adds two benchmarks for the `DB.CompactSelectedSeries()` entry point introduced in #1154:

- `BenchmarkCompactSelectedSeries`: measures the end-to-end cost of compacting and evicting a selected subset of head series.
- `BenchmarkFilterSeriesAndSortPostings`: isolates the upfront filter-and-sort step that runs under the compaction lock before block writing begins.

Together, these benchmarks help quantify how the operation scales with the number of selected series and identify where the fixed costs come from.

For a head containing **100k series × 120 samples per series** (single chunk range; benchmark run on an Apple M5 Pro), the cost of compacting N selected series is approximately:

- **Wall time**: `140 ms + 8.7 µs × N`
- **Memory**: `45 MB + 1.9 KB × N`

The model fits well once roughly **10% or more of the head** is selected. Below that point, wall-clock time bottoms out at a fixed cost of about `140 ms`, dominated by `db.reloadBlocks()` and `RebuildSymbolTable()`, which scan the entire head regardless of how many series are compacted. Memory usage, however, continues to decrease roughly in proportion to the number of selected series.

##### Benchmark setup

The benchmark populates a TSDB head with:

- 100,000 series
- 120 samples per series (`DefaultSamplesPerChunk`)
- One chunk range per series

It then compacts different fractions of the head:

| Selected fraction | Selected series |
|---|---:|
| 100% | 100,000 |
| 50% | 50,000 |
| 30% | 30,000 |
| 10% | 10,000 |
| 1% | 1,000 |
| 0.1% | 100 |

##### End-to-end compaction (`BenchmarkCompactSelectedSeries`)

| Selected | Time | Memory |
|---|---:|---:|
| 100,000 | 1,013 ms | 239 MB |
| 50,000 | 571 ms | 140 MB |
| 30,000 | 407 ms | 110 MB |
| 10,000 | 232 ms | 66 MB |
| 1,000 | 152 ms | 47 MB |
| 100 | 140 ms | 45 MB |

The results show two distinct regimes:

- At `30%`-`100%` selectivity, _runtime and memory scale approximately linearly with the number of selected series_.
- Below `10%` selectivity, runtime flattens out around `140 ms`, indicating a fixed-cost floor that is largely independent of selection size.

A simple approximation for the end-to-end operation is:

> Time ≈ 140 ms + 8.7 µs × selected series
>
> Memory ≈ 45 MB + 1.9 KB × selected series

The fit is surprisingly accurate across the high-selectivity range.

##### Filter-and-sort only (`BenchmarkFilterSeriesAndSortPostings`)

| Input refs | Time | Memory |
|---|---:|---:|
| 100,000 | 24.8 ms | 9.8 MB |
| 50,000 | 13.5 ms | 4.7 MB |
| 30,000 | 7.8 ms | 2.8 MB |
| 10,000 | 2.4 ms | 676 KB |
| 1,000 | 0.21 ms | 16 KB |
| 100 | 0.023 ms | 9 KB |

This step scales nearly linearly and remains inexpensive even at the largest input size.

At 100k refs it contributes only ~25 ms out of ~1 second total runtime (~2.4%). At lower selectivities it becomes effectively negligible.

##### Key observations

- `CompactSelectedSeries()` scales predictably with the number of selected series.
- The filter-and-sort phase is not a bottleneck.
- The fixed `~140 ms` floor is dominated by work that is independent of selection size, primarily:
  - `db.reloadBlocks()`
  - `RebuildSymbolTable()`
  - Other whole-head maintenance work
- For callers such as Mimir's block builder, compacting very small batches does not significantly reduce wall-clock cost because the fixed overhead dominates.

##### Caveats

The benchmark is intended to characterize scaling behavior rather than predict exact production latencies.

Notable simplifications:

- The results show here come from a local development machine (Apple M5 Pro).
- No out-of-order data.
- Single chunk range.
- Disk writes benefit from the local filesystem cache.

While absolute timings will vary in production, the observed scaling characteristics should carry over.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*
