### PR TITLE
[r407] ci: drop test_go_oldest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,28 +100,6 @@ jobs:
           cache_key_suffix: upgrade
       - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true --test.lts-version=${{ matrix.lts_version }} -run TestVersionUpgrade
 
-  test_go_oldest:
-    name: Go tests with previous Go version
-    runs-on: ubuntu-latest
-    if: false # We don't care about this in mimir-prometheus.
-    env:
-      # Enforce the Go version.
-      GOTOOLCHAIN: local
-    container:
-      # The go version in this image should be N-1 wrt test_go.
-      image: quay.io/prometheus/golang-builder:1.25-base
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci-setup@3e5cd31b34b8ae19efa8f071c5e3cdb44884a7f8 # v0.2.1
-        with:
-          enable_npm: false
-          cache_key_suffix: oldest
-      - run: make build
-      # Don't run NPM build; don't run race-detector.
-      - run: make test GO_ONLY=1 test-flags=""
-
   test_ui:
     name: UI tests
     runs-on: ubuntu-latest
@@ -378,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_windows, golangci, codeql, build_all]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository == 'prometheus/prometheus'
     steps:
       - uses: prometheus/promci/publish_main@13941414d409d227afd67544e5d306827db5a1a2 # v0.8.5
@@ -394,7 +372,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_windows, golangci, codeql, build_all]
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.') && github.repository == 'prometheus/prometheus')
       ||


### PR DESCRIPTION
Backport of #1289 to `r407`.

#### Which issue(s) does the PR fix:

None, but it unblocks CI on every pull request against `r407`, which currently fails with:

```
Error: test_go_oldest uses Go 1.25, but should use Go 1.26 (oldest supported version)
make: *** [Makefile:211: check-go-mod-version] Error 1
```

`scripts/check-go-mod-version.sh` asserts that the image pinned in `test_go_oldest` matches the oldest Go version upstream still supports, which it reads from https://go.dev/dl/?mode=json at run time. That makes it a time bomb: Go 1.27.0 shipped, the expected value moved from 1.25 to 1.26, and CI broke without anyone touching Go.

The job itself has been disabled with `if: false` for a while. mimir-prometheus is only consumed by Mimir, so the only Go version worth testing is the one Mimir builds with, which is what the remaining jobs already use. Testing N-1 is an upstream concern.

The assertion is guarded on the job existing, so removing the job retires the check too.

Applied as a fresh edit rather than a cherry-pick, because this branch pins older `actions/checkout` and `promci-setup` digests inside the deleted block. The resulting diff is otherwise identical to #1289.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes

NONE

```