### PR TITLE
[mimir-release-2.17] tsdb: harden head-chunk cache lifecycle (#19136)

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2372,10 +2372,12 @@ func (mc *memChunk) len() (count int) {
 	return count
 }
 
+// collectHeadChunks walks the headChunks linked list once and returns a slice
+// in oldest-first order (matching mmappedChunks ordering).
+// buf must have length 0 but may have non-zero capacity for reuse; the
+// returned slice's tail beyond its length is zeroed, so a reused, shrinking
+// buffer does not pin chunks from a previous, longer collection.
 func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
-	if head == nil {
-		return buf
-	}
 	// Single walk: append newest-to-oldest (following prev pointers), then
 	// reverse to oldest-to-newest. Pointer-chasing the linked list is the
 	// expensive part; slices.Reverse on a contiguous array is essentially
@@ -2385,6 +2387,7 @@ func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
 		hc = append(hc, elem)
 	}
 	slices.Reverse(hc)
+	clear(hc[len(hc):cap(hc)])
 	return hc
 }
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -263,7 +263,6 @@ func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta, head
 
 	// Multiple head chunks: collect once O(N), iterate O(N).
 	headChunksBuf = collectHeadChunks(s.headChunks, headChunksBuf[:0])
-	clear(headChunksBuf[len(headChunksBuf):cap(headChunksBuf)])
 	for i, chk := range headChunksBuf {
 		maxTime := chk.maxTime
 		if i == len(headChunksBuf)-1 {
@@ -383,18 +382,47 @@ type headChunkReader struct {
 	enableCache bool
 	// Cache for head chunks — avoids O(n²) linked-list walks when
 	// iterating all chunks of a series oldest-to-newest.
-	cachedSeriesRef      storage.SeriesRef
-	cachedHeadChunks     []*memChunk
-	cachedHeadChunksHead *memChunk          // Head pointer at collection time; detects head-chunk replacement.
-	cachedMmapLen        int                // len(s.mmappedChunks) at collection time; detects mmap events.
-	cachedFirstChunkID   chunks.HeadChunkID // s.firstChunkID at collection time; detects truncation.
+	cachedKey        headChunkCacheKey
+	cachedHeadChunks []*memChunk
+}
+
+// headChunkCacheKey identifies the chunk-layout state of a series at
+// collection time; any layout change (append, mmapping, truncation) alters at
+// least one field, invalidating the cached slice.
+type headChunkCacheKey struct {
+	ref          storage.SeriesRef
+	head         *memChunk          // Head pointer; detects head-chunk replacement.
+	mmapLen      int                // len(s.mmappedChunks); detects mmap events.
+	firstChunkID chunks.HeadChunkID // Detects truncation.
+}
+
+// headChunkCacheKeyFor returns the cache key for the current chunk layout of s.
+// The series lock must be held.
+func headChunkCacheKeyFor(s *memSeries) headChunkCacheKey {
+	return headChunkCacheKey{
+		ref:          storage.SeriesRef(s.ref),
+		head:         s.headChunks,
+		mmapLen:      len(s.mmappedChunks),
+		firstChunkID: s.firstChunkID,
+	}
 }
 
 func (h *headChunkReader) Close() error {
 	if h.isoState != nil {
 		h.isoState.Close()
 	}
+	// Release the cache so a closed reader retains no chunk data.
+	h.cachedKey = headChunkCacheKey{}
+	h.cachedHeadChunks = nil
 	return nil
+}
+
+// EnableChunkCache enables the head-chunk cache for sequential chunk access
+// patterns (range queries), which look up every chunk of a series. The cache
+// is invalidated whenever the series' chunk layout changes (a parallel append,
+// mmapping, or truncation), falling back to O(n) for that lookup.
+func (h *headChunkReader) EnableChunkCache() {
+	h.enableCache = true
 }
 
 // getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
@@ -407,23 +435,21 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 		return nil
 	}
 
-	ref := storage.SeriesRef(s.ref)
-	if ref == h.cachedSeriesRef && s.headChunks == h.cachedHeadChunksHead &&
-		h.cachedMmapLen == len(s.mmappedChunks) && h.cachedFirstChunkID == s.firstChunkID {
+	key := headChunkCacheKeyFor(s)
+	if key == h.cachedKey {
 		return h.cachedHeadChunks
 	}
 
-	var buf []*memChunk
-	if h.cachedHeadChunks != nil {
-		buf = h.cachedHeadChunks[:0]
+	buf := h.cachedHeadChunks[:0]
+	// Pre-size the first collection, and do not carry oversized backing arrays
+	// from one series to the next (the headChunksBufMaxCap policy used for
+	// headChunksBuf) — but keep a large array while it still serves the same
+	// series.
+	if c := cap(buf); c == 0 || (c > headChunksBufMaxCap && key.ref != h.cachedKey.ref) {
+		buf = make([]*memChunk, 0, s.headChunks.len())
 	}
 	h.cachedHeadChunks = collectHeadChunks(s.headChunks, buf)
-	// Allow GC of *memChunk pointers left over from a previous, longer collection.
-	clear(h.cachedHeadChunks[len(h.cachedHeadChunks):cap(h.cachedHeadChunks)])
-	h.cachedSeriesRef = ref
-	h.cachedHeadChunksHead = s.headChunks
-	h.cachedMmapLen = len(s.mmappedChunks)
-	h.cachedFirstChunkID = s.firstChunkID
+	h.cachedKey = key
 	return h.cachedHeadChunks
 }
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 // TestMemSeries_chunk runs a series of tests on memSeries.chunk() calls.
@@ -668,47 +669,70 @@ func TestHeadIndexReader_LabelValuesExcluding(t *testing.T) {
 	})
 }
 
+// newCacheTestHead creates a Head whose single series ("__name__"="test",
+// ref 1) has at least three head chunks and no mmapped chunks, and returns the
+// head, the series, and the ref of its newest head chunk (chunk IDs are stable
+// across truncation).
+func newCacheTestHead(t *testing.T) (*Head, *memSeries, chunks.HeadChunkRef) {
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 100
+	h, _ := newTestHeadWithOptions(t, compression.None, opts)
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	// Append enough samples to create multiple head chunks. With
+	// ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk holds ~20
+	// samples (range/step = 100/5).
+	app := h.Appender(context.Background())
+	lbls := labels.FromStrings("__name__", "test")
+	for i := int64(0); i < 500; i += 5 {
+		_, err := app.Append(0, lbls, i, float64(i))
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	s := h.series.getByID(1)
+	require.NotNil(t, s)
+	// Snapshot values under the lock and assert after unlocking: a failing
+	// require while the series lock is held would deadlock the head Close in
+	// the test cleanup.
+	s.Lock()
+	headChunksLen := s.headChunks.len()
+	mmappedLen := len(s.mmappedChunks)
+	newestCID := s.firstChunkID + chunks.HeadChunkID(mmappedLen) + chunks.HeadChunkID(headChunksLen) - 1
+	newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
+	s.Unlock()
+	require.Greater(t, headChunksLen, 2, "need at least 3 head chunks for the test")
+	require.Zero(t, mmappedLen, "test requires a series with no mmapped chunks")
+
+	return h, s, newestRef
+}
+
 func TestHeadChunkReaderCache(t *testing.T) {
 	t.Run("cache_hit", func(t *testing.T) {
 		// Verify that a second chunk lookup for the same (unchanged) series
 		// returns the cached head-chunks slice without re-collecting.
-		opts := DefaultHeadOptions()
-		opts.ChunkRange = 100
-		opts.ChunkDirRoot = t.TempDir()
-		h, err := NewHead(nil, nil, nil, nil, opts, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, h.Close()) })
-
-		app := h.Appender(context.Background())
-		lbls := labels.FromStrings("__name__", "test")
-		for i := int64(0); i < 500; i += 5 {
-			_, err := app.Append(0, lbls, i, float64(i))
-			require.NoError(t, err)
-		}
-		require.NoError(t, app.Commit())
-
-		s := h.series.getByID(1)
-		require.NotNil(t, s)
-		s.Lock()
-		require.Greater(t, s.headChunks.len(), 1, "need multiple head chunks for the test")
-		newestCID := s.firstChunkID + chunks.HeadChunkID(len(s.mmappedChunks)) + chunks.HeadChunkID(s.headChunks.len()) - 1
-		newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
-		s.Unlock()
+		h, _, newestRef := newCacheTestHead(t)
 
 		cr, err := h.chunksRange(0, 10000, nil)
 		require.NoError(t, err)
-		cr.enableCache = true
+		cr.EnableChunkCache()
 
 		// First call: populates the cache.
 		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, cr.cachedHeadChunks)
-		cachedSlice := cr.cachedHeadChunks
 
-		// Second call (same series, no changes): must reuse the cached slice.
+		// Plant a sentinel: a cache hit returns the slice untouched, while a
+		// re-collection overwrites index 0 with the series' real oldest chunk.
+		// The newest-chunk lookup below never dereferences index 0, so the
+		// sentinel is safe.
+		sentinel := &memChunk{}
+		cr.cachedHeadChunks[0] = sentinel
+
+		// Second call (same series, no changes): must take the cache-hit path.
 		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
-		require.Same(t, &cachedSlice[0], &cr.cachedHeadChunks[0], "expected cache hit — slice backing array should be identical")
+		require.Same(t, sentinel, cr.cachedHeadChunks[0], "expected cache hit — the cached slice should not have been re-collected")
 	})
 
 	t.Run("invalidated_after_mmap", func(t *testing.T) {
@@ -718,41 +742,16 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// keeps the same head pointer, so a pointer-only check would return
 		// a stale cache with chunks that have been mmapped.
 
-		opts := DefaultHeadOptions()
-		opts.ChunkRange = 100
-		opts.ChunkDirRoot = t.TempDir()
-		h, err := NewHead(nil, nil, nil, nil, opts, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, h.Close()) })
-
-		// Append enough samples to create multiple head chunks.
-		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk
-		// holds ~20 samples (range/step = 100/5). We want >=3 head chunks.
-		app := h.Appender(context.Background())
-		lbls := labels.FromStrings("__name__", "test")
-		for i := int64(0); i < 500; i += 5 {
-			_, err := app.Append(0, lbls, i, float64(i))
-			require.NoError(t, err)
-		}
-		require.NoError(t, app.Commit())
-
-		// Look up the series and verify we have multiple head chunks.
-		s := h.series.getByID(1)
-		require.NotNil(t, s)
+		h, s, newestRef := newCacheTestHead(t)
 		s.Lock()
-		require.Greater(t, s.headChunks.len(), 1, "need multiple head chunks for the test")
 		headChunksLenBefore := s.headChunks.len()
 		newestChunkMinTime := s.headChunks.minTime
-		// The chunk ID for the newest head chunk:
-		// firstChunkID + len(mmapped) + headChunksLen - 1
-		newestCID := s.firstChunkID + chunks.HeadChunkID(len(s.mmappedChunks)) + chunks.HeadChunkID(s.headChunks.len()) - 1
-		newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
 		s.Unlock()
 
 		// Create a headChunkReader with cache enabled and query the newest head chunk to populate the cache.
 		cr, err := h.chunksRange(0, 10000, nil)
 		require.NoError(t, err)
-		cr.enableCache = true
+		cr.EnableChunkCache()
 
 		chk1, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
@@ -762,18 +761,23 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.NotNil(t, cr.cachedHeadChunks)
 		require.Len(t, cr.cachedHeadChunks, headChunksLenBefore)
 
-		// Now mmap all but the newest head chunk — this severs the linked list.
+		// Now mmap all but the newest head chunk — this severs the linked
+		// list. Snapshot under the lock, assert after unlocking (a failing
+		// require under the series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
 		s.mmapChunks(h.chunkDiskMapper)
-		require.Equal(t, 1, s.headChunks.len(), "after mmap, should have exactly 1 head chunk")
-		require.Same(t, headPtrBefore, s.headChunks, "head pointer should not change (the bug scenario)")
-		require.Equal(t, newestChunkMinTime, s.headChunks.minTime, "newest chunk should be the remaining head chunk")
-
+		headChunksLenAfter := s.headChunks.len()
+		headPtrAfter := s.headChunks
+		newestMinTimeAfter := s.headChunks.minTime
 		// Recompute the newest chunk ID after mmap: more mmapped chunks now.
-		newestCID = s.firstChunkID + chunks.HeadChunkID(len(s.mmappedChunks)) + chunks.HeadChunkID(s.headChunks.len()) - 1
+		newestCID := s.firstChunkID + chunks.HeadChunkID(len(s.mmappedChunks)) + chunks.HeadChunkID(s.headChunks.len()) - 1
 		newestRef = chunks.NewHeadChunkRef(s.ref, newestCID)
 		s.Unlock()
+
+		require.Equal(t, 1, headChunksLenAfter, "after mmap, should have exactly 1 head chunk")
+		require.Same(t, headPtrBefore, headPtrAfter, "mmapChunks must keep the head pointer — the precondition that would blind a pointer-only cache check")
+		require.Equal(t, newestChunkMinTime, newestMinTimeAfter, "newest chunk should be the remaining head chunk")
 
 		// Query the newest head chunk again. With the bug, the stale cache
 		// would be used and return a wrong (mmapped) chunk.
@@ -800,44 +804,16 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// otherwise chunk IDs are resolved against the stale slice and the
 		// wrong chunk is returned.
 
-		opts := DefaultHeadOptions()
-		opts.ChunkRange = 100
-		opts.ChunkDirRoot = t.TempDir()
-		h, err := NewHead(nil, nil, nil, nil, opts, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, h.Close()) })
-
-		// Append enough samples to create multiple head chunks.
-		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk
-		// holds ~20 samples (range/step = 100/5). We want >=3 head chunks.
-		app := h.Appender(context.Background())
-		lbls := labels.FromStrings("__name__", "test")
-		for i := int64(0); i < 500; i += 5 {
-			_, err := app.Append(0, lbls, i, float64(i))
-			require.NoError(t, err)
-		}
-		require.NoError(t, app.Commit())
-
-		s := h.series.getByID(1)
-		require.NotNil(t, s)
-		// Snapshot values under the lock and assert after unlocking: a
-		// failing require while the series lock is held would deadlock the
-		// head Close in the test cleanup.
+		h, s, newestRef := newCacheTestHead(t)
 		s.Lock()
-		headChunksLen := s.headChunks.len()
-		mmappedLen := len(s.mmappedChunks)
 		newestChunkMinTime := s.headChunks.minTime
+		headChunksLenBefore := s.headChunks.len()
 		firstChunkIDBefore := s.firstChunkID
-		// Chunk IDs are stable across truncation, so this ref stays valid.
-		newestCID := firstChunkIDBefore + chunks.HeadChunkID(mmappedLen) + chunks.HeadChunkID(headChunksLen) - 1
-		newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
 		s.Unlock()
-		require.Greater(t, headChunksLen, 2, "need at least 3 head chunks for the test")
-		require.Zero(t, mmappedLen, "test requires a series with no mmapped chunks")
 
 		cr, err := h.chunksRange(0, 10000, nil)
 		require.NoError(t, err)
-		cr.enableCache = true
+		cr.EnableChunkCache()
 
 		// First call: populates the cache.
 		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
@@ -845,7 +821,9 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.NotNil(t, cr.cachedHeadChunks)
 
 		// Truncate the oldest head chunk: the head pointer and the mmapped
-		// chunk count (0) are unchanged, but firstChunkID advances.
+		// chunk count (0) are unchanged, but firstChunkID advances. Snapshot
+		// under the lock, assert after unlocking (a failing require under the
+		// series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
 		oldestMaxTime := s.headChunks.oldest().maxTime
@@ -865,12 +843,75 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		chk, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, chk)
-		require.Len(t, cr.cachedHeadChunks, headChunksLen-1, "the stale cache must be re-collected after truncation")
+		require.Len(t, cr.cachedHeadChunks, headChunksLenBefore-1, "the stale cache must be re-collected after truncation")
 
 		it := chk.Iterator(nil)
 		require.Equal(t, chunkenc.ValFloat, it.Next())
 		ts, _ := it.At()
 		require.Equal(t, newestChunkMinTime, ts, "returned chunk should be the newest head chunk, not a stale cached entry")
+	})
+
+	t.Run("cache_cap_release", func(t *testing.T) {
+		// The cache must not carry an oversized backing array from one series
+		// to the next (the headChunksBufMaxCap policy).
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 1
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+		// The big series gets more than headChunksBufMaxCap head chunks
+		// (ChunkRange=1 cuts a chunk per sample); the small series a few.
+		app := h.Appender(context.Background())
+		big := labels.FromStrings("__name__", "big")
+		small := labels.FromStrings("__name__", "small")
+		for i := range int64(headChunksBufMaxCap) + 10 {
+			_, err := app.Append(0, big, i, float64(i))
+			require.NoError(t, err)
+		}
+		for i := range int64(5) {
+			_, err := app.Append(0, small, i, float64(i))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+
+		bigSeries := h.series.getByHash(big.Hash(), big)
+		require.NotNil(t, bigSeries)
+		smallSeries := h.series.getByHash(small.Hash(), small)
+		require.NotNil(t, smallSeries)
+
+		cr, err := h.chunksRange(0, 10000, nil)
+		require.NoError(t, err)
+		cr.EnableChunkCache()
+
+		// Populate the cache with the big series: its cap exceeds the bound.
+		bigRef := chunks.NewHeadChunkRef(bigSeries.ref, bigSeries.firstChunkID)
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
+		require.NoError(t, err)
+		require.Greater(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
+
+		// Switching to the small series must release the oversized array and
+		// pre-size the replacement from the series' chunk count.
+		smallRef := chunks.NewHeadChunkRef(smallSeries.ref, smallSeries.firstChunkID)
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(smallRef)}, false)
+		require.NoError(t, err)
+		require.LessOrEqual(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
+	})
+
+	t.Run("released_on_close", func(t *testing.T) {
+		// A closed reader must retain no cache key or chunk data.
+		h, _, newestRef := newCacheTestHead(t)
+
+		cr, err := h.chunksRange(0, 10000, nil)
+		require.NoError(t, err)
+		cr.EnableChunkCache()
+
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		require.NoError(t, err)
+		require.NotNil(t, cr.cachedHeadChunks)
+
+		require.NoError(t, cr.Close())
+		require.Equal(t, headChunkCacheKey{}, cr.cachedKey)
+		require.Nil(t, cr.cachedHeadChunks)
 	})
 
 	t.Run("buffer_cap_release", func(t *testing.T) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -310,7 +310,6 @@ func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChun
 	// (OOOCompactionHead.Chunks), which only requests OOO chunks, so this
 	// branch is not reached. It is kept for correctness if callers change.
 	cr.headChunksBuf = collectHeadChunks(s.headChunks, cr.headChunksBuf[:0])
-	clear(cr.headChunksBuf[len(cr.headChunksBuf):cap(cr.headChunksBuf)])
 	hc := cr.headChunksBuf
 	if cap(cr.headChunksBuf) > headChunksBufMaxCap {
 		cr.headChunksBuf = nil
@@ -318,23 +317,26 @@ func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChun
 	return hc
 }
 
-// EnableChunkCache enables the head-chunk cache on the underlying headChunkReader.
-// This should only be called for range queries where the cache provides O(1) lookups
-// across multiple chunk accesses for the same series.
+// EnableChunkCache enables the head-chunk cache on the underlying
+// headChunkReader; see its documentation for the caching semantics.
 func (cr *HeadAndOOOChunkReader) EnableChunkCache() {
 	if cr.cr != nil {
-		cr.cr.enableCache = true
+		cr.cr.EnableChunkCache()
 	}
 }
 
 func (cr *HeadAndOOOChunkReader) Close() error {
-	if cr.cr != nil && cr.cr.isoState != nil {
-		cr.cr.isoState.Close()
+	var err error
+	if cr.cr != nil {
+		err = cr.cr.Close()
 	}
 	if cr.oooIsoState != nil {
 		cr.oooIsoState.Close()
 	}
-	return nil
+	// Release the fallback collection buffer so a closed reader retains no
+	// chunk data.
+	cr.headChunksBuf = nil
+	return err
 }
 
 type OOOCompactionHead struct {
@@ -614,11 +616,11 @@ func (q *HeadAndOOOQuerier) LabelNames(ctx context.Context, hints *storage.Label
 }
 
 func (q *HeadAndOOOQuerier) Close() error {
-	q.chunkr.Close()
+	err := q.chunkr.Close()
 	if q.querier == nil {
-		return nil
+		return err
 	}
-	return q.querier.Close()
+	return errors.Join(err, q.querier.Close())
 }
 
 func (q *HeadAndOOOQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
@@ -666,11 +668,11 @@ func (q *HeadAndOOOChunkQuerier) LabelNames(ctx context.Context, hints *storage.
 }
 
 func (q *HeadAndOOOChunkQuerier) Close() error {
-	q.chunkr.Close()
+	err := q.chunkr.Close()
 	if q.querier == nil {
-		return nil
+		return err
 	}
-	return q.querier.Close()
+	return errors.Join(err, q.querier.Close())
 }
 
 func (q *HeadAndOOOChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {


### PR DESCRIPTION
Backport of prometheus/prometheus#19136 to `mimir-release-2.17`.

Stacked on the #19134 backport, which is stacked on #1266. Merge those first.

This brings the head-chunk cache introduced by #1266 to the same lifecycle guarantees as `main`: the fingerprint becomes a single comparable key so future fields cannot be forgotten in the comparison, the cache and the OOO reader's fallback buffer are released on `Close`, the `headChunksBufMaxCap` policy is applied when the reader moves to a different series, and the head-and-OOO queriers stop swallowing chunk-reader `Close` errors.

One behaviour change worth noting: `headChunkReader` gains an exported `EnableChunkCache`, so it now satisfies the `chunkCacheToggler` assertion in `selectSeriesSet`/`selectChunkSeriesSet`. Before this, only `HeadAndOOOChunkReader` could ever turn the cache on, so range queries against a head without out-of-order support never used it.

Backport adaptations, since this branch predates two upstream changes:

* `memSeries.headChunkCount` does not exist here (added upstream by prometheus/prometheus#18300), so the replacement collection is pre-sized from `headChunks.len()`. That is an extra list walk, but only on the first collection for a reader or when switching series with an oversized backing array.
* `newTestHeadWithOptions` does not register a cleanup on this branch, so the new tests close the head themselves; `t.Context()` → `context.Background()`.

```release-notes
NONE
```
