### PR TITLE
tsdb: report CommitStats including duplicate samples dropped at commit time

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -458,6 +458,7 @@ type headMetrics struct {
 	chunksRemoved             prometheus.Counter
 	gcDuration                prometheus.Summary
 	samplesAppended           *prometheus.CounterVec
+	duplicateSamples          *prometheus.CounterVec
 	outOfOrderSamplesAppended *prometheus.CounterVec
 	outOfBoundSamples         *prometheus.CounterVec
 	outOfOrderSamples         *prometheus.CounterVec
@@ -558,6 +559,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 		samplesAppended: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_samples_appended_total",
 			Help: "Total number of appended samples.",
+		}, []string{"type"}),
+		duplicateSamples: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_duplicate_samples_total",
+			Help: "Total number of samples dropped because the series already had a sample at the same timestamp, either silently at commit time or with an error at append time. Rejections of synthetic start-timestamp zero samples are not counted.",
 		}, []string{"type"}),
 		outOfOrderSamplesAppended: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_out_of_order_samples_appended_total",
@@ -660,6 +665,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.walCorruptionsTotal,
 			m.dataTotalReplayDuration,
 			m.samplesAppended,
+			m.duplicateSamples,
 			m.outOfOrderSamplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -429,7 +429,11 @@ type headAppenderBase struct {
 	storeST                         bool // Whether start-timestamp storage is enabled for this append.
 	useXOR2                         bool // Whether XOR2 encoding is used for float chunks in this append.
 	useHistogramST                  bool // Whether ST-capable histogram chunk encoding is used in this append.
+
+	// commitStats is populated at the end of Commit, readable via CommitStats.
+	commitStats CommitStats
 }
+
 type headAppender struct {
 	headAppenderBase
 	hints *storage.AppendOptions
@@ -497,6 +501,8 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
 		case errors.Is(err, storage.ErrTooOldSample):
 			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+		case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+			a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
 		}
 		return 0, err
 	}
@@ -873,6 +879,8 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 				a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			case errors.Is(err, storage.ErrTooOldSample):
 				a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+			case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+				a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			}
 			return 0, err
 		}
@@ -905,6 +913,8 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 				a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			case errors.Is(err, storage.ErrTooOldSample):
 				a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+			case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+				a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
 			}
 			return 0, err
 		}
@@ -1178,6 +1188,10 @@ type appenderCommitContext struct {
 	// Number of samples out of order but accepted: with ooo enabled and within time window.
 	oooFloatsAccepted    int
 	oooHistogramAccepted int
+	// Number of samples dropped at commit time because the series already had a
+	// sample at the same timestamp, with an equal or a conflicting value.
+	floatDuplicatesDropped int
+	histoDuplicatesDropped int
 	// Number of samples rejected due to: out of order but OOO support disabled.
 	floatOOORejected int
 	histoOOORejected int
@@ -1185,8 +1199,13 @@ type appenderCommitContext struct {
 	floatTooOldRejected int
 	histoTooOldRejected int
 	// Number of samples rejected due to: out of bounds: with t < minValidTime (OOO support disabled).
-	floatOOBRejected    int
-	histoOOBRejected    int
+	floatOOBRejected int
+	histoOOBRejected int
+	// Same-timestamp drops aggregated per series, allocated lazily on the first drop.
+	droppedConflict     []DiscardedSeriesSamples
+	droppedExactDup     []DiscardedSeriesSamples
+	droppedConflictIdx  map[chunks.HeadSeriesRef]int
+	droppedExactDupIdx  map[chunks.HeadSeriesRef]int
 	inOrderMint         int64
 	inOrderMaxt         int64
 	appendChunkOpts     chunkOpts
@@ -1400,6 +1419,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 		oooSample, _, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.floatDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
 		}
 
@@ -1413,7 +1435,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1438,7 +1461,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblSamples = append(acc.wblSamples, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1447,12 +1471,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 					acc.oooMaxT = s.T
 				}
 				acc.oooFloatsAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.floatsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.floatsAppended, &acc.floatDuplicatesDropped)
 			}
 		default:
 			if math.Float64bits(s.V) == value.QuietZeroNaN {
@@ -1475,6 +1495,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			} else {
 				// The sample is an exact duplicate, and should be silently dropped.
 				acc.floatsAppended--
+				acc.recordDroppedExactDup(series, &acc.floatDuplicatesDropped)
 			}
 		}
 
@@ -1508,6 +1529,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		oooSample, _, err := series.appendableHistogram(s.T, s.H, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.histoDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
@@ -1519,7 +1543,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1544,7 +1569,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblHistograms = append(acc.wblHistograms, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1553,12 +1579,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 					acc.oooMaxT = s.T
 				}
 				acc.oooHistogramAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.histogramsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.histogramsAppended, &acc.histoDuplicatesDropped)
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1575,8 +1597,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate, and should be silently dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.recordDroppedExactDup(series, &acc.histoDuplicatesDropped)
 			}
 		}
 
@@ -1610,6 +1633,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		oooSample, _, err := series.appendableFloatHistogram(s.T, s.FH, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
+			if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				acc.recordDroppedConflict(series, &acc.histoDuplicatesDropped)
+			}
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
@@ -1621,7 +1647,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			var result OOOInsertResult
+			result, chunkCreated, mmapRefs = series.insertWithResult(s.ST, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1646,7 +1673,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 					acc.oooMmapMarkersCount++
 				}
 			}
-			if ok {
+			switch result {
+			case OOOInserted:
 				acc.wblFloatHistograms = append(acc.wblFloatHistograms, s)
 				if s.T < acc.oooMinT {
 					acc.oooMinT = s.T
@@ -1655,12 +1683,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 					acc.oooMaxT = s.T
 				}
 				acc.oooHistogramAccepted++
-			} else {
-				// Sample is an exact duplicate of the last sample.
-				// NOTE: We can only detect updates if they clash with a sample in the OOOHeadChunk,
-				// not with samples in already flushed OOO chunks.
-				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
-				acc.histogramsAppended--
+			case OOODuplicateExact, OOODuplicateConflict:
+				acc.recordOOODuplicate(result, series, &acc.histogramsAppended, &acc.histoDuplicatesDropped)
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1677,8 +1701,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate, and should be silently dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.recordDroppedExactDup(series, &acc.histoDuplicatesDropped)
 			}
 		}
 
@@ -1794,10 +1819,19 @@ func (a *headAppenderBase) Commit() (err error) {
 	h.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatTooOldRejected))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatsAppended))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histogramsAppended))
+	h.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatDuplicatesDropped))
+	h.metrics.duplicateSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoDuplicatesDropped))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.oooFloatsAccepted))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.oooHistogramAccepted))
 	h.updateMinMaxTime(acc.inOrderMint, acc.inOrderMaxt)
 	h.updateMinOOOMaxOOOTime(acc.oooMinT, acc.oooMaxT)
+
+	a.commitStats = CommitStats{
+		DiscardedSamples: DiscardedSampleStats{
+			SameTimestampDifferentValue: acc.droppedConflict,
+			SameTimestampSameValue:      acc.droppedExactDup,
+		},
+	}
 
 	acc.collectOOORecords(a)
 	if h.wbl != nil {
@@ -1814,26 +1848,8 @@ func (a *headAppenderBase) Commit() (err error) {
 
 // insert is like append, except it inserts. Used for OOO samples.
 func (s *memSeries) insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (inserted, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
-	if s.ooo == nil {
-		s.ooo = &memSeriesOOOFields{}
-	}
-	c := s.ooo.oooHeadChunk
-	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
-		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
-		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
-		chunkCreated = true
-	}
-
-	ok := c.chunk.Insert(st, t, v, h, fh)
-	if ok {
-		if chunkCreated || t < c.minTime {
-			c.minTime = t
-		}
-		if chunkCreated || t > c.maxTime {
-			c.maxTime = t
-		}
-	}
-	return ok, chunkCreated, mmapRefs
+	result, chunkCreated, mmapRefs := s.insertWithResult(st, t, v, h, fh, o, oooCapMax, logger)
+	return result == OOOInserted, chunkCreated, mmapRefs
 }
 
 // chunkOpts are chunk-level options that are passed when appending to a memSeries.

--- a/tsdb/head_append_mimir.go
+++ b/tsdb/head_append_mimir.go
@@ -1,0 +1,155 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// CommitStats reports what the most recent Commit did beyond its error return.
+type CommitStats struct {
+	// DiscardedSamples reports samples silently dropped because the series already
+	// had a sample at that timestamp.
+	DiscardedSamples DiscardedSampleStats
+}
+
+// DiscardedSampleStats reports samples that Commit silently dropped because the
+// series already had a sample at that timestamp. No Append error is returned for
+// these drops, so this is the only signal that they were not stored.
+type DiscardedSampleStats struct {
+	// SameTimestampDifferentValue aggregates drops whose value differed from the stored sample.
+	SameTimestampDifferentValue []DiscardedSeriesSamples
+	// SameTimestampSameValue aggregates drops that exactly duplicated the stored sample.
+	SameTimestampSameValue []DiscardedSeriesSamples
+}
+
+// TotalDifferentValue returns the number of dropped samples across all series in
+// the SameTimestampDifferentValue category.
+func (s DiscardedSampleStats) TotalDifferentValue() int {
+	return totalDiscarded(s.SameTimestampDifferentValue)
+}
+
+// TotalSameValue returns the number of dropped samples across all series in the
+// SameTimestampSameValue category.
+func (s DiscardedSampleStats) TotalSameValue() int {
+	return totalDiscarded(s.SameTimestampSameValue)
+}
+
+func totalDiscarded(dropped []DiscardedSeriesSamples) (n int) {
+	for _, d := range dropped {
+		n += d.Count
+	}
+	return n
+}
+
+// DiscardedSeriesSamples aggregates the dropped samples of one series.
+type DiscardedSeriesSamples struct {
+	// Labels references the head's own series labels; read them synchronously after Commit.
+	Labels labels.Labels
+	Count  int
+}
+
+// CommitStatsReporter is implemented by appenders that report what their most
+// recent Commit did. Wrappers must forward the method.
+type CommitStatsReporter interface {
+	CommitStats() CommitStats
+}
+
+var (
+	_ CommitStatsReporter = &initAppender{}
+	_ CommitStatsReporter = &headAppender{}
+	_ CommitStatsReporter = &initAppenderV2{}
+	_ CommitStatsReporter = &headAppenderV2{}
+	_ CommitStatsReporter = dbAppender{}
+	_ CommitStatsReporter = dbAppenderV2{}
+)
+
+// CommitStats returns what the most recent Commit did.
+func (a *headAppenderBase) CommitStats() CommitStats {
+	return a.commitStats
+}
+
+// CommitStats returns the zero value if nothing was ever appended.
+func (a *initAppender) CommitStats() CommitStats {
+	if s, ok := a.app.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+// CommitStats returns the zero value if nothing was ever appended.
+func (a *initAppenderV2) CommitStats() CommitStats {
+	if s, ok := a.app.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+func (a dbAppender) CommitStats() CommitStats {
+	if s, ok := a.Appender.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+func (a dbAppenderV2) CommitStats() CommitStats {
+	if s, ok := a.AppenderV2.(CommitStatsReporter); ok {
+		return s.CommitStats()
+	}
+	return CommitStats{}
+}
+
+// recordDroppedConflict records a commit-time drop whose value differed from the
+// stored same-timestamp sample. Callers must hold s's lock.
+func (acc *appenderCommitContext) recordDroppedConflict(s *memSeries, dropped *int) {
+	*dropped++
+	acc.droppedConflict, acc.droppedConflictIdx = recordDroppedSample(acc.droppedConflict, acc.droppedConflictIdx, s)
+}
+
+// recordDroppedExactDup records a commit-time drop that exactly duplicated the
+// stored same-timestamp sample. Callers must hold s's lock.
+func (acc *appenderCommitContext) recordDroppedExactDup(s *memSeries, dropped *int) {
+	*dropped++
+	acc.droppedExactDup, acc.droppedExactDupIdx = recordDroppedSample(acc.droppedExactDup, acc.droppedExactDupIdx, s)
+}
+
+// recordOOODuplicate accounts for an out-of-order sample dropped because its
+// timestamp already exists. Callers must hold s's lock.
+//
+// NOTE: The clash can only be detected against samples in the OOO head chunk,
+// not against samples in already flushed OOO chunks.
+// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
+func (acc *appenderCommitContext) recordOOODuplicate(result OOOInsertResult, s *memSeries, appended, dropped *int) {
+	*appended--
+	if result == OOODuplicateConflict {
+		acc.recordDroppedConflict(s, dropped)
+	} else {
+		acc.recordDroppedExactDup(s, dropped)
+	}
+}
+
+// recordDroppedSample reads s.lset directly rather than calling s.labels(): callers
+// hold s's lock and labels() locks again under the dedupelabels build tag.
+func recordDroppedSample(dropped []DiscardedSeriesSamples, idx map[chunks.HeadSeriesRef]int, s *memSeries) ([]DiscardedSeriesSamples, map[chunks.HeadSeriesRef]int) {
+	if idx == nil {
+		idx = map[chunks.HeadSeriesRef]int{}
+	}
+	if i, ok := idx[s.ref]; ok {
+		dropped[i].Count++
+		return dropped, idx
+	}
+	idx[s.ref] = len(dropped)
+	return append(dropped, DiscardedSeriesSamples{Labels: s.lset, Count: 1}), idx
+}

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -188,6 +188,8 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricType).Inc()
 		case errors.Is(appErr, storage.ErrTooOldSample):
 			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricType).Inc()
+		case errors.Is(appErr, storage.ErrDuplicateSampleForTimestamp):
+			a.head.metrics.duplicateSamples.WithLabelValues(sampleMetricType).Inc()
 		}
 		return 0, appErr
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -10832,3 +10832,162 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		requireCounterConsistent("final state")
 	})
 }
+
+func TestHeadAppender_DuplicateSamplesDroppedMetric(t *testing.T) {
+	ctx := context.Background()
+	lbls := labels.FromStrings("foo", "bar")
+
+	statsOf := func(t *testing.T, app storage.Appender) DiscardedSampleStats {
+		t.Helper()
+		reporter, ok := app.(CommitStatsReporter)
+		require.True(t, ok, "appender must report commit stats")
+		return reporter.CommitStats().DiscardedSamples
+	}
+	requireStats := func(t *testing.T, app storage.Appender, wantSameValue, wantDifferentValue int) {
+		t.Helper()
+		stats := statsOf(t, app)
+		require.Equal(t, wantSameValue, stats.TotalSameValue(), "same-value dropped samples")
+		require.Equal(t, wantDifferentValue, stats.TotalDifferentValue(), "different-value dropped samples")
+	}
+
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			head, _ := newTestHead(t, DefaultBlockDuration, compression.None, true)
+
+			dupsDropped := func() float64 {
+				return prom_testutil.ToFloat64(head.metrics.duplicateSamples.WithLabelValues(scenario.sampleType))
+			}
+
+			app := head.Appender(ctx)
+			_, _, err := scenario.appendFunc(app, lbls, 60_000, 1)
+			require.NoError(t, err)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 2)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			requireStats(t, app, 0, 0)
+
+			// Exact duplicate of the latest in-order sample: dropped at commit.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 2)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 1.0, dupsDropped())
+			requireStats(t, app, 1, 0)
+
+			// Different value against a committed sample: Append error. Counted in
+			// the metric (all duplicate discards) but NOT in CommitStats, which only
+			// reclassifies samples that Append accepted.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 3)
+			require.ErrorIs(t, err, storage.ErrDuplicateSampleForTimestamp)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 2.0, dupsDropped())
+			requireStats(t, app, 0, 0)
+			// Must not be counted as an out-of-order rejection.
+			require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.outOfOrderSamples.WithLabelValues(scenario.sampleType)))
+
+			// Within-batch conflict: passes Append, dropped at commit, first sample wins.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 180_000, 6)
+			require.NoError(t, err)
+			_, _, err = scenario.appendFunc(app, lbls, 180_000, 7)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 3.0, dupsDropped())
+			requireStats(t, app, 0, 1)
+
+			// Within-batch exact duplicate.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 240_000, 8)
+			require.NoError(t, err)
+			_, _, err = scenario.appendFunc(app, lbls, 240_000, 8)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 4.0, dupsDropped())
+			requireStats(t, app, 1, 0)
+
+			// First out-of-order sample is accepted.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 4)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 4.0, dupsDropped())
+			requireStats(t, app, 0, 0)
+
+			// Exact duplicate of the out-of-order sample.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 4)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 5.0, dupsDropped())
+			requireStats(t, app, 1, 0)
+
+			// OOO timestamp clash is dropped even when the value differs.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 5)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 6.0, dupsDropped())
+			requireStats(t, app, 0, 1)
+
+			// Dropped duplicates must not inflate the appended count (5 stored samples).
+			require.Equal(t, 5.0, prom_testutil.ToFloat64(head.metrics.samplesAppended.WithLabelValues(scenario.sampleType)))
+		})
+	}
+
+	t.Run("stats aggregate per series with counts", func(t *testing.T) {
+		head, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+		lblsA := labels.FromStrings("foo", "bar")
+		lblsB := labels.FromStrings("foo", "baz")
+
+		app := head.Appender(ctx)
+		_, err := app.Append(0, lblsA, 100, 1)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		app = head.Appender(ctx)
+		for range 3 {
+			_, err = app.Append(0, lblsA, 100, 1)
+			require.NoError(t, err)
+		}
+		_, err = app.Append(0, lblsB, 100, 10)
+		require.NoError(t, err)
+		_, err = app.Append(0, lblsB, 100, 11)
+		require.NoError(t, err)
+		_, err = app.Append(0, lblsB, 100, 12)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		stats := statsOf(t, app)
+		require.Equal(t, []DiscardedSeriesSamples{{Labels: lblsA, Count: 3}}, stats.SameTimestampSameValue)
+		require.Equal(t, []DiscardedSeriesSamples{{Labels: lblsB, Count: 2}}, stats.SameTimestampDifferentValue)
+	})
+
+	t.Run("rollback reports no stats", func(t *testing.T) {
+		head, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+
+		app := head.Appender(ctx)
+		_, err := app.Append(0, lbls, 100, 1)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		app = head.Appender(ctx)
+		_, err = app.Append(0, lbls, 100, 1)
+		require.NoError(t, err)
+		require.NoError(t, app.Rollback())
+		requireStats(t, app, 0, 0)
+	})
+
+	t.Run("stats reachable through the DB appender chain on first push", func(t *testing.T) {
+		db := newTestDB(t)
+
+		// First push routes dbAppender -> initAppender -> headAppender.
+		app := db.Appender(ctx)
+		_, err := app.Append(0, lbls, 100, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lbls, 100, 1)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		requireStats(t, app, 1, 0)
+	})
+}

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -14,8 +14,6 @@
 package tsdb
 
 import (
-	"sort"
-
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
@@ -35,35 +33,7 @@ func NewOOOChunk() *OOOChunk {
 // Insert inserts the sample such that order is maintained.
 // Returns false if insert was not possible due to the same timestamp already existing.
 func (o *OOOChunk) Insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
-	// Although out-of-order samples can be out-of-order amongst themselves, we
-	// are opinionated and expect them to be usually in-order meaning we could
-	// try to append at the end first if the new timestamp is higher than the
-	// last known timestamp.
-	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
-		o.samples = append(o.samples, sample{st, t, v, h, fh})
-		return true
-	}
-
-	// Find index of sample we should replace.
-	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
-
-	if i >= len(o.samples) {
-		// none found. append it at the end
-		o.samples = append(o.samples, sample{st, t, v, h, fh})
-		return true
-	}
-
-	// Duplicate sample for timestamp is not allowed.
-	if o.samples[i].t == t {
-		return false
-	}
-
-	// Expand length by 1 to make room. use a zero sample, we will overwrite it anyway.
-	o.samples = append(o.samples, sample{})
-	copy(o.samples[i+1:], o.samples[i:])
-	o.samples[i] = sample{st, t, v, h, fh}
-
-	return true
+	return o.insertWithResult(st, t, v, h, fh) == OOOInserted
 }
 
 func (o *OOOChunk) NumSamples() int {

--- a/tsdb/ooo_head_mimir.go
+++ b/tsdb/ooo_head_mimir.go
@@ -1,0 +1,110 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"log/slog"
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// OOOInsertResult reports the outcome of inserting a sample into the out-of-order
+// head chunk. The zero value is deliberately invalid so that a missed assignment
+// cannot read as a successful insert.
+type OOOInsertResult uint8
+
+const (
+	OOOInserted OOOInsertResult = iota + 1
+	// OOODuplicateExact reports a drop: a sample with the same timestamp and an equal value exists.
+	OOODuplicateExact
+	// OOODuplicateConflict reports a drop: a sample with the same timestamp but a different value exists.
+	OOODuplicateConflict
+)
+
+// insertWithResult is OOOChunk.Insert reporting whether a sample dropped for an
+// already existing timestamp was an exact duplicate or a value conflict.
+func (o *OOOChunk) insertWithResult(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) OOOInsertResult {
+	// Although out-of-order samples can be out-of-order amongst themselves, we
+	// are opinionated and expect them to be usually in-order meaning we could
+	// try to append at the end first if the new timestamp is higher than the
+	// last known timestamp.
+	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
+		return OOOInserted
+	}
+
+	// Find index of sample we should replace.
+	i := sort.Search(len(o.samples), func(i int) bool { return o.samples[i].t >= t })
+
+	if i >= len(o.samples) {
+		// none found. append it at the end
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
+		return OOOInserted
+	}
+
+	// Overwrites of an existing timestamp are not allowed.
+	if o.samples[i].t == t {
+		if o.samples[i].valueEqual(v, h, fh) {
+			return OOODuplicateExact
+		}
+		return OOODuplicateConflict
+	}
+
+	// Expand length by 1 to make room. use a zero sample, we will overwrite it anyway.
+	o.samples = append(o.samples, sample{})
+	copy(o.samples[i+1:], o.samples[i:])
+	o.samples[i] = sample{st, t, v, h, fh}
+
+	return OOOInserted
+}
+
+// valueEqual reports whether (v, h, fh) equals s's value; a type mismatch counts as different.
+func (s sample) valueEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+	switch {
+	case h != nil:
+		return s.h != nil && h.Equals(s.h)
+	case fh != nil:
+		return s.fh != nil && fh.Equals(s.fh)
+	default:
+		return s.h == nil && s.fh == nil && math.Float64bits(s.f) == math.Float64bits(v)
+	}
+}
+
+// insertWithResult is memSeries.insert reporting the OOOInsertResult instead of
+// collapsing it to a bool.
+func (s *memSeries) insertWithResult(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (result OOOInsertResult, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
+	if s.ooo == nil {
+		s.ooo = &memSeriesOOOFields{}
+	}
+	c := s.ooo.oooHeadChunk
+	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
+		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
+		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
+		chunkCreated = true
+	}
+
+	result = c.chunk.insertWithResult(st, t, v, h, fh)
+	if result == OOOInserted {
+		if chunkCreated || t < c.minTime {
+			c.minTime = t
+		}
+		if chunkCreated || t > c.maxTime {
+			c.maxTime = t
+		}
+	}
+	return result, chunkCreated, mmapRefs
+}


### PR DESCRIPTION
The TSDB can accept samples at Append and silently drop them as duplicates at Commit, leaving callers unable to account for the drops.

This adds:

- `prometheus_tsdb_duplicate_samples_total{type="float|histogram"}` for duplicate-timestamp drops detected at Append or Commit.
- `CommitStatsReporter` with per-series counts of silent commit-time drops, split into same-value and conflicting-value categories. Append-time errors are excluded from these stats.

This is the fork counterpart of prometheus/prometheus#19711, consumed by grafana/mimir#16347 for discard metrics and cost attribution. Existing sample acceptance and first-value-wins behavior remain unchanged. In-order histogram exact duplicates are counted as duplicates instead of out-of-order rejections.

OOO detection remains limited to the current OOO head chunk. API shape and always-on per-series collection remain open for draft review.

Related to grafana/mimir#15552. Co-authored with @duricanikolic.

Validation: focused V1/V2 duplicate-stat tests and OOO truncation/restart tests.

```release-notes
[ENHANCEMENT] TSDB: Add duplicate-discard metrics and per-series commit statistics.
[BUGFIX] TSDB: Stop counting in-order histogram exact duplicates as out-of-order rejections.
```
