### PR TITLE
tsdb: lazily filter ShardedPostings in the Head

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -160,36 +160,115 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 	return index.NewListPostings(ep)
 }
 
-// ShardedPostings implements IndexReader. This function returns an failing postings list if sharding
+// ShardedPostings implements IndexReader. This function returns a failing postings list if sharding
 // has not been enabled in the Head.
+//
+// The returned postings filter lazily: each call to Next/Seek looks up the series in the Head to
+// check shard membership. This keeps the series hot in the CPU cache for the subsequent Series()
+// call that the caller typically makes to retrieve the labels of the same ref.
 func (h *headIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCount uint64) index.Postings {
 	if !h.head.opts.EnableSharding {
 		return index.ErrPostings(errors.New("sharding is disabled"))
 	}
 
-	out := make([]storage.SeriesRef, 0, 128)
-	notFoundSeriesCount := 0
-
-	for p.Next() {
-		s := h.head.series.getByID(chunks.HeadSeriesRef(p.At()))
-		if s == nil {
-			notFoundSeriesCount++
-			continue
-		}
-
-		// Check if the series belong to the shard.
-		if s.shardHash%shardCount != shardIndex {
-			continue
-		}
-
-		out = append(out, storage.SeriesRef(s.ref))
+	// When shardCount is a power of two, the modulo used to compute shard membership can be
+	// replaced by a cheaper bitwise AND with shardCount-1.
+	if shardCount > 0 && shardCount&(shardCount-1) == 0 {
+		return &lazyPostingsShardPowerOfTwo{p: p, shardIndex: shardIndex, shardCount: shardCount, head: h.head}
 	}
-	if notFoundSeriesCount > 0 {
-		h.head.logger.Debug("Looked up series not found", "count", notFoundSeriesCount)
-	}
-
-	return index.NewListPostings(out)
+	return &lazyPostingsShardDecimal{p: p, shardIndex: shardIndex, shardCount: shardCount, head: h.head}
 }
+
+// lazyPostingsShardDecimal is a lazy index.Postings that filters the wrapped postings p, keeping only
+// the series belonging to shardIndex out of shardCount, using a modulo division.
+type lazyPostingsShardDecimal struct {
+	p          index.Postings
+	shardIndex uint64
+	shardCount uint64
+	head       *Head
+	cur        storage.SeriesRef
+}
+
+// Next implements index.Postings.
+func (p *lazyPostingsShardDecimal) Next() bool {
+	for p.p.Next() {
+		s := p.head.series.getByID(chunks.HeadSeriesRef(p.p.At()))
+		if s == nil || s.shardHash%p.shardCount != p.shardIndex {
+			continue
+		}
+		p.cur = storage.SeriesRef(s.ref)
+		return true
+	}
+	return false
+}
+
+// Seek implements index.Postings.
+func (p *lazyPostingsShardDecimal) Seek(v storage.SeriesRef) bool {
+	if p.cur >= v {
+		return true
+	}
+	for ok := p.p.Seek(v); ok; ok = p.p.Next() {
+		s := p.head.series.getByID(chunks.HeadSeriesRef(p.p.At()))
+		if s == nil || s.shardHash%p.shardCount != p.shardIndex {
+			continue
+		}
+		p.cur = storage.SeriesRef(s.ref)
+		return true
+	}
+	return false
+}
+
+// At implements index.Postings.
+func (p *lazyPostingsShardDecimal) At() storage.SeriesRef { return p.cur }
+
+// Err implements index.Postings.
+func (p *lazyPostingsShardDecimal) Err() error { return p.p.Err() }
+
+// lazyPostingsShardPowerOfTwo is a lazy index.Postings that filters the wrapped postings p, keeping
+// only the series belonging to shardIndex out of shardCount, using a bitwise AND. It is only valid
+// when shardCount is a power of two.
+type lazyPostingsShardPowerOfTwo struct {
+	p          index.Postings
+	shardIndex uint64
+	shardCount uint64
+	head       *Head
+	cur        storage.SeriesRef
+}
+
+// Next implements index.Postings.
+func (p *lazyPostingsShardPowerOfTwo) Next() bool {
+	for p.p.Next() {
+		s := p.head.series.getByID(chunks.HeadSeriesRef(p.p.At()))
+		if s == nil || s.shardHash&(p.shardCount-1) != p.shardIndex {
+			continue
+		}
+		p.cur = storage.SeriesRef(s.ref)
+		return true
+	}
+	return false
+}
+
+// Seek implements index.Postings.
+func (p *lazyPostingsShardPowerOfTwo) Seek(v storage.SeriesRef) bool {
+	if p.cur >= v {
+		return true
+	}
+	for ok := p.p.Seek(v); ok; ok = p.p.Next() {
+		s := p.head.series.getByID(chunks.HeadSeriesRef(p.p.At()))
+		if s == nil || s.shardHash&(p.shardCount-1) != p.shardIndex {
+			continue
+		}
+		p.cur = storage.SeriesRef(s.ref)
+		return true
+	}
+	return false
+}
+
+// At implements index.Postings.
+func (p *lazyPostingsShardPowerOfTwo) At() storage.SeriesRef { return p.cur }
+
+// Err implements index.Postings.
+func (p *lazyPostingsShardPowerOfTwo) Err() error { return p.p.Err() }
 
 // LabelValuesFor returns LabelValues for the given label name in the series referred to by postings.
 func (h *headIndexReader) LabelValuesFor(postings index.Postings, name string) storage.LabelValues {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3780,36 +3780,40 @@ func TestHeadShardedPostings(t *testing.T) {
 	require.NoError(t, p.Err())
 	require.NotEmpty(t, expected)
 
-	// Query the same postings for each shard.
-	const shardCount = uint64(4)
-	actualShards := make(map[uint64][]storage.SeriesRef)
-	actualPostings := make([]storage.SeriesRef, 0, len(expected))
+	// Test both a power-of-two shard count (bitwise AND path) and a non-power-of-two one (modulo path).
+	for _, shardCount := range []uint64{3, 4} {
+		t.Run(fmt.Sprintf("shardCount=%d", shardCount), func(t *testing.T) {
+			// Query the same postings for each shard.
+			actualShards := make(map[uint64][]storage.SeriesRef)
+			actualPostings := make([]storage.SeriesRef, 0, len(expected))
 
-	for shardIndex := range shardCount {
-		p, err = ir.Postings(ctx, "const", "1")
-		require.NoError(t, err)
+			for shardIndex := range shardCount {
+				p, err := ir.Postings(ctx, "const", "1")
+				require.NoError(t, err)
 
-		p = ir.ShardedPostings(p, shardIndex, shardCount)
-		for p.Next() {
-			ref := p.At()
+				p = ir.ShardedPostings(p, shardIndex, shardCount)
+				for p.Next() {
+					ref := p.At()
 
-			actualShards[shardIndex] = append(actualShards[shardIndex], ref)
-			actualPostings = append(actualPostings, ref)
-		}
-		require.NoError(t, p.Err())
-	}
+					actualShards[shardIndex] = append(actualShards[shardIndex], ref)
+					actualPostings = append(actualPostings, ref)
+				}
+				require.NoError(t, p.Err())
+			}
 
-	// We expect the postings merged out of shards is the exact same of the non sharded ones.
-	require.ElementsMatch(t, expected, actualPostings)
+			// We expect the postings merged out of shards is the exact same of the non sharded ones.
+			require.ElementsMatch(t, expected, actualPostings)
 
-	// We expect the series in each shard are the expected ones.
-	for shardIndex, ids := range actualShards {
-		for _, id := range ids {
-			var lbls labels.ScratchBuilder
+			// We expect the series in each shard are the expected ones.
+			for shardIndex, ids := range actualShards {
+				for _, id := range ids {
+					var lbls labels.ScratchBuilder
 
-			require.NoError(t, ir.Series(id, &lbls, nil))
-			require.Equal(t, shardIndex, labels.StableHash(lbls.Labels())%shardCount)
-		}
+					require.NoError(t, ir.Series(id, &lbls, nil))
+					require.Equal(t, shardIndex, labels.StableHash(lbls.Labels())%shardCount)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[PERF] TSDB: Filter Head sharded postings lazily to keep series hot in the CPU cache.
```

---

`headIndexReader.ShardedPostings` used to eagerly walk the input postings, look up
every series via `head.series.getByID` and materialize the matching refs into a
slice. Callers then iterate that slice and call `Series()` for each ref, which
performs a second `getByID` for the same series — by then the series is no longer
in the CPU cache.

This returns a lazy `index.Postings` instead, so the shard-membership lookup
happens during `Next()`/`Seek()` and the series stays hot for the `Series()` call
that immediately follows `At()`.

It also splits the shard-membership computation into two implementations:
`lazyPostingsShardPowerOfTwo` replaces the modulo with a bitwise AND when
`shardCount` is a power of two (the common case), and `lazyPostingsShardDecimal`
keeps the modulo for the rest.

The not-found series debug counter and log were removed; the feature is stable and
the log was not actionable.
