### PR TITLE
tsdb: advance lastSeriesID past tombstone refs during WAL replay

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -911,6 +911,40 @@ func TestHead_ReadWAL(t *testing.T) {
 	}
 }
 
+func TestHead_ReadWAL_TombstonesAdvanceLastSeriesID(t *testing.T) {
+	entries := []any{
+		[]record.RefSeries{
+			{Ref: 10, Labels: labels.FromStrings("a", "1")},
+		},
+		[]record.RefSample{
+			{Ref: 10, T: 100, V: 1},
+		},
+		[]tombstones.Stone{
+			// Interval tombstone for a ref with no series record in the WAL.
+			{Ref: 35, Intervals: []tombstones.Interval{{Mint: 0, Maxt: 100}}},
+			// Full-range tombstone for a ref with no series record in the WAL,
+			// e.g. because the record was dropped from the checkpoint after the
+			// tombstone deleted the series during an earlier replay.
+			{Ref: 42, Intervals: []tombstones.Interval{{Mint: math.MinInt64, Maxt: math.MaxInt64}}},
+		},
+	}
+
+	head, w := newTestHead(t, 1000, compression.None, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+
+	populateTestWL(t, w, entries, nil, false)
+
+	require.NoError(t, head.Init(math.MinInt64))
+
+	// lastSeriesID must account for tombstone refs, not just series records:
+	// otherwise a new series could be issued ref 42, and the full-range
+	// tombstone (retained in checkpoints indefinitely) would delete it on the
+	// next replay.
+	require.Equal(t, uint64(42), head.lastSeriesID.Load())
+}
+
 func TestHead_LoadWALSeriesMissingAcrossSegments(t *testing.T) {
 	head, w := newTestHead(t, 1000, compression.None, false)
 	defer func() {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -315,6 +315,14 @@ Outer:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
 			for _, s := range v {
+				// A tombstone proves a series with this ref was created at some point,
+				// even if its series record is no longer in the WAL. Advance lastSeriesID
+				// accordingly: full-range tombstones are retained in checkpoints
+				// indefinitely, so if the ref were issued to a new series, the retained
+				// tombstone would delete that series on a subsequent replay.
+				if h.lastSeriesID.Load() < uint64(s.Ref) {
+					h.lastSeriesID.Store(uint64(s.Ref))
+				}
 				if len(s.Intervals) == 1 && s.Intervals[0].Mint == math.MinInt64 && s.Intervals[0].Maxt == math.MaxInt64 {
 					// This series was fully deleted at this point. This record is only done for stale series at the moment.
 					mod := uint64(s.Ref) % uint64(concurrency)


### PR DESCRIPTION
ref: [#i-2026-07-02-mimir-ops-03-continuous-test-failed](https://grafanalabs.enterprise.slack.com/archives/C0BETLPN56E)

`lastSeriesID` is rebuilt during WAL replay from series records only. A tombstone proves its ref was allocated at some point, even when the series record is no longer in the WAL (full-range tombstones are retained in checkpoints indefinitely, while the deleted series' records are eventually dropped). Without accounting for tombstone refs, the counter can restore below still-tombstoned refs and reissue them to new series — which the retained full-range tombstones then delete on the next replay, dropping their samples as unknown series references. Observed during the above incident in ops as a self-sustaining per-restart data-loss cycle on small tenants.

This advances `lastSeriesID` past any tombstone ref seen during replay, making ref reuse impossible regardless of which records survive checkpointing.

A fuller fix will be implemented upstream, but this will mitigate the issue in the near-term.

Made with [Cursor](https://cursor.com)