### PR TITLE
[r409] ci: bump create-github-app-token to v0.3.1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-github-bot
 

--- a/.github/workflows/merge-upstream-prometheus.yml
+++ b/.github/workflows/merge-upstream-prometheus.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-github-bot
 
@@ -365,7 +365,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-github-bot
 

--- a/.github/workflows/trigger-mimir-update.yml
+++ b/.github/workflows/trigger-mimir-update.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-github-bot
           permission_set: ${{ github.ref == 'refs/heads/main' && 'main' || 'release' }}

--- a/.github/workflows/vendor_reviewer.yml
+++ b/.github/workflows/vendor_reviewer.yml
@@ -21,7 +21,7 @@ jobs:
       # Generate GitHub App Token for approving PRs
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: mimir-vendoring
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Backport of #1283 to `r409`.

`grafana/shared-workflows/actions/create-github-app-token` v0.2.x ..= v0.3.0 were [disabled at the org level on 2026-08-19](https://raintank-corp.slack.com/archives/CKF4X4H1D/p1787091628989459) after `i-2026-08-18-github-tokens-logged-in-plain-text-in-grafana-grafana`: in combination with other actions they could log tokens in plain text. Any workflow still pinned to those versions fails with a startup failure before a single job runs. On release branches that means `trigger-mimir-update`, which runs on every push to `r[0-9]*`, no longer notifies grafana/mimir.

v0.3.1 has the fix and keeps the same inputs, so this is a plain pin bump.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes

NONE

```
