### PR TITLE
ci: bump Go to 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       # Whenever the Go version is updated here, .promu.yml
       # should also be updated.
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -33,7 +33,7 @@ jobs:
     name: More Go tests
     runs-on: ubuntu-latest
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     if: false # We don't care about this in mimir-prometheus.
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -90,7 +90,7 @@ jobs:
       matrix:
         lts_version: ${{ fromJSON(needs.list_lts_releases.outputs.versions) }}
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -129,7 +129,7 @@ jobs:
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -156,7 +156,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.26.x
+          go-version: 1.27.x
       - run: |
           $TestTargets = go list ./... | Where-Object { $_ -NotMatch "(github.com/prometheus/prometheus/config|github.com/prometheus/prometheus/web)"}
           go test $TestTargets -vet=off -v
@@ -169,7 +169,7 @@ jobs:
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -189,7 +189,7 @@ jobs:
     container:
       # Whenever the Go version is updated here, .promu.yml
       # should also be updated.
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -307,7 +307,7 @@ jobs:
     name: Check generated parser
     runs-on: ubuntu-latest
     container:
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:1.27-base
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -330,7 +330,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.26.x
+          go-version: 1.27.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       GOTOOLCHAIN: local
     container:
       # The go version in this image should be N-1 wrt test_go.
-      image: quay.io/prometheus/golang-builder:1.25-base
+      image: quay.io/prometheus/golang-builder:1.26-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.26.x
+          go-version: 1.27.x
       - name: Run Fuzzing
         run: |
           for fuzz_test in ${{ join(matrix.fuzz_test, ' ') }}; do

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here,
     # .github/workflows should also be updated.
-    version: 1.26
+    version: 1.27
 repository:
     path: github.com/prometheus/prometheus
 build:

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.1
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None, but it unblocks CI on every open PR.

`scripts/check-go-mod-version.sh` derives the oldest supported Go version at run time from https://go.dev/dl/?mode=json and asserts that the `test_go_oldest` job pins that same version. Go 1.27.0 was released, so the oldest supported version moved from 1.25 to 1.26, and the check started failing on every pull request:

```
Error: test_go_oldest uses Go 1.25, but should use Go 1.26 (oldest supported version)
make: *** [Makefile:211: check-go-mod-version] Error 1
```

The first commit moves `test_go_oldest` to 1.26 so the check passes. On its own that would leave `test_go_oldest` on the same version as `test_go`, contradicting the "should be N-1 wrt test_go" comment, so the second commit moves the build and test jobs to Go 1.27 (`quay.io/prometheus/golang-builder:1.27-base`, published 2026-08-21) and leaves `test_go_oldest` at 1.26. `.promu.yml` moves with the workflows, as the comment there asks.

Linting on 1.27 then fails inside the standard library, because golangci-lint v2.12.2 bundles a `go/types` older than the generic methods that 1.27 introduced:

```
src/math/rand/v2/rand.go:213:17: method must have no type parameters (typecheck)
```

The third commit bumps golangci-lint to v2.13.1, which added Go 1.27 support and is built with go1.27.0. The `golangci` job reads its version from `make print-golangci-lint-version`, so no workflow change is needed.

Note this puts us ahead of upstream, which is still on Go 1.26 and golangci-lint v2.12.2, so expect conflicts in `merge-upstream-prometheus` until upstream bumps too. Upstream has also since made `test_go_oldest` derive its version dynamically and dropped the assertion from `check-go-mod-version.sh`, which will replace that pin when the merge lands.

`go.mod` is deliberately left at `go 1.25.10`, matching upstream. The check only rejects a `go.mod` version *newer* than the oldest supported one.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes

NONE

```