### PR TITLE
fix: correct shared workflow action tag comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,7 +585,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           PR_URL: ${{ steps.get-pr-url.outputs.pr_url }}
           PR_NUMBER: ${{ steps.get-pr-url.outputs.pr_number }}
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 # send-slack-message-v1.0.0
         with:
           channel-id: C04AF91LPFX #mimir-ci-notifications
           payload: |

--- a/.github/workflows/remind-upstream-merge.yml
+++ b/.github/workflows/remind-upstream-merge.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Send Slack reminder
         if: steps.find-prs.outputs.payload != ''
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 # send-slack-message-v1.0.0
         with:
           channel-id: C04AF91LPFX #mimir-ci-notifications
           payload: ${{ steps.find-prs.outputs.payload }}


### PR DESCRIPTION
## What changed

Update two `send-slack-message` comments to the actual historical tag `send-slack-message-v1.0.0`.

## Why

The bare version comments omit the shared-workflows monorepo component name, preventing Renovate from identifying the correct tag namespace and causing lookup failures. This repository uses the historical hyphenated release tag; the pinned SHA was verified against that exact tag.

## Validation

- Verified `send-slack-message-v1.0.0` resolves to the pinned SHA.
- `actionlint` on changed workflows (pre-existing runner-label/shellcheck/constant-condition diagnostics excluded)
- `git diff --check`

Related to grafana/shared-workflows#2255
