### PR TITLE
OTLP: Use warning instead of errors when ingesting messages with no data points

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/annotations.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/annotations.go
@@ -26,6 +26,9 @@ import (
 type WarningCategory string
 
 const (
+	// WarningCategoryEmptyDataPoints is set when an OTLP metric has no data
+	// points and is dropped.
+	WarningCategoryEmptyDataPoints WarningCategory = "empty_data_points"
 	// WarningCategoryLabelNameCollision is set when two or more OTLP attribute
 	// names map to the same label name after sanitization and their values are
 	// concatenated.

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -288,7 +288,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 				case pmetric.MetricTypeGauge:
 					dataPoints := metric.Gauge().DataPoints()
 					if dataPoints.Len() == 0 {
-						errs = errors.Join(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						annots.Add(newCategorizedWarningf(WarningCategoryEmptyDataPoints, "empty data points. %s is dropped", metric.Name()))
 						break
 					}
 					if err := c.addGaugeNumberDataPoints(ctx, dataPoints, settings, appOpts); err != nil {
@@ -300,7 +300,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 				case pmetric.MetricTypeSum:
 					dataPoints := metric.Sum().DataPoints()
 					if dataPoints.Len() == 0 {
-						errs = errors.Join(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						annots.Add(newCategorizedWarningf(WarningCategoryEmptyDataPoints, "empty data points. %s is dropped", metric.Name()))
 						break
 					}
 					if err := c.addSumNumberDataPoints(ctx, dataPoints, settings, appOpts); err != nil {
@@ -312,7 +312,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 				case pmetric.MetricTypeHistogram:
 					dataPoints := metric.Histogram().DataPoints()
 					if dataPoints.Len() == 0 {
-						errs = errors.Join(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						annots.Add(newCategorizedWarningf(WarningCategoryEmptyDataPoints, "empty data points. %s is dropped", metric.Name()))
 						break
 					}
 					if settings.ConvertHistogramsToNHCB {
@@ -337,7 +337,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 				case pmetric.MetricTypeExponentialHistogram:
 					dataPoints := metric.ExponentialHistogram().DataPoints()
 					if dataPoints.Len() == 0 {
-						errs = errors.Join(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						annots.Add(newCategorizedWarningf(WarningCategoryEmptyDataPoints, "empty data points. %s is dropped", metric.Name()))
 						break
 					}
 					ws, err := c.addExponentialHistogramDataPoints(
@@ -357,7 +357,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 				case pmetric.MetricTypeSummary:
 					dataPoints := metric.Summary().DataPoints()
 					if dataPoints.Len() == 0 {
-						errs = errors.Join(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						annots.Add(newCategorizedWarningf(WarningCategoryEmptyDataPoints, "empty data points. %s is dropped", metric.Name()))
 						break
 					}
 					if err := c.addSummaryDataPoints(ctx, dataPoints, settings, appOpts); err != nil {

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -308,6 +308,60 @@ func TestFromMetrics(t *testing.T) {
 		}, ws)
 	})
 
+	t.Run("empty data points are surfaced as warnings", func(t *testing.T) {
+		for _, tc := range []struct {
+			name       string
+			buildEmpty func(pmetric.Metric)
+		}{
+			{
+				name: "gauge",
+				buildEmpty: func(m pmetric.Metric) {
+					m.SetEmptyGauge()
+				},
+			},
+			{
+				name: "sum",
+				buildEmpty: func(m pmetric.Metric) {
+					m.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				},
+			},
+			{
+				name: "histogram",
+				buildEmpty: func(m pmetric.Metric) {
+					m.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				},
+			},
+			{
+				name: "exponential histogram",
+				buildEmpty: func(m pmetric.Metric) {
+					m.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				},
+			},
+			{
+				name: "summary",
+				buildEmpty: func(m pmetric.Metric) {
+					m.SetEmptySummary()
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				request := pmetricotlp.NewExportRequest()
+				m := request.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+				m.SetName("test_empty")
+				tc.buildEmpty(m)
+
+				converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
+				annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{})
+				require.NoError(t, err)
+				require.Equal(t, map[WarningCategory]int{WarningCategoryEmptyDataPoints: 1}, CountWarningsByCategory(annots))
+
+				ws, infos := annots.AsStrings("", 0, 0)
+				require.Empty(t, infos)
+				require.Equal(t, []string{"empty data points. test_empty is dropped"}, ws)
+			})
+		}
+	})
+
 	t.Run("attribute collision is surfaced as a warning", func(t *testing.T) {
 		request := pmetricotlp.NewExportRequest()
 		rm := request.Metrics().ResourceMetrics().AppendEmpty()

--- a/storage/remote/write_otlp_handler_test.go
+++ b/storage/remote/write_otlp_handler_test.go
@@ -302,6 +302,38 @@ func TestOTLPWriteHandler(t *testing.T) {
 			require.NoError(t, ex.ConsumeMetrics(t.Context(), request.Metrics()))
 			require.Equal(t, 1.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("histogram_zero_count_non_zero_sum")))
 		})
+
+		t.Run("empty data points", func(t *testing.T) {
+			request := pmetricotlp.NewExportRequest()
+			m := request.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			m.SetName("test_empty_gauge")
+			m.SetEmptyGauge()
+
+			ex := newExporter()
+			require.Equal(t, 0.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("empty_data_points")))
+			require.NoError(t, ex.ConsumeMetrics(t.Context(), request.Metrics()))
+			require.Equal(t, 1.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("empty_data_points")))
+		})
+	})
+
+	t.Run("empty metric does not reject healthy metrics", func(t *testing.T) {
+		request := pmetricotlp.NewExportRequest()
+		metrics := request.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
+
+		healthy := metrics.AppendEmpty()
+		healthy.SetName("healthy_metric")
+		dp := healthy.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		dp.SetIntValue(1)
+
+		empty := metrics.AppendEmpty()
+		empty.SetName("empty_metric")
+		empty.SetEmptyGauge()
+
+		appendable := handleOTLP(t, request, config.OTLPConfig{}, OTLPOptions{})
+		samples := appendable.ResultSamples()
+		require.Len(t, samples, 1)
+		require.Equal(t, "healthy_metric", samples[0].L.Get(labels.MetricName))
 	})
 }
 


### PR DESCRIPTION
Backporting https://github.com/prometheus/prometheus/pull/19343 to Mimir 3.2

ref: https://github.com/grafana/mimir/pull/14789#issuecomment-5263940778