### PR TITLE
[mimir-release-2.17] tsdb: optimize head chunk access paths (#18300)

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -1087,6 +1087,9 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		}
 		closers = append(closers, chunkr)
 
+		// Enable the head-chunk cache for compaction.
+		enableChunkCache(chunkr)
+
 		tombsr, err := b.Tombstones()
 		if err != nil {
 			return fmt.Errorf("open tombstone reader for block %+v: %w", b.Meta(), err)

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1412,6 +1412,119 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			h.Close()
 		})
 	}
+
+	// Sub-benchmark with multiple head chunks per series, as can happen with
+	// native histograms that trigger a counter reset on every sample. This
+	// stresses the linked-list traversal in s.chunk() and exercises the
+	// head-chunk cache.
+	for _, tc := range []struct{ series, chunks int }{
+		{100000, 1},  // Baseline: cache skipped (prev==nil).
+		{100000, 10}, // Realistic: cache active, but improvement negligible vs total compaction cost.
+		{10, 100},    // Moderate pathological case.
+		{10, 1000},   // Heavy pathological case.
+	} {
+		nSeries, nChunks := tc.series, tc.chunks
+		b.Run(fmt.Sprintf("many head chunks/series=%d,chunks=%d", nSeries, nChunks), func(b *testing.B) {
+			dir := b.TempDir()
+			chunkDir := b.TempDir()
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = int64(nChunks+1) * 1000 // Wide enough so nothing gets mmapped.
+			opts.ChunkDirRoot = chunkDir
+			opts.EnableNativeHistograms.Store(true)
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
+			require.NoError(b, err)
+
+			app := h.Appender(context.Background())
+			for i := range nSeries {
+				lbls := labels.FromStrings("__name__", "bench", "series", strconv.Itoa(i))
+				for j := range nChunks {
+					// Counter reset on every histogram forces a new head chunk per sample.
+					hist := tsdbutil.GenerateTestHistogramWithHint(j, histogram.CounterReset)
+					_, err := app.AppendHistogram(0, lbls, int64(j)*1000, hist, nil)
+					require.NoError(b, err)
+				}
+			}
+			require.NoError(b, app.Commit())
+
+			// Verify we actually have the expected number of head chunks.
+			for i := range nSeries {
+				lbls := labels.FromStrings("__name__", "bench", "series", strconv.Itoa(i))
+				s := h.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(b, s, "series %d not found", i)
+				require.Equal(b, uint32(nChunks), s.headChunkCount.Load(), "series %d: unexpected head chunk count", i)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				createBlockFromHead(b, filepath.Join(dir, strconv.Itoa(i)), h)
+			}
+			h.Close()
+		})
+	}
+}
+
+func TestCompactionFromHead(t *testing.T) {
+	t.Run("multiple head chunks", func(t *testing.T) {
+		// Verify compaction from a Head with multiple head chunks per series
+		// produces correct blocks. This exercises the chunkCacheEnabler path
+		// in PopulateBlock, which enables the head-chunk cache during
+		// compaction for O(1) chunk lookups.
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 100
+		opts.ChunkDirRoot = t.TempDir()
+		h, err := NewHead(nil, nil, nil, nil, opts, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+		// Append enough samples to create multiple head chunks.
+		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk holds
+		// ~20 samples (range/step = 100/5). 200 samples → ~10 head chunks.
+		lbls := labels.FromStrings("__name__", "test")
+		var expSamples []sample
+		app := h.Appender(context.Background())
+		for i := int64(0); i < 1000; i += 5 {
+			_, err := app.Append(0, lbls, i, float64(i))
+			require.NoError(t, err)
+			expSamples = append(expSamples, sample{t: i, f: float64(i)})
+		}
+		require.NoError(t, app.Commit())
+
+		// Verify we have multiple head chunks.
+		s := h.series.getByID(1)
+		require.NotNil(t, s)
+		s.Lock()
+		headChunks := int(s.headChunkCount.Load())
+		s.Unlock()
+		require.Greater(t, headChunks, 1, "need multiple head chunks for this test")
+
+		// Compact from head.
+		blockDir := createBlockFromHead(t, t.TempDir(), h)
+
+		// Re-read the block and verify all samples survived.
+		block, err := OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, block.Close()) })
+
+		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+		defer q.Close()
+
+		ss := q.Select(context.Background(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "__name__", "test"))
+		require.True(t, ss.Next(), "expected a series")
+
+		var actSamples []sample
+		it := ss.At().Iterator(nil)
+		for it.Next() == chunkenc.ValFloat {
+			ts, v := it.At()
+			actSamples = append(actSamples, sample{t: ts, f: v})
+		}
+		require.NoError(t, it.Err())
+		require.False(t, ss.Next(), "expected only one series")
+		require.NoError(t, ss.Err())
+
+		require.Equal(t, expSamples, actSamples, "compacted block should contain all samples")
+	})
 }
 
 func BenchmarkCompactionFromOOOHead(b *testing.B) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2402,6 +2402,7 @@ func (mc *memChunk) len() (count int) {
 
 // collectHeadChunks walks the headChunks linked list once and returns a slice
 // in oldest-first order (matching mmappedChunks ordering).
+// For example, given head{t4} -> t3 -> t2 -> t1 -> t0, it returns [t0, t1, t2, t3, t4].
 // buf must have length 0 but may have non-zero capacity for reuse; the
 // returned slice's tail beyond its length is zeroed, so a reused, shrinking
 // buffer does not pin chunks from a previous, longer collection.
@@ -2428,30 +2429,6 @@ func (mc *memChunk) oldest() (elem *memChunk) {
 	elem = mc
 	for elem.prev != nil {
 		elem = elem.prev
-	}
-	return elem
-}
-
-// atOffset returns a memChunk that's Nth element on the linked list.
-func (mc *memChunk) atOffset(offset int) (elem *memChunk) {
-	if offset == 0 {
-		return mc
-	}
-	if offset == 1 {
-		return mc.prev
-	}
-	if offset < 0 {
-		return nil
-	}
-
-	var i int
-	elem = mc
-	for i < offset {
-		i++
-		elem = elem.prev
-		if elem == nil {
-			break
-		}
 	}
 	return elem
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1967,14 +1967,12 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper *chunks.ChunkDiskMap
 func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
-		return
+		return count
 	}
 
-	// Write chunks starting from the oldest one and stop before we get to current s.headChunks.
-	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
-	// then we need to write chunks t0 to t3, but skip s.headChunks.
-	for i := s.headChunks.len() - 1; i > 0; i-- {
-		chk := s.headChunks.atOffset(i)
+	// Collect head chunks in oldest-first order, then write all except the newest.
+	hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
+	for _, chk := range hc[:len(hc)-1] {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -28,9 +28,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 
-// headChunksBufMaxCap is the maximum capacity for the reusable headChunksBuf
-// slice. If the buffer grows beyond this, it is released to avoid holding
-// oversized backing arrays across many series iterations.
+// headChunksBufMaxCap is the maximum capacity retained for reusable []*memChunk
+// buffers. If a buffer grows beyond this, it is released to avoid holding
+// oversized backing arrays across series iterations.
 const headChunksBufMaxCap = 256
 
 func (h *Head) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
@@ -418,9 +418,10 @@ func (h *headChunkReader) Close() error {
 }
 
 // EnableChunkCache enables the head-chunk cache for sequential chunk access
-// patterns (range queries), which look up every chunk of a series. The cache
-// is invalidated whenever the series' chunk layout changes (a parallel append,
-// mmapping, or truncation), falling back to O(n) for that lookup.
+// patterns (range queries, compaction), which look up every chunk of a series.
+// The cache is invalidated whenever the series' chunk layout changes (a
+// parallel append, mmapping, or truncation), falling back to O(n) for that
+// lookup.
 func (h *headChunkReader) EnableChunkCache() {
 	h.enableCache = true
 }
@@ -547,28 +548,21 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // (and not the chunkenc.Chunk inside it) can be garbage collected after its usage.
 // if isOpen is true, it means that the returned *memChunk is used for appends.
 func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
-	// ix represents the index of chunk in the s.mmappedChunks slice. The chunk id's are
-	// incremented by 1 when new chunk is created, hence (id - firstChunkID) gives the slice index.
-	// The max index for the s.mmappedChunks slice can be len(s.mmappedChunks)-1, hence if the ix
-	// is >= len(s.mmappedChunks), it represents one of the chunks on s.headChunks linked list.
-	// The order of elements is different for slice and linked list.
-	// For s.mmappedChunks slice newer chunks are appended to it.
-	// For s.headChunks list newer chunks are prepended to it.
+	// ix is the chunk's oldest-first position in the logical sequence. Chunk IDs
+	// increase by one when a chunk is created, so id-firstChunkID yields that position.
+	// s.mmappedChunks is stored oldest-first, while the s.headChunks linked list is
+	// stored newest-first:
 	//
 	// memSeries {
 	//   mmappedChunks: [t0, t1, t2]
-	//   headChunk:     {t5}->{t4}->{t3}
+	//   headChunks:    {t5}->{t4}->{t3}
 	// }
+	//
+	// Values below len(s.mmappedChunks) index the slice directly. Remaining values
+	// index head chunks oldest-first; the pre-collected headChunks slice already uses
+	// this order, while the linked-list fallback reverses the index.
 	ix := int(id) - int(s.firstChunkID)
-
-	var headChunksLen int
-	if headChunks != nil {
-		headChunksLen = len(headChunks)
-	} else if s.headChunks != nil {
-		headChunksLen = s.headChunks.len()
-	}
-
-	if ix < 0 || ix > len(s.mmappedChunks)+headChunksLen-1 {
+	if ix < 0 {
 		return nil, false, false, storage.ErrNotFound
 	}
 
@@ -600,16 +594,23 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	}
 
 	// Fallback: walk the linked list.
-
+	headChunksLen := int(s.headChunkCount.Load())
+	if ix >= headChunksLen {
+		return nil, false, false, storage.ErrNotFound
+	}
+	// Walk from newest (offset 0) to target. The list is newest-first,
+	// but ix is oldest-first, so reverse the offset.
 	offset := headChunksLen - ix - 1
-	// headChunks is a linked list where first element is the most recent one and the last one is the oldest.
-	// This order is reversed when compared with mmappedChunks, since mmappedChunks[0] is the oldest chunk,
-	// while headChunk.atOffset(0) would give us the most recent chunk.
-	// So when calling headChunk.atOffset() we need to reverse the value of ix.
-	elem := s.headChunks.atOffset(offset)
+	elem := s.headChunks
+	for range offset {
+		if elem == nil {
+			break
+		}
+		elem = elem.prev
+	}
 	if elem == nil {
-		// This should never really happen and would mean that headChunksLen value is NOT equal
-		// to the length of the headChunks list.
+		// Defensive: headChunkCount disagreed with the actual list length.
+		// This only catches walks that run off the end of the list.
 		return nil, false, false, storage.ErrNotFound
 	}
 	return elem, true, offset == 0, nil
@@ -645,7 +646,7 @@ func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator 
 	return it
 }
 
-// iterator returns a chunk iterator for the requested chunkID, or a NopIterator if the requested ID is out of range.
+// iterator returns a chunk iterator for the requested chunk ID, or a NopIterator if it is out of range.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
 func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *isolationState, it chunkenc.Iterator) chunkenc.Iterator {
 	ix := int(id) - int(s.firstChunkID)
@@ -664,20 +665,20 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 			}
 		}
 
-		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
-			// Iterate all head chunks from the oldest to the newest.
-			headChunksLen := s.headChunks.len()
-			for j := headChunksLen - 1; j >= 0; j-- {
-				chk := s.headChunks.atOffset(j)
-				chkSamples := chk.chunk.NumSamples()
+			// Reset ix, so its base is 0 (oldest non-mmapped head chunk).
+			ix -= len(s.mmappedChunks)
+
+			// Head chunks are indexed oldest-first, matching chunk ID order, but the list is walked newest-first,
+			// so j starts at the highest (newest) index and counts down.
+			j := int(s.headChunkCount.Load()) - 1
+			for elem := s.headChunks; elem != nil; elem = elem.prev {
+				chkSamples := elem.chunk.NumSamples()
 				totalSamples += chkSamples
-				// Chunk ID is len(s.mmappedChunks) + $(headChunks list position).
-				// Where $(headChunks list position) is zero for the oldest chunk and $(s.headChunks.len() - 1)
-				// for the newest (open) chunk.
-				if headChunksLen-1-j < ix {
+				if j < ix {
 					previousSamples += chkSamples
 				}
+				j--
 			}
 		}
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -168,7 +170,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  0,
 			expected: outMmappedChunk,
@@ -182,7 +184,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  2,
 			expected: outMmappedChunk,
@@ -196,7 +198,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  3,
 			expected: outErr,
@@ -410,6 +412,25 @@ func TestMemSeries_chunk(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("head chunk count mismatch", func(t *testing.T) {
+		// A drifted headChunkCount (larger than the actual list length) must
+		// yield ErrNotFound, not a panic or a nil chunk with a nil error.
+		s := &memSeries{ref: 1}
+		s.headChunkCount.Store(2) // Drifted: the list is empty.
+
+		// ix == count-1: the walk is skipped entirely (offset 0).
+		c, headChunk, isOpen, err := s.chunk(1, nil, nil, nil)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.Nil(t, c)
+		require.False(t, headChunk)
+		require.False(t, isOpen)
+
+		// ix < count-1: the walk runs off the end of the shorter list.
+		c, _, _, err = s.chunk(0, nil, nil, nil)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.Nil(t, c)
+	})
 }
 
 // TestMemSeries_chunk_FastPath verifies that the O(1) indexed lookup via a
@@ -475,6 +496,10 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 			require.Same(t, chkLL, chkFP, "ix=%d: head chunk pointer mismatch", ix)
 		}
 	}
+
+	// Out-of-range ID via the fast path must return ErrNotFound.
+	_, _, _, err = series.chunk(chunks.HeadChunkID(totalChunks), chunkDiskMapper, memChunkPool, hc)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 }
 
 func TestHeadIndexReader_PostingsForLabelMatching(t *testing.T) {
@@ -988,7 +1013,13 @@ func TestHeadChunkReaderCache(t *testing.T) {
 	})
 }
 
-var benchSink *memChunk
+// Benchmark sinks prevent the compiler from eliding the measured calls.
+var (
+	benchSinkChunk  *memChunk
+	benchSinkChunks []*memChunk
+	benchSinkMeta   []chunks.Meta
+	benchSinkInt    int
+)
 
 // BenchmarkSeriesChunkIteration measures iterating all N head chunks of a series
 // oldest-to-newest (the real query pattern) using the cached head-chunks slice.
@@ -1000,12 +1031,13 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 				firstChunkID: 0,
 				headChunks:   buildHeadChunksLight(n),
 			}
+			s.setHeadChunks(s.headChunks, uint32(n))
 			hc := collectHeadChunks(s.headChunks, nil)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for j := 0; j < b.N; j++ {
 				for i := range n {
-					benchSink, _, _, _ = s.chunk(chunks.HeadChunkID(i), nil, nil, hc)
+					benchSinkChunk, _, _, _ = s.chunk(chunks.HeadChunkID(i), nil, nil, hc)
 				}
 			}
 		})
@@ -1025,4 +1057,131 @@ func buildHeadChunksLight(n int) *memChunk {
 		}
 	}
 	return head
+}
+
+func BenchmarkAppendSeriesChunks(b *testing.B) {
+	for _, numHeadChunks := range []int{1, 4, 16, 64, 256} {
+		b.Run(fmt.Sprintf("head only/%d", numHeadChunks), func(b *testing.B) {
+			s := &memSeries{
+				ref:        1,
+				headChunks: buildHeadChunksLight(numHeadChunks),
+			}
+			mint := int64(0)
+			maxt := int64(numHeadChunks) * 1000
+			chks := make([]chunks.Meta, 0, numHeadChunks)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
+			}
+			benchSinkMeta = chks
+		})
+
+		b.Run(fmt.Sprintf("with mmapped/%d", numHeadChunks), func(b *testing.B) {
+			// Same number of mmapped chunks as head chunks. Mmapped chunks are
+			// strictly older than all head chunks, as in a real series.
+			mmapped := make([]*mmappedChunk, numHeadChunks)
+			for i := range numHeadChunks {
+				mmapped[i] = &mmappedChunk{
+					minTime: int64(i-numHeadChunks) * 1000,
+					maxTime: int64(i-numHeadChunks)*1000 + 999,
+				}
+			}
+			s := &memSeries{
+				ref:           1,
+				headChunks:    buildHeadChunksLight(numHeadChunks),
+				mmappedChunks: mmapped,
+			}
+			mint := int64(-numHeadChunks) * 1000
+			maxt := int64(numHeadChunks) * 1000
+			chks := make([]chunks.Meta, 0, numHeadChunks*2)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
+			}
+			benchSinkMeta = chks
+		})
+	}
+}
+
+func BenchmarkCollectHeadChunks(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			head := buildHeadChunksLight(n)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSinkChunks = collectHeadChunks(head, make([]*memChunk, 0, n))
+			}
+		})
+	}
+}
+
+func BenchmarkSeriesChunk(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		for _, pos := range []struct {
+			name string
+			id   chunks.HeadChunkID
+		}{
+			{name: "oldest", id: 0}, // Worst case: the full list walk.
+			{name: "middle", id: chunks.HeadChunkID(n / 2)},
+		} {
+			if n < 2 && pos.name == "middle" {
+				// With a single chunk, "middle" is the same lookup as "oldest".
+				continue
+			}
+			b.Run(fmt.Sprintf("%d/%s", n, pos.name), func(b *testing.B) {
+				s := &memSeries{
+					ref:          1,
+					firstChunkID: 0,
+					headChunks:   buildHeadChunksLight(n),
+				}
+				s.setHeadChunks(s.headChunks, uint32(n))
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					c, _, _, err := s.chunk(pos.id, nil, nil, nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSinkChunk = c
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkTruncateChunksBefore(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			// mint truncates the oldest half of head chunks.
+			mint := int64(n/2) * 1000
+			head := buildHeadChunksLight(n)
+			headChunks := collectHeadChunks(head, nil)
+			removedHeadChunks := n / 2
+			var boundary, removedTail *memChunk
+			if removedHeadChunks > 0 {
+				boundary = headChunks[removedHeadChunks]
+				removedTail = headChunks[removedHeadChunks-1]
+			}
+			s := &memSeries{firstChunkID: 0}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if boundary != nil {
+					boundary.prev = removedTail
+				}
+				s.firstChunkID = 0
+				s.mmappedChunks = nil
+				s.setHeadChunks(head, uint32(n))
+				benchSinkInt = s.truncateChunksBefore(mint, 0)
+			}
+		})
+	}
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1439,7 +1439,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			}
 
 			if tc.headChunks == 0 {
-				series.headChunks = nil
+				series.setHeadChunks(nil, 0)
 			} else {
 				for i := headStart; i < chunkRange*(tc.mmappedChunks+tc.headChunks); i += chunkStep {
 					ok, _ := series.append(int64(i), float64(i), 0, cOpts)
@@ -1454,9 +1454,6 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 				require.Nil(t, series.headChunks, "head chunk is present")
 			}
 			require.Len(t, series.mmappedChunks, tc.mmappedChunks, "wrong number of mmapped chunks")
-
-			// Normalize the counter after this test fixture directly manipulates headChunks.
-			series.headChunkCount.Store(uint32(tc.headChunks))
 
 			truncated := series.truncateChunksBefore(tc.truncateBefore, 0)
 			require.Equal(t, tc.expectedTruncated, truncated, "wrong number of truncated chunks returned")
@@ -1481,6 +1478,22 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			require.Equal(t, tc.expectedFirstChunkID, series.firstChunkID, "wrong firstChunkID after truncation")
 		})
 	}
+
+	t.Run("head chunk count mismatch", func(t *testing.T) {
+		// truncateChunksBefore must advance firstChunkID by the actual number of
+		// removed chunks, measured from the list itself, even if headChunkCount
+		// drifted from the real list length.
+		s := &memSeries{ref: 1}
+		s.setHeadChunks(buildHeadChunksLight(5), 5)
+		s.headChunkCount.Store(7) // Drifted: the list has 5 chunks.
+
+		// Chunks span [0,999]..[4000,4999]; mint=2000 drops the two oldest.
+		removed := s.truncateChunksBefore(2000, 0)
+		require.Equal(t, 2, removed)
+		require.Equal(t, chunks.HeadChunkID(2), s.firstChunkID)
+		require.Equal(t, 3, s.headChunks.len())
+		require.Equal(t, uint32(3), s.headChunkCount.Load(), "truncation re-syncs the counter from the walk")
+	})
 }
 
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -118,11 +118,18 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	return selectSeriesSet(ctx, sortSeries, hints, ms, q.index, q.chunks, q.tombstones, q.mint, q.maxt)
 }
 
-// chunkCacheToggler is an optional interface implemented by chunk readers that
-// support an in-memory head-chunk cache. The cache is only beneficial for range
-// queries (Step > 0) where every chunk of a series is accessed.
-type chunkCacheToggler interface {
+// chunkCacheEnabler is an optional interface implemented by chunk readers that
+// support an in-memory head-chunk cache. The cache is beneficial when every
+// chunk of a series is accessed sequentially, such as range queries and compaction.
+type chunkCacheEnabler interface {
 	EnableChunkCache()
+}
+
+// enableChunkCache enables the head-chunk cache on cr if it supports one.
+func enableChunkCache(cr ChunkReader) {
+	if enabler, ok := cr.(chunkCacheEnabler); ok {
+		enabler.EnableChunkCache()
+	}
 }
 
 func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.SelectHints, ms []*labels.Matcher,
@@ -132,9 +139,7 @@ func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.Select
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if toggler, ok := chunks.(chunkCacheToggler); ok {
-			toggler.EnableChunkCache()
-		}
+		enableChunkCache(chunks)
 	}
 
 	p, err := index.PostingsForMatchers(ctx, sharded, ms...)
@@ -186,9 +191,7 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if toggler, ok := chunks.(chunkCacheToggler); ok {
-			toggler.EnableChunkCache()
-		}
+		enableChunkCache(chunks)
 	}
 
 	if hints != nil {


### PR DESCRIPTION
Backport of [prometheus/prometheus#18300](https://github.com/prometheus/prometheus/pull/18300) to `mimir-release-2.17`.

Stacked on #1271, which backports prometheus/prometheus#19139 and centralizes mutation of the `headChunks`/`headChunkCount` pair. Merge #1271 first.

This replaces repeated linked-list length and offset traversals with tracked head-chunk counts, direct traversal, or pre-collected head chunks. It also enables the head-chunk cache during compaction, addressing the O(n²) access path seen when series accumulate many in-memory head chunks.

Backport adaptations for this branch:

- Preserve the release branch's older GC implementation instead of importing later stale-series and `mmapReady` bookkeeping from the upstream conflict context.
- Adapt `testing.T.Context`, `testing.B.Context`, and `testing.B.Loop` usage so the `mimir-prometheus` module remains compatible with its declared Go 1.23 toolchain.
- Enable native histograms explicitly in the new compaction benchmark because this release branch disables them by default.
- Remove redundant test-only counter normalization after the fixture switches to `setHeadChunks`.
- Use the explicit named return required by the release branch's formatter.

GEM v2.17 builds the dependency with Go 1.26.5. Performance evidence for the optimized paths is available in the upstream PR.

### Validation

- Focused chunk lookup, cache, truncation, mmap, and compaction tests pass with the race detector.
- The focused suite passes under `slicelabels`, `stringlabels`, and `dedupelabels`.
- `go test -timeout 20m ./tsdb` passes.
- Repository-pinned golangci-lint passes in diff-aware mode; the release branch's full lint target has unrelated pre-existing findings.
- Formatting and `git diff --check` pass.
- The backport is one DCO-signed, verified commit with the upstream source hash and co-author trailers preserved.

```release-notes
[PERF] TSDB: Fix O(n²) head chunk iteration and optimize chunk lookups using tracked head chunk counts and pre-collected head chunks
```
