### PR TITLE
Fix for sending slack notifications

### DIFF
--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -297,11 +297,13 @@ jobs:
           git push --force origin "${LOCAL_BRANCH}:${BOT_BRANCH}"
 
       - name: Send Slack notification for merge conflicts
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # v3.0.2
         with:
-          channel-id: C04AF91LPFX #mimir-ci-notifications
+          method: chat.postMessage
+          # channel C04AF91LPFX is #mimir-ci-notifications
           payload: |
             {
+              "channel": "C04AF91LPFX",
               "text": ":sadcomputer: *Merge conflicts detected in upstream prometheus merge* (prometheus/`${{ needs.check-merge.outputs.upstream_branch }}` -> mimir-prometheus/`${{ needs.check-merge.outputs.local_branch }}`)\n\n<!subteam^S03C2P8659U> check and resolve the conflicts in <${{ steps.create-conflict-pr.outputs.pull-request-url }}|the PR>."
             }
 
@@ -313,11 +315,13 @@ jobs:
       id-token: write
     steps:
       - name: Send Slack notification for merge error
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # v3.0.2
         with:
-          channel-id: C04AF91LPFX #mimir-ci-notifications
+          method: chat.postMessage
+          # channel C04AF91LPFX is #mimir-ci-notifications
           payload: |
             {
+              "channel": "C04AF91LPFX",
               "text": ":sadcomputer: *Upstream prometheus merge failed* (prometheus/`${{ needs.check-merge.outputs.upstream_branch }}` -> mimir-prometheus/`${{ needs.check-merge.outputs.local_branch }}`)\n\n<!subteam^S03C2P8659U> please investigate the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow logs> and resolve manually."
             }
 


### PR DESCRIPTION
This PR fixes an issue with the sending of slack message to notify of a merge issue. eg https://github.com/grafana/mimir-prometheus/actions/runs/27725926093/job/82022165426

```
SLACK_BOT_TOKEN:
  ##[error]Error: Need to provide at least one botToken or webhookUrl
```

Likely as part of the security clean up the get-vault-secrets removed export_env which was relied upon by the v1.0.0 of send-slack-message.

This PR updates to use v3.0.2 of send-slack-message.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*
NONE
-->
```release-notes

```
