### PR TITLE
[r400] Only return prefix if case-sensitive

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -155,7 +155,7 @@ func (m *Matcher) SetMatches() []string {
 // Prefix returns the required prefix of the value to match, if possible.
 // It will be empty if it's an equality matcher or if the prefix can't be determined.
 func (m *Matcher) Prefix() string {
-	if m.re == nil {
+	if m.re == nil || m.re.caseInsensitivePrefix {
 		return ""
 	}
 	return m.re.prefix

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -190,7 +190,7 @@ func TestPrefix(t *testing.T) {
 		},
 		{
 			matcher:               mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
-			prefix:                "ABC",
+			prefix:                "",
 			caseInsensitivePrefix: true,
 		},
 	} {


### PR DESCRIPTION
Backport 968c5f8d6535b00eed0ed3a3b0ea6ce7cc77c444 from #1228

---

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Mirrors https://github.com/prometheus/prometheus/pull/19045


#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE

```
