### PR TITLE
ci: drop test_go_oldest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,28 +100,6 @@ jobs:
           cache_key_suffix: upgrade
       - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true --test.lts-version=${{ matrix.lts_version }} -run TestVersionUpgrade
 
-  test_go_oldest:
-    name: Go tests with previous Go version
-    runs-on: ubuntu-latest
-    if: false # We don't care about this in mimir-prometheus.
-    env:
-      # Enforce the Go version.
-      GOTOOLCHAIN: local
-    container:
-      # The go version in this image should be N-1 wrt test_go.
-      image: quay.io/prometheus/golang-builder:1.25-base
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci-setup@55bd31fe92710532260eb57c554f2697363285c5 # v0.2.2
-        with:
-          enable_npm: false
-          cache_key_suffix: oldest
-      - run: make build
-      # Don't run NPM build; don't run race-detector.
-      - run: make test GO_ONLY=1 test-flags=""
-
   test_ui:
     name: UI tests
     runs-on: ubuntu-latest
@@ -378,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_windows, golangci, codeql, build_all]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository == 'prometheus/prometheus'
     steps:
       - uses: prometheus/promci/publish_main@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
@@ -394,7 +372,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_windows, golangci, codeql, build_all]
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.') && github.repository == 'prometheus/prometheus')
       ||


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None, but it unblocks CI on every open pull request, which currently fails with:

```
Error: test_go_oldest uses Go 1.25, but should use Go 1.26 (oldest supported version)
make: *** [Makefile:211: check-go-mod-version] Error 1
```

`scripts/check-go-mod-version.sh` asserts that the image pinned in `test_go_oldest` matches the oldest Go version upstream still supports, which it reads from https://go.dev/dl/?mode=json at run time. That makes it a time bomb: Go 1.27.0 shipped, the expected value moved from 1.25 to 1.26, and CI broke on every pull request without anyone touching Go.

The job itself has been disabled with `if: false` for a while. mimir-prometheus is only consumed by Mimir, so the only Go version worth testing is the one Mimir builds with, currently 1.26 -- matching the rest of the jobs here. Testing N-1 is an upstream concern.

So drop the job. The assertion is guarded on the job existing, so removing it retires the check too, and the next Go release will not break CI again.

Note upstream has since reworked this job to derive its version dynamically, so expect one conflict here on the next `merge-upstream-prometheus`, resolved by keeping the deletion.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes

NONE

```