### PR TITLE
ci: use ubuntu-x64-large runners on mimir-release-2.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - slicelabels # there's no such tag when this is being written, but it makes the CI job name more obvious.
           - stringlabels
           - dedupelabels
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64-large
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
             fuzz: FuzzFastRegexMatcher_WithStaticallyDefinedRegularExpressions
           - package: ./model/labels
             fuzz: FuzzFastRegexMatcher_WithFuzzyRegularExpressions
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64-large
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Move the `test` and `fuzz` CI jobs off GitHub-hosted `ubuntu-24.04` onto Grafana `ubuntu-x64-large` runners so the suite stops getting killed mid-run (exit 143 / SIGTERM), which was also cancelling sibling matrix jobs via fail-fast.

- `test` matrix (`slicelabels` / `stringlabels` / `dedupelabels`) → `ubuntu-x64-large`
- `fuzz` matrix → `ubuntu-x64-large`

Made with [Cursor](https://cursor.com)