### PR TITLE
ci: use ubuntu-x64-large for heavy Go test and fuzz jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   test_go:
     name: Go tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     container:
       # Whenever the Go version is updated here, .promu.yml
       # should also be updated.
@@ -31,7 +31,7 @@ jobs:
 
   test_go_more:
     name: More Go tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     container:
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   test_go_386:
     name: Go tests for 32-bit x86
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     if: false # We don't care about this in mimir-prometheus.
     container:
       image: quay.io/prometheus/golang-builder:1.26-base
@@ -102,7 +102,7 @@ jobs:
 
   test_go_oldest:
     name: Go tests with previous Go version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     if: false # We don't care about this in mimir-prometheus.
     env:
       # Enforce the Go version.
@@ -477,7 +477,7 @@ jobs:
             fuzz: FuzzFastRegexMatcher_WithStaticallyDefinedRegularExpressions
           - package: ./model/labels
             fuzz: FuzzFastRegexMatcher_WithFuzzyRegularExpressions
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64-large
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
   fuzzing:
     name: Run Go Fuzz Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     strategy:
       matrix:
         fuzz_test: [[FuzzParseMetricText, FuzzParseOpenMetric], [FuzzParseMetricSelector, FuzzParseExpr], [FuzzXORChunk, FuzzXOR2Chunk], [FuzzParseProtobuf]]


### PR DESCRIPTION
## Summary

Move the heavy Go test and fuzz CI jobs onto Grafana `ubuntu-x64-large` runners, matching [mimir-release-2.17 #1273](https://github.com/grafana/mimir-prometheus/pull/1273).

- `test_go`, `test_go_more`, `test_go_386`, `test_go_oldest` → `ubuntu-x64-large`
- `fuzzing_mimir` and reusable `fuzzing` workflow job → `ubuntu-x64-large`

Made with [Cursor](https://cursor.com)