### PR TITLE
tsdb: backport review fixes for CompactSelectedSeries

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -781,7 +781,15 @@ func (c *LeveledCompactor) Write(dest string, b BlockReader, mint, maxt int64, b
 		meta.Compaction.Parents = []BlockDesc{
 			{ULID: base.ULID, MinTime: base.MinTime, MaxTime: base.MaxTime},
 		}
-		meta.Compaction.Hints = slices.Clone(base.Compaction.Hints)
+		if base.Compaction.FromOutOfOrder() {
+			meta.Compaction.SetOutOfOrder()
+		}
+		if base.Compaction.FromStaleSeries() {
+			meta.Compaction.SetStaleSeries()
+		}
+		if base.Compaction.FromSelectedSeries() {
+			meta.Compaction.SetSelectedSeries()
+		}
 	}
 
 	err := c.write(dest, []shardedBlock{{meta: meta}}, DefaultBlockPopulator{}, b)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1969,18 +1969,22 @@ type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
 // The caller must hold db.cmtx.
 func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSeriesEvictor, configure func(*BlockMeta)) error {
 	mint, maxt := db.head.opts.ChunkRange*(db.head.MinTime()/db.head.opts.ChunkRange), db.head.MaxTime()
-	// Capture the head's current append-ID as an eviction watermark before
-	// writing any blocks.
+	// Capture the highest guaranteed-committed appendID as an eviction watermark
+	// before writing any blocks.
 	//
-	// The generated blocks are guaranteed to contain all samples with
-	// appendID <= watermark. Samples appended later (appendID > watermark)
-	// may or may not be present, depending on when each block writer takes
-	// its isolation snapshot.
+	// Samples with appendID <= watermark are guaranteed to be present in some
+	// generated block. Samples with higher IDs may or may not be present,
+	// depending on block-writer snapshot timing.
 	//
-	// Eviction uses the watermark as a safety guard: a series is removed
-	// only if it has not received any samples with appendID > watermark
-	// since compaction began.
-	appendIDWatermark := db.head.iso.lastAppendID()
+	// The watermark is used during eviction: a series is removed only if it has
+	// not received any samples with appendID > watermark since compaction began.
+	//
+	// We use committedAppendID instead of lastAppendID because open appenders are
+	// excluded from all block snapshots via incompleteAppends. If one of those
+	// appenders commits between the write and evict phases, using lastAppendID
+	// could evict a series whose newest sample is present in neither the block nor
+	// the head, causing that sample to be lost on WAL replay.
+	appendIDWatermark := db.head.iso.committedAppendID()
 	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
 	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2097,12 +2097,13 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 	// the caller's slice in place by sorting and removing duplicates before
 	// constructing the postings. This avoids "out-of-order series added"
 	// errors during compaction.
-	if !slices.IsSorted(seriesRefs) {
-		slices.Sort(seriesRefs)
+	refs := slices.Clone(seriesRefs)
+	if !slices.IsSorted(refs) {
+		slices.Sort(refs)
 	}
-	seriesRefs = slices.Compact(seriesRefs)
-	postings := index.NewListPostings(seriesRefs)
-	totalSeries := len(seriesRefs)
+	refs = slices.Compact(refs)
+	postings := index.NewListPostings(refs)
+	totalSeries := len(refs)
 	// Skip series with out-of-order data: the ref-list pipeline writes only in-order chunks,
 	// so a series whose OOO state is non-empty would have its OOO chunks orphaned upon
 	// eviction. Such series stay in the head and are picked up on a later cycle.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2002,7 +2002,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 			continue
 		}
 
-		db.logger.Info("Head portion block created", "ulids", fmt.Sprintf("%v", uids), "min_time", mint, "max_time", maxt)
+		db.logger.Info("Head portion block created", "ulids", fmt.Sprintf("%v", uids), "min_time", mint, "max_time", mint+db.head.chunkRange.Load()-1)
 
 		if err := db.reloadBlocks(); err != nil {
 			errs := []error{fmt.Errorf("reloadBlocks blocks: %w", err)}
@@ -2102,7 +2102,7 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		return err
 	}
 	skippedSeries := totalSeries - len(selectedSeriesRefs.sortedByRef)
-	db.logger.Info("Starting selected series compaction", "num_series", len(selectedSeriesRefs.sortedByRef), "num_skipped_ooo", skippedSeries)
+	db.logger.Info("Starting selected series compaction", "num_series", len(selectedSeriesRefs.sortedByRef), "num_skipped_ooo", skippedSeries, "isolation_disabled", db.head.opts.IsolationDisabled)
 
 	if len(selectedSeriesRefs.sortedByRef) == 0 {
 		elapsed := time.Since(start)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2001,7 +2001,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 		if len(uids) == 0 {
 			continue
 		}
-		
+
 		db.logger.Info("Head portion block created", "ulids", fmt.Sprintf("%v", uids), "min_time", mint, "max_time", maxt)
 
 		if err := db.reloadBlocks(); err != nil {
@@ -2116,7 +2116,7 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
 		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateSelectedSeries(seriesRefs, maxt, appendIDWatermark)
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1981,6 +1981,8 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 	// only if it has not received any samples with appendID > watermark
 	// since compaction began.
 	appendIDWatermark := db.head.iso.lastAppendID()
+	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
+	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
 		view := viewFactory(db.head, mint, mint+db.head.chunkRange.Load()-1)
 
@@ -1993,6 +1995,13 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 			return fmt.Errorf("persist head portion: %w", err)
 		}
 
+		// compactor.Write returns no UIDs when the view contained no chunks, which happens
+		// on a chunk-range slice that holds no data for the selected series. There is nothing
+		// to reload or log in that case.
+		if len(uids) == 0 {
+			continue
+		}
+		
 		db.logger.Info("Head portion block created", "ulids", fmt.Sprintf("%v", uids), "min_time", mint, "max_time", maxt)
 
 		if err := db.reloadBlocks(); err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2093,11 +2093,20 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 	db.metrics.selectedSeriesCompactionsTriggered.Inc()
 	start := time.Now()
 
+	// index.NewListPostings expects sorted, duplicate-free refs. Normalize
+	// the caller's slice in place by sorting and removing duplicates before
+	// constructing the postings. This avoids "out-of-order series added"
+	// errors during compaction.
+	if !slices.IsSorted(seriesRefs) {
+		slices.Sort(seriesRefs)
+	}
+	seriesRefs = slices.Compact(seriesRefs)
+	postings := index.NewListPostings(seriesRefs)
 	totalSeries := len(seriesRefs)
 	// Skip series with out-of-order data: the ref-list pipeline writes only in-order chunks,
 	// so a series whose OOO state is non-empty would have its OOO chunks orphaned upon
 	// eviction. Such series stay in the head and are picked up on a later cycle.
-	selectedSeriesRefs, err := db.head.filterSeriesAndSortPostings(index.NewListPostings(seriesRefs), isSeriesWithoutOOO)
+	selectedSeriesRefs, err := db.head.filterSeriesAndSortPostings(postings, isSeriesWithoutOOO)
 	if err != nil {
 		return err
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10557,6 +10557,99 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 		"visible samples after restart must match the expected watermark-guard outcome")
 }
 
+// TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction verifies
+// that a sample committed while compaction is in progress is not lost.
+//
+// The test covers the case where a write starts before compaction begins but
+// only commits after block generation and before eviction. Such a sample may
+// not be included in the generated blocks, so compaction must ensure the
+// corresponding series is retained in the head.
+//
+// The test verifies that the sample remains queryable both immediately after
+// compaction and after a restart.
+func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing.T) {
+	if defaultIsolationDisabled {
+		t.Skip("watermark guard relies on per-sample append-IDs that s.txs only tracks when isolation is enabled")
+	}
+
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	// Filler series keeps head.MaxTime at 700, ensuring the late append at
+	// t=400 remains within appendableMinValidTime() = max(700-500, 0) = 200.
+	filler := labels.FromStrings("name", "filler")
+	sel := labels.FromStrings("name", "selected")
+
+	baseline := db.Appender(context.Background())
+	_, err := baseline.Append(0, filler, 100, 0.1)
+	require.NoError(t, err)
+	_, err = baseline.Append(0, filler, 700, 0.7)
+	require.NoError(t, err)
+	selRef, err := baseline.Append(0, sel, 100, 10.0)
+	require.NoError(t, err)
+	_, err = baseline.Append(selRef, sel, 200, 20.0)
+	require.NoError(t, err)
+	require.NoError(t, baseline.Commit())
+
+	require.Equal(t, int64(700), db.Head().MaxTime())
+
+	const (
+		lateT = int64(400)
+		lateV = 40.0
+	)
+
+	// Open the appender BEFORE CompactSelectedSeries: this is the key
+	// difference from TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart,
+	// where the appender is opened inside the hook (and so gets an appendID
+	// strictly greater than the captured watermark). Here, the appender's ID
+	// is issued before the watermark capture, so a watermark based on
+	// lastAppendID() would incorrectly cover it.
+	late := db.Appender(context.Background())
+	_, err = late.Append(selRef, sel, lateT, lateV)
+	require.NoError(t, err)
+
+	// Commit the pre-opened appender after the block is written but before
+	// eviction runs, so the late sample exists only in the head when the
+	// evictor consults shouldEvict.
+	var hookErr error
+	compactHeadViewBeforeEvictTestingCallback = func() {
+		hookErr = late.Commit()
+	}
+	t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
+
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{selRef}))
+	require.NoError(t, hookErr, "the late commit inside the hook must itself succeed")
+
+	require.Len(t, db.Blocks(), 1)
+	require.Equal(t, uint64(2), db.Head().NumSeries(),
+		"sel must survive eviction because its late commit has an appendID > watermark")
+
+	expected := []chunks.Sample{
+		sample{t: 100, f: 10.0},
+		sample{t: 200, f: 20.0},
+		sample{t: lateT, f: lateV},
+	}
+	querySelected := func(d *DB) []chunks.Sample {
+		q, err := d.Querier(0, chunkRange)
+		require.NoError(t, err)
+		seriesSet := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+		return seriesSet[`{name="selected"}`]
+	}
+	require.Equal(t, expected, querySelected(db),
+		"all three samples must be visible: the block holds t=100,200 and the head retains the late t=400")
+
+	require.NoError(t, db.Close())
+	db, err = Open(db.Dir(), nil, nil, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.Equal(t, expected, querySelected(db),
+		"the late sample must survive restart, proving no tombstone was written for sel")
+}
+
 // TestCompactSelectedSeries_ChunkBoundarySampleNotLost verifies that
 // CompactSelectedSeries preserves a sample whose timestamp lands exactly on
 // a chunk-range boundary.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10101,6 +10101,36 @@ func TestCompactStaleHead_ChunkBoundarySampleNotLost(t *testing.T) {
 		"boundary sample must remain the stale-NaN marker")
 }
 
+// TestCompactSelectedSeries_SingleTimestampHeadIsEvicted exercises the case where the head
+// holds a single timestamp, i.e., MinTime == MaxTime. compactHeadViewLocked's inclusive
+// loop still writes a block for that slice, and the eviction step must remove the persisted
+// series rather than leaving them behind to overlap the freshly written block.
+func TestCompactSelectedSeries_SingleTimestampHeadIsEvicted(t *testing.T) {
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	sel := labels.FromStrings("name", "single")
+	app := db.Appender(context.Background())
+	ref, err := app.Append(0, sel, chunkRange, 1.0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, int64(chunkRange), db.Head().MinTime(), "test precondition: single-timestamp head")
+	require.Equal(t, int64(chunkRange), db.Head().MaxTime(), "test precondition: single-timestamp head")
+	require.Equal(t, uint64(1), db.Head().NumSeries())
+
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{ref}))
+
+	require.Equal(t, uint64(0), db.Head().NumSeries(),
+		"single-timestamp series must be evicted after its sample is persisted to a block")
+	require.Len(t, db.Blocks(), 1, "exactly one block should be produced for the single chunk-range slice")
+}
+
 // TestCompactSelectedSeries verifies the happy path of CompactSelectedSeries:
 //   - Non-stale series in the ref list are evicted, even though their lastValue is not a
 //     stale-NaN (the key behavioural difference vs. CompactStaleHead).
@@ -10152,6 +10182,47 @@ func TestCompactSelectedSeries(t *testing.T) {
 	// Selected-series compaction metrics should reflect one successful run.
 	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.metrics.selectedSeriesCompactionsTriggered))
 	require.Equal(t, float64(0), prom_testutil.ToFloat64(db.metrics.selectedSeriesCompactionsFailed))
+}
+
+// TestCompactSelectedSeries_UnsortedDuplicateRefs verifies that CompactSelectedSeries
+// tolerates an input slice that is unsorted and contains duplicate refs:
+//   - The postings list backing the selected-series view must observe sorted, unique refs,
+//     since index.NewListPostings retains the slice and relies on it being sorted.
+//   - The block populator must not see the same series twice, otherwise it fails with
+//     "out-of-order series added" and the whole compaction errors out.
+//
+// Each series in the deduplicated input must be evicted exactly once.
+func TestCompactSelectedSeries_UnsortedDuplicateRefs(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MinBlockDuration = 1000
+	opts.MaxBlockDuration = 1000
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	s1Labels := labels.FromStrings("name", "selected1")
+	s2Labels := labels.FromStrings("name", "selected2")
+	s3Labels := labels.FromStrings("name", "selected3")
+
+	app := db.Appender(context.Background())
+	s1, err := app.Append(0, s1Labels, 100, 1.0)
+	require.NoError(t, err)
+	s2, err := app.Append(0, s2Labels, 200, 2.0)
+	require.NoError(t, err)
+	s3, err := app.Append(0, s3Labels, 300, 3.0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	require.Equal(t, uint64(3), db.Head().NumSeries())
+
+	// Refs are allocated monotonically, so reversing the natural order guarantees
+	// the input is unsorted; inserting each ref twice exercises de-duplication.
+	refs := []storage.SeriesRef{s3, s1, s2, s1, s3, s2}
+	require.NoError(t, db.CompactSelectedSeries(refs),
+		"compaction must succeed even when the caller passes unsorted, duplicate refs")
+
+	require.Equal(t, uint64(0), db.Head().NumSeries(),
+		"each deduplicated series must be evicted exactly once")
+	require.Len(t, db.Blocks(), 1, "duplicates must not produce extra blocks")
 }
 
 // TestCompactSelectedSeries_EmptyRefs verifies that passing nil or an empty slice is a no-op

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10202,10 +10202,10 @@ func TestCompactSelectedSeries_MultipleChunkRanges(t *testing.T) {
 	}
 }
 
-// TestCompactSelectedSeries_DoesNotDecrementNumStaleSeries verifies that evicting non-stale
-// series via CompactSelectedSeries does not decrement Head.numStaleSeries — the wereStale=false
-// flag inside truncateSeries gates the decrement.
-func TestCompactSelectedSeries_DoesNotDecrementNumStaleSeries(t *testing.T) {
+// TestCompactSelectedSeries_DecrementsNumStaleSeriesWhenStaleSeriesCompacted verifies
+// that evicting a stale series via CompactSelectedSeries keeps Head.numStaleSeries in sync,
+// i.e., it is decremented only when CompactSelectedSeries actually compacts a stale serie.
+func TestCompactSelectedSeries_DecrementsNumStaleSeriesWhenStaleSeriesCompacted(t *testing.T) {
 	opts := DefaultOptions()
 	opts.MinBlockDuration = 1000
 	opts.MaxBlockDuration = 1000
@@ -10215,28 +10215,39 @@ func TestCompactSelectedSeries_DoesNotDecrementNumStaleSeries(t *testing.T) {
 
 	staleV := math.Float64frombits(value.StaleNaN)
 	stale := labels.FromStrings("name", "stale")
-	nonStale := labels.FromStrings("name", "non-stale")
+	nonStale1 := labels.FromStrings("name", "non-stale-1")
+	nonStale2 := labels.FromStrings("name", "non-stale-2")
 
 	// Stale series: a normal sample followed by a stale-NaN.
 	app := db.Appender(context.Background())
-	_, err := app.Append(0, stale, 100, 1.0)
+	staleRef, err := app.Append(0, stale, 100, 1.0)
 	require.NoError(t, err)
-	_, err = app.Append(0, stale, 200, staleV)
+	staleRef, err = app.Append(staleRef, stale, 200, staleV)
 	require.NoError(t, err)
 	// Non-stale series: ordinary samples only.
-	nonStaleRef, err := app.Append(0, nonStale, 100, 2.0)
+	nonStaleRef1, err := app.Append(0, nonStale1, 100, 2.0)
+	require.NoError(t, err)
+	nonStaleRef2, err := app.Append(0, nonStale2, 100, 3.0)
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	require.Equal(t, uint64(2), db.Head().NumSeries())
+	require.Equal(t, uint64(3), db.Head().NumSeries())
 	require.Equal(t, uint64(1), db.Head().NumStaleSeries())
 
-	// Evict only the non-stale series.
-	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{nonStaleRef}))
+	// Evict only a non-stale serie.
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{nonStaleRef1}))
 
 	// The stale series remains, and the stale counter must not have been touched.
-	require.Equal(t, uint64(1), db.Head().NumSeries())
+	require.Equal(t, uint64(2), db.Head().NumSeries())
 	require.Equal(t, uint64(1), db.Head().NumStaleSeries(), "numStaleSeries must not be decremented when evicting non-stale series")
+
+	// Evict a stale serie and a non-stale serie.
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{staleRef, nonStaleRef2}))
+
+	// The stale series is removed, and the stale counter must be decremented.
+	require.Equal(t, uint64(0), db.Head().NumSeries())
+	require.Equal(t, uint64(0), db.Head().NumStaleSeries(),
+		"numStaleSeries must be decremented when CompactSelectedSeries evicts a stale serie")
 }
 
 // TestCompactSelectedSeries_SkipsSeriesWithOOOData verifies that CompactSelectedSeries skips

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1373,12 +1373,14 @@ func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 // tombstones so the deleted series are ignored on replay. shouldEvict is the per-series
 // predicate that decides whether each ref is evicted; series that received fresh samples since
 // the caller collected the ref list are skipped before the predicate is consulted.
+// maxt is inclusive: it matches the highest sample timestamp that the caller has just persisted
+// to a block, so a head whose MinTime equals maxt still has data eligible for eviction.
 // It returns the number of series that were actually evicted.
 func (h *Head) truncateSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) (int, error) {
 	h.chunkSnapshotMtx.Lock()
 	defer h.chunkSnapshotMtx.Unlock()
 
-	if h.MinTime() >= maxt {
+	if h.MinTime() > maxt {
 		return 0, nil
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1324,20 +1324,15 @@ func isStaleSeries(s *memSeries) bool {
 }
 
 // truncateStaleSeries removes the provided series as long as they are still stale and
-// carry no out-of-order data. It decrements Head.numStaleSeries by the number of series
-// that were actually evicted.
+// carry no out-of-order data.
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
 func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
-	n, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
+	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
 		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark)
 	})
-	if err != nil {
-		return err
-	}
-	h.numStaleSeries.Sub(uint64(n))
-	return nil
+	return err
 }
 
 // truncateSelectedSeries removes the series identified by the provided refs from the head.
@@ -2362,13 +2357,14 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) map[storage.SeriesRef]struct{} {
 	// Drop old chunks and remember series IDs and hashes if they can be
 	// deleted entirely.
-	deleted, affected, chunksRemoved := h.series.gcSeries(seriesRefs, maxt, shouldEvict)
+	deleted, affected, chunksRemoved, staleSeriesDeleted := h.series.gcSeries(seriesRefs, maxt, shouldEvict)
 	seriesRemoved := len(deleted)
 
 	h.metrics.seriesRemoved.Add(float64(seriesRemoved))
 	h.metrics.chunksRemoved.Add(float64(chunksRemoved))
 	h.metrics.chunks.Sub(float64(chunksRemoved))
 	h.numSeries.Sub(uint64(seriesRemoved))
+	h.numStaleSeries.Sub(uint64(staleSeriesDeleted))
 
 	// Remove deleted series IDs from the postings lists.
 	h.postings.Delete(deleted, affected)
@@ -2466,12 +2462,14 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 
 // gcSeries walks all series and removes those whose ref is in seriesRefs, whose maxTime is
 // <= maxt, and for which shouldEvict returns true. Returns the set of deleted refs, the set
-// of label-name/value pairs whose postings are affected, and the count of removed chunks.
-func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _ int) {
+// of label-name/value pairs whose postings are affected, the count of removed chunks, and
+// the number of deleted series that carried a stale-NaN last value.
+func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _, _ int) {
 	var (
-		deleted  = map[storage.SeriesRef]struct{}{}
-		affected = map[labels.Label]struct{}{}
-		rmChunks = 0
+		deleted            = map[storage.SeriesRef]struct{}{}
+		affected           = map[labels.Label]struct{}{}
+		rmChunks           = 0
+		staleSeriesDeleted = 0
 	)
 
 	refsSet := map[storage.SeriesRef]struct{}{}
@@ -2516,6 +2514,9 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
+		if isStaleSeries(series) {
+			staleSeriesDeleted++
+		}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
 		delete(s.series[stripe], series.ref)
@@ -2524,7 +2525,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 
 	s.iterForDeletion(check)
 
-	return deleted, affected, rmChunks
+	return deleted, affected, rmChunks, staleSeriesDeleted
 }
 
 // The iterForDeletion function iterates through all series, invoking the checkDeletedFunc for each.

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -216,6 +216,32 @@ func (i *isolation) lastAppendID() uint64 {
 	return i.appendsOpenList.appendID
 }
 
+// committedAppendID returns the highest appendID guaranteed to be committed
+// at the time of the call. Any sample with appendID <= committedAppendID()
+// has completed its commit path (its appender has called closeAppend), so it
+// cannot appear in isolationState.incompleteAppends.
+//
+// Returns 0 when isolation is disabled. If there are no open appenders, all
+// issued IDs are committed and the result is lastAppendID(). Otherwise, the
+// lowest open appendID is still in flight, and a block writer that snapshots
+// before it commits would exclude it. In that case, the highest guaranteed-
+// committed ID is one less than the lowest open appendID.
+func (i *isolation) committedAppendID() uint64 {
+	if i.disabled {
+		return 0
+	}
+
+	i.appendMtx.RLock()
+	defer i.appendMtx.RUnlock()
+
+	// appendsOpenList is a sentinel-headed ring; .next == sentinel means no open appenders,
+	// in which case the sentinel's appendID stores the last issued ID.
+	if i.appendsOpenList.next == i.appendsOpenList {
+		return i.appendsOpenList.appendID
+	}
+	return i.appendsOpenList.next.appendID - 1
+}
+
 func (i *isolation) closeAppend(appendID uint64) {
 	if i.disabled {
 		return

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -70,6 +70,88 @@ func TestIsolation(t *testing.T) {
 	require.Equal(t, int64(math.MaxInt64), iso.lowestAppendTime())
 }
 
+// TestCommittedAppendID pins the contract of (*isolation).committedAppendID:
+// it returns the highest appendID that is guaranteed to be committed, i.e. the
+// highest ID a block writer cannot see in incompleteAppends. Callers in the
+// compaction path use it to decide whether a series can be safely evicted, so
+// regressions here can cause silent data loss.
+func TestCommittedAppendID(t *testing.T) {
+	t.Run("disabled isolation always returns 0", func(t *testing.T) {
+		iso := newIsolation(true)
+		require.Equal(t, uint64(0), iso.committedAppendID())
+
+		// Even after issuing an ID (which is a no-op when disabled), the result
+		// must stay 0 because no per-sample append-IDs are tracked.
+		_, _ = iso.newAppendID(0)
+		require.Equal(t, uint64(0), iso.committedAppendID())
+	})
+
+	t.Run("no appenders ever opened", func(t *testing.T) {
+		iso := newIsolation(false)
+		require.Equal(t, uint64(0), iso.committedAppendID(),
+			"with no appenders the sentinel's appendID is 0, which is also the last issued ID")
+	})
+
+	t.Run("all issued IDs closed returns lastAppendID", func(t *testing.T) {
+		iso := newIsolation(false)
+		idA, _ := iso.newAppendID(0)
+		idB, _ := iso.newAppendID(0)
+		iso.closeAppend(idA)
+		iso.closeAppend(idB)
+		require.Equal(t, idB, iso.committedAppendID(),
+			"with no open appenders, committed must equal lastAppendID")
+		require.Equal(t, iso.lastAppendID(), iso.committedAppendID())
+	})
+
+	t.Run("single open appender caps committed at id-1", func(t *testing.T) {
+		iso := newIsolation(false)
+		id, _ := iso.newAppendID(0)
+		require.Equal(t, id-1, iso.committedAppendID(),
+			"the only open appender is in flight, so committed is one below its id")
+	})
+
+	t.Run("multiple open appenders track the lowest", func(t *testing.T) {
+		iso := newIsolation(false)
+		idA, _ := iso.newAppendID(0) // 1
+		idB, _ := iso.newAppendID(0) // 2
+		idC, _ := iso.newAppendID(0) // 3
+		require.Equal(t, idA-1, iso.committedAppendID(),
+			"with A,B,C open the lowest open is A, so committed is A-1")
+
+		// Closing the highest open ID must not change committed: A is still in
+		// flight, so anything >= A is still uncovered by the block.
+		iso.closeAppend(idC)
+		require.Equal(t, idA-1, iso.committedAppendID(),
+			"closing the highest open appender does not advance committed")
+
+		// Closing the lowest open ID raises committed to (next lowest)-1.
+		iso.closeAppend(idA)
+		require.Equal(t, idB-1, iso.committedAppendID(),
+			"closing the lowest open appender raises committed to (new lowest)-1")
+
+		// Closing the last open appender returns committed to lastAppendID.
+		iso.closeAppend(idB)
+		require.Equal(t, idC, iso.committedAppendID(),
+			"once every issued ID is closed, committed equals lastAppendID")
+	})
+
+	t.Run("open reads do not influence committed", func(t *testing.T) {
+		// committedAppendID is independent of readsOpen: a stale read snapshot
+		// captured at a lower watermark must not pull committed back, otherwise
+		// long-running queries would unnecessarily block eviction.
+		iso := newIsolation(false)
+		idA, _ := iso.newAppendID(0)
+		state := iso.State(0, math.MaxInt64)
+		iso.closeAppend(idA)
+
+		require.Equal(t, idA, iso.committedAppendID(),
+			"with no open appenders, committed must equal lastAppendID even while a read is open")
+
+		state.Close()
+		require.Equal(t, idA, iso.committedAppendID())
+	})
+}
+
 func countOpenReads(iso *isolation) int {
 	count := 0
 	iso.TraverseOpenReads(func(*isolationState) bool {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
In #1154 we added support for compaction of selected series. That PR introduced a framework used by both, at that moment available compaction of stale series, and newly added selected series.

We have then opened a [Prometheus PR](https://github.com/prometheus/prometheus/pull/18905) to upstream #1154  and #1201. The PR has been in review for a couple of weeks, and we have received different valuable feedbacks. The PR was approved, but we are waiting for one more reviewer to approve it, before it will be merged.

This PR implements all fixes requested by the Prometheus PR's reviewer, so that we can test them while we are waiting for Prometheus' PR's approval.

##### Fixes (one commit per finding)

- **Chunk-range boundary samples were silently dropped** ([419908b0c](https://github.com/grafana/mimir-prometheus/pull/1222/changes/419908b0c14aa9aa0a7fbc3012f1c8300c72ad98)): `compactHeadViewLocked`'s loop boundary was exclusive, so a sample sitting exactly on a chunk-range boundary (e.g., `MinTime == MaxTime == maxt`) did not get a block written before its series was evicted. The loop is now inclusive (`mint <= maxt`).

- **`numStaleSeries` counter drift** ([2bbffdd24](https://github.com/grafana/mimir-prometheus/pull/1222/changes/2bbffdd241f3fbbd63aa97d115a0ee7b3dc1e027)): when `CompactSelectedSeries` evicted a series that happened to be stale, the per-series stale flag was cleared but `Head.numStaleSeries` was not decremented. The decrement now happens inside `gcSeries` based on the per-series check, so both stale-series and selected-series compaction keep the counter in sync.

- **Evictor received unfiltered ref list** ([dc8280831](https://github.com/grafana/mimir-prometheus/pull/1222/changes/dc828083139e5ebb46d191926e987205c3f76baf)): the closure passed to `compactHeadViewLocked` for eviction used the raw caller-supplied refs rather than the OOO-filtered subset, so series carrying OOO data could be evicted and orphan their out-of-order chunks. The evictor now consumes `selectedSeriesRefs.sortedByRef` consistently.

- **Single-timestamp head was not evicted** ([5be7db5b1](https://github.com/grafana/mimir-prometheus/pull/1222/changes/5be7db5b1f8d6766ca290beadf62a527921076d4)): the eviction guard in `truncateSeries` was `MinTime() >= maxt` (inherited from the pre-inclusive loop), so on a single-sample head (`MinTime == MaxTime == maxt`) the block was written but the series stayed in the head, producing a block overlapping live head data. The guard is now `> maxt` to match the inclusive loop semantics. Same commit also sorts and de-duplicates the caller's ref list before constructing the postings, so the block populator never sees an unsorted or duplicated label set.

- **Open-appender data loss** ([4f35de4fd](https://github.com/grafana/mimir-prometheus/pull/1222/changes/4f35de4fd07e0c6579ce4eb272204def07909aea)): the eviction watermark was captured with `iso.lastAppendID()`, which includes the IDs of appenders that are open at capture time. Their samples are excluded from the generated block via `incompleteAppends`; if such an appender committed between the write and evict phases, `hasAppendIDAbove`'s strict `>` comparison let the series be evicted and the WAL tombstone dropped the sample on replay. The watermark is now captured with a new `iso.committedAppendID()` helper that excludes open-at-capture-time appender IDs.

- **Caller slice was mutated in place** ([778bb0b8a](https://github.com/grafana/mimir-prometheus/pull/1222/changes/778bb0b8a39913572f309b8d1a68a33bcfcea5a9)): the input `[]storage.SeriesRef` slice was sorted and de-duplicated in place, which is surprising to callers that may keep a handle to the same slice. The slice is now cloned before the sort/compact, so the caller's slice is left untouched.

- **Minor issues** ([c59720c7a](https://github.com/grafana/mimir-prometheus/pull/1222/changes/c59720c7ad3e87052004ced0325d40cfad7444b3)): assorted comment fixups and small cleanups.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix different findings related to the selected series compaction.

```
