### PR TITLE
TSDB: prevent selected-series eviction from losing concurrently committed samples

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1989,9 +1989,14 @@ type headViewFactory func(head *Head, mint, maxt int64) BlockReader
 // after compaction began and may not be present in any block.
 //
 // When isolation is disabled, appendIDWatermark is always 0 and the
-// append-ID check becomes a no-op. In that mode, the caller must ensure
-// that no concurrent writes target the selected series.
-type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
+// append-ID check becomes a no-op.
+//
+// appendSeqWatermark is the head's appendSeq counter, captured under
+// commitBarrier before the blocks were written. A series whose
+// lastAppendSeq is above it (or with a commit pending) received samples
+// from a commit that started after the capture and must not be evicted.
+// Unlike the append-ID check, this works with isolation disabled.
+type headSeriesEvictor func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error
 
 // compactHeadViewLocked writes a block (or sequence of blocks, one per chunk range) for the
 // restricted head view produced by viewFactory, then runs evictor to remove those series from the
@@ -2017,6 +2022,15 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 	// could evict a series whose newest sample is present in neither the block nor
 	// the head, causing that sample to be lost on WAL replay.
 	appendIDWatermark := db.head.iso.committedAppendID()
+	// Capture the appendSeq watermark under the commit barrier: taking the write lock
+	// drains in-flight commits, so every commit either fully applied its samples before
+	// this point (they will be in the generated blocks; the series is stamped <= the
+	// watermark) or starts after it (stamped above the watermark, skipped by eviction).
+	// Unlike the appendID watermark above, this also protects appends made while
+	// isolation is disabled.
+	db.head.commitBarrier.Lock()
+	appendSeqWatermark := db.head.appendSeq.Load()
+	db.head.commitBarrier.Unlock()
 	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
 	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
@@ -2056,7 +2070,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 		compactHeadViewBeforeEvictTestingCallback = nil
 	}
 
-	if err := evict(maxt, appendIDWatermark); err != nil {
+	if err := evict(maxt, appendIDWatermark, appendSeqWatermark); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)
@@ -2088,8 +2102,8 @@ func (db *DB) CompactStaleHead() (err error) {
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, staleSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+		func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
+			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark, appendSeqWatermark)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetStaleSeries() },
 	); err != nil {
@@ -2171,8 +2185,8 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+		func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, appendSeqWatermark)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10749,6 +10749,79 @@ func TestCompactSelectedSeries(t *testing.T) {
 	require.Equal(t, float64(0), prom_testutil.ToFloat64(db.metrics.selectedSeriesCompactionsFailed))
 }
 
+// TestCompactSelectedSeries_ConcurrentAppendNotLost verifies that a sample committed to a
+// selected series after its block has been written but before the series is evicted from the
+// head is not lost. Such a sample is present in neither the generated block nor (without the
+// guard) the head, and the eviction tombstone would even suppress it on WAL replay.
+//
+// The regression this guards against: with isolation disabled (as Mimir runs), the
+// appendID-based eviction watermark is always 0 and the only remaining guard was the series
+// maxTime. A concurrent append whose sample timestamp is in order for its series but below the
+// head's MaxTime (e.g. a producer that writes timestamps lagging wall clock) slipped past both
+// guards and was silently destroyed together with the evicted series.
+func TestCompactSelectedSeries_ConcurrentAppendNotLost(t *testing.T) {
+	for _, isolationDisabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("isolation disabled=%t", isolationDisabled), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			opts.IsolationDisabled = isolationDisabled
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			t.Cleanup(func() {
+				compactHeadViewBeforeEvictTestingCallback = nil
+				require.NoError(t, db.Close())
+			})
+
+			selected1 := labels.FromStrings("name", "selected1")
+			selected2 := labels.FromStrings("name", "selected2")
+
+			app := db.Appender(context.Background())
+			s1, err := app.Append(0, selected1, 100, 1.0)
+			require.NoError(t, err)
+			s2, err := app.Append(0, selected2, 200, 2.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// After the blocks for the selected series have been written, but before the
+			// series are evicted from the head, commit another sample to selected1. The
+			// timestamp is in order for the series (150 > 100) but below the head's MaxTime
+			// (200), so it dodges the series-maxTime eviction guard, and with isolation
+			// disabled the appendID watermark guard is a no-op.
+			compactHeadViewBeforeEvictTestingCallback = func() {
+				app := db.Appender(context.Background())
+				_, err := app.Append(0, selected1, 150, 1.5)
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+			}
+
+			require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{s1, s2}))
+
+			// selected1 received a sample after the block write: it must have been skipped by
+			// the eviction and still live in the head. selected2 must have been evicted.
+			require.Equal(t, uint64(1), db.Head().NumSeries(), "series appended to during the compaction must be skipped by the eviction")
+
+			// No sample may be lost: selected1 has both samples (the pre-compaction one via
+			// the block and/or head, the concurrent one via the head), selected2 has its
+			// sample via the block.
+			q, err := db.Querier(math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			res := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "name", "selected.*"))
+
+			s1Samples := res[selected1.String()]
+			timestamps := make([]int64, 0, len(s1Samples))
+			for _, s := range s1Samples {
+				timestamps = append(timestamps, s.T())
+			}
+			require.Equal(t, []int64{100, 150}, timestamps, "the concurrently appended sample must not be lost")
+
+			s2Samples := res[selected2.String()]
+			require.Len(t, s2Samples, 1)
+			require.Equal(t, int64(200), s2Samples[0].T())
+		})
+	}
+}
+
 // TestCompactSelectedSeries_UnsortedDuplicateRefs verifies that CompactSelectedSeries
 // tolerates an input slice that is unsorted and contains duplicate refs:
 //   - The postings list backing the selected-series view must observe sorted, unique refs,

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10822,6 +10822,228 @@ func TestCompactSelectedSeries_ConcurrentAppendNotLost(t *testing.T) {
 	}
 }
 
+// TestCompactSelectedSeries_OpenAppenderSamplesNotLost verifies that a series with a sample
+// buffered in a still-open appender is not evicted, even when ANOTHER appender committed to
+// the same series in the meantime. With a boolean pending-commit marker, the second
+// appender's commit would clear the pending state of the first appender's still-buffered
+// sample; the series would be evicted and the first appender would then commit into the
+// removed memSeries, silently losing the sample (the eviction tombstone even suppresses it
+// on WAL replay). This must hold in both isolation modes: the buffered sample has no
+// append-ID recorded in the series until it commits, so isolation does not cover it either.
+func TestCompactSelectedSeries_OpenAppenderSamplesNotLost(t *testing.T) {
+	for _, isolationDisabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("isolation disabled=%t", isolationDisabled), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			opts.IsolationDisabled = isolationDisabled
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+			// The filler keeps head.MaxTime at 700 so all timestamps used below stay
+			// in order for their series yet below the head max time, dodging the
+			// series-maxTime eviction guard.
+			filler := labels.FromStrings("name", "filler")
+			sel := labels.FromStrings("name", "selected")
+
+			app := db.Appender(context.Background())
+			_, err := app.Append(0, filler, 700, 0.7)
+			require.NoError(t, err)
+			selRef, err := app.Append(0, sel, 300, 1.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// Appender A buffers a sample for sel and stays open across the compaction.
+			appA := db.Appender(context.Background())
+			_, err = appA.Append(selRef, sel, 450, 4.5)
+			require.NoError(t, err)
+
+			// Appender B commits a lower (still in-order) sample to the same series.
+			appB := db.Appender(context.Background())
+			_, err = appB.Append(selRef, sel, 350, 3.5)
+			require.NoError(t, err)
+			require.NoError(t, appB.Commit())
+
+			require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{selRef}))
+
+			// sel still has a buffered sample in appender A, so it must have been
+			// skipped by the eviction; A's commit must land in the live series.
+			require.Equal(t, uint64(2), db.Head().NumSeries(),
+				"a series with samples buffered in an open appender must be skipped by the eviction")
+			require.NoError(t, appA.Commit())
+
+			q, err := db.Querier(math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			res := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+			samples := res[sel.String()]
+			timestamps := make([]int64, 0, len(samples))
+			for _, s := range samples {
+				timestamps = append(timestamps, s.T())
+			}
+			require.Equal(t, []int64{300, 350, 450}, timestamps,
+				"the sample buffered in the open appender must not be lost")
+		})
+	}
+}
+
+// TestCompactStaleHead_OpenAppenderSamplesNotLost is the CompactStaleHead counterpart of
+// TestCompactSelectedSeries_OpenAppenderSamplesNotLost: a series whose last committed sample
+// is a staleness marker but which still has a live sample buffered in an open appender must
+// not be evicted by the stale-series compaction.
+func TestCompactStaleHead_OpenAppenderSamplesNotLost(t *testing.T) {
+	for _, isolationDisabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("isolation disabled=%t", isolationDisabled), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			opts.IsolationDisabled = isolationDisabled
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+			filler := labels.FromStrings("name", "filler")
+			stale := labels.FromStrings("name", "stale")
+
+			app := db.Appender(context.Background())
+			_, err := app.Append(0, filler, 700, 0.7)
+			require.NoError(t, err)
+			staleRef, err := app.Append(0, stale, 300, 1.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// Appender A buffers a live sample and stays open across the compaction.
+			appA := db.Appender(context.Background())
+			_, err = appA.Append(staleRef, stale, 450, 4.5)
+			require.NoError(t, err)
+
+			// Appender B commits a staleness marker, making the series eligible for
+			// stale-series compaction (and, with a boolean marker, clobbering A's
+			// pending state).
+			appB := db.Appender(context.Background())
+			_, err = appB.Append(staleRef, stale, 350, math.Float64frombits(value.StaleNaN))
+			require.NoError(t, err)
+			require.NoError(t, appB.Commit())
+			require.Equal(t, uint64(1), db.Head().NumStaleSeries())
+
+			require.NoError(t, db.CompactStaleHead())
+
+			require.Equal(t, uint64(2), db.Head().NumSeries(),
+				"a stale series with samples buffered in an open appender must be skipped by the eviction")
+			require.NoError(t, appA.Commit())
+
+			q, err := db.Querier(math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			res := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "stale"))
+			samples := res[stale.String()]
+			timestamps := make([]int64, 0, len(samples))
+			for _, s := range samples {
+				timestamps = append(timestamps, s.T())
+			}
+			require.Equal(t, []int64{300, 350, 450}, timestamps,
+				"the sample buffered in the open appender must not be lost to the stale-series eviction")
+		})
+	}
+}
+
+// TestCompactSelectedSeries_CommitsRacingCompactionNotLost runs appends+commits against a
+// selected series concurrently with the whole compaction, so commits race the commit-barrier
+// watermark capture itself as well as the block-write and eviction phases. The testing
+// callback additionally holds the write-to-evict window open until several commits have
+// landed inside it. Every commit that reported success must remain queryable afterwards,
+// whether its samples ended up in the block, in the surviving head series, or in a
+// re-created series (if the eviction won the race).
+func TestCompactSelectedSeries_CommitsRacingCompactionNotLost(t *testing.T) {
+	for _, isolationDisabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("isolation disabled=%t", isolationDisabled), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			opts.IsolationDisabled = isolationDisabled
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			t.Cleanup(func() {
+				compactHeadViewBeforeEvictTestingCallback = nil
+				require.NoError(t, db.Close())
+			})
+
+			filler := labels.FromStrings("name", "filler")
+			sel := labels.FromStrings("name", "selected")
+
+			app := db.Appender(context.Background())
+			_, err := app.Append(0, filler, 700, 0.7)
+			require.NoError(t, err)
+			selRef, err := app.Append(0, sel, 200, 2.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// The writer commits one in-order sample per iteration, racing the
+			// compaction. Timestamps stay below the head max time (700) so the
+			// series-maxTime guard never protects them.
+			const maxTS = 690
+			var (
+				committed atomic.Int64 // highest successfully committed timestamp
+				writerErr error
+				stop      = make(chan struct{})
+				done      = make(chan struct{})
+			)
+			committed.Store(200)
+			go func() {
+				defer close(done)
+				for ts := int64(201); ts <= maxTS; ts++ {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					app := db.Appender(context.Background())
+					if _, err := app.Append(0, sel, ts, float64(ts)); err != nil {
+						writerErr = fmt.Errorf("append ts=%d: %w", ts, err)
+						_ = app.Rollback()
+						return
+					}
+					if err := app.Commit(); err != nil {
+						writerErr = fmt.Errorf("commit ts=%d: %w", ts, err)
+						return
+					}
+					committed.Store(ts)
+				}
+			}()
+
+			// Hold the window between block write and eviction open until several
+			// commits have landed inside it (bounded so the test cannot hang if the
+			// writer finishes early).
+			compactHeadViewBeforeEvictTestingCallback = func() {
+				target := committed.Load() + 5
+				for committed.Load() < target && committed.Load() < maxTS {
+					select {
+					case <-done:
+						return
+					default:
+						runtime.Gosched()
+					}
+				}
+			}
+
+			require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{selRef}))
+			close(stop)
+			<-done
+			require.NoError(t, writerErr)
+
+			q, err := db.Querier(math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			res := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+			present := map[int64]bool{}
+			for _, s := range res[sel.String()] {
+				present[s.T()] = true
+			}
+			for ts := int64(200); ts <= committed.Load(); ts++ {
+				require.True(t, present[ts], "committed sample ts=%d must not be lost", ts)
+			}
+		})
+	}
+}
+
 // TestCompactSelectedSeries_UnsortedDuplicateRefs verifies that CompactSelectedSeries
 // tolerates an input slice that is unsorted and contains duplicate refs:
 //   - The postings list backing the selected-series view must observe sorted, unique refs,
@@ -11143,35 +11365,19 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 
 	require.Len(t, db.Blocks(), 1)
 
-	// The watermark guard only fires when isolation is enabled, because it
-	// relies on per-sample append-IDs that s.txs only tracks in that mode.
-	//   - isolation enabled: hasAppendIDAbove catches the post-watermark
-	//     commit, sel survives eviction, and all three samples are queryable.
-	//   - isolation disabled: per-sample append-IDs aren't tracked, the guard
-	//     is a no-op, sel gets evicted along with the late sample, and the
-	//     WAL tombstone drops the late sample permanently on replay. Only the
-	//     two samples the block captured remain queryable.
-	var (
-		expectedHeadSeries uint64
-		expectedSamples    []chunks.Sample
-	)
-	if defaultIsolationDisabled {
-		expectedHeadSeries = 1 // only filler remains; sel was evicted
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-		}
-	} else {
-		expectedHeadSeries = 2 // filler + sel
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-			sample{t: lateT, f: lateV},
-		}
+	// The late commit lands after the watermark capture, so the eviction skips sel in
+	// both isolation modes: with isolation enabled hasAppendIDAbove catches it, and with
+	// isolation disabled the appendSeq stamp does. Sel survives eviction and all three
+	// samples stay queryable.
+	expectedHeadSeries := uint64(2) // filler + sel
+	expectedSamples := []chunks.Sample{
+		sample{t: 100, f: 10.0},
+		sample{t: 200, f: 20.0},
+		sample{t: lateT, f: lateV},
 	}
 
 	require.Equal(t, expectedHeadSeries, db.Head().NumSeries(),
-		"head series count must match the expected watermark-guard outcome for this isolation mode")
+		"a series appended to during the compaction must be skipped by the eviction")
 
 	querySelected := func(d *DB) []chunks.Sample {
 		q, err := d.Querier(0, chunkRange)
@@ -11206,10 +11412,6 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 // The test verifies that the sample remains queryable both immediately after
 // compaction and after a restart.
 func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing.T) {
-	if defaultIsolationDisabled {
-		t.Skip("watermark guard relies on per-sample append-IDs that s.txs only tracks when isolation is enabled")
-	}
-
 	const chunkRange = 1000
 	opts := DefaultOptions()
 	opts.MinBlockDuration = chunkRange

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -132,6 +132,17 @@ type Head struct {
 
 	iso *isolation
 
+	// appendSeq is a monotonic sequence assigned to each Commit under commitBarrier.
+	// Unlike isolation appendIDs, it is maintained even when isolation is disabled, so
+	// selected-series eviction can detect series appended to after its watermark capture.
+	appendSeq atomic.Uint64
+	// commitBarrier is held for reading by Commit while it assigns appendSeq and applies
+	// samples, and taken for writing by compactHeadViewLocked to capture an appendSeq
+	// watermark with no commit in flight: every commit is then either fully applied before
+	// the watermark (its series stamps are <= watermark) or starts after it (stamps above
+	// the watermark, so eviction skips those series).
+	commitBarrier sync.RWMutex
+
 	oooIso *oooIsolation
 
 	cardinalityMutex      sync.Mutex
@@ -1377,9 +1388,11 @@ func isStaleSeries(s *memSeries) bool {
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
-func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+// appendSeqWatermark is the Head.appendSeq captured under commitBarrier before eviction; it
+// provides the same protection when isolation is disabled (see appendedSinceWatermark).
+func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark) && !appendedSinceWatermark(s, appendSeqWatermark)
 	})
 	return err
 }
@@ -1390,9 +1403,11 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, a
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
-func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+// appendSeqWatermark is the Head.appendSeq captured under commitBarrier before eviction; it
+// provides the same protection when isolation is disabled (see appendedSinceWatermark).
+func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark) && !appendedSinceWatermark(s, appendSeqWatermark)
 	})
 	return err
 }
@@ -1415,6 +1430,15 @@ func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 		it.Next()
 	}
 	return false
+}
+
+// appendedSinceWatermark reports whether s was appended to by a commit that started after
+// the given Head.appendSeq watermark was captured, or has an append pending commit. Such
+// samples may not be present in the blocks written before the capture, so the series must
+// not be evicted. Unlike hasAppendIDAbove, this works with isolation disabled.
+// Must be called with s.Lock held.
+func appendedSinceWatermark(s *memSeries, watermark uint64) bool {
+	return s.pendingCommit || s.lastAppendSeq > watermark
 }
 
 // truncateSeries removes the provided series from the head, taking the chunk-snapshot lock,
@@ -2863,9 +2887,13 @@ type memSeries struct {
 	// to spread chunks writing across time. Doesn't apply to the last chunk of the chunk range. 0 to disable variance.
 	chunkEndTimeVariance float64
 
-	nextAt                           int64 // Timestamp at which to cut the next chunk.
-	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
-	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
+	nextAt int64 // Timestamp at which to cut the next chunk.
+	// lastAppendSeq is Head.appendSeq of the last commit that applied samples to this
+	// series. Guarded by the series lock. Used by selected-series eviction, which skips
+	// series stamped above its captured watermark; works with isolation disabled.
+	lastAppendSeq                    uint64
+	histogramChunkHasComputedEndTime bool // True if nextAt has been predicted for the current histograms chunk; false otherwise.
+	pendingCommit                    bool // Whether there are samples waiting to be committed to this series.
 	// Whether garbage collection has removed this series from the head index. Such a
 	// series is unreachable, so appending to it would silently lose the samples;
 	// appenders that looked it up before it was collected have to get a fresh one

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1414,9 +1414,9 @@ func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64
 
 // hasAppendIDAbove reports whether s contains any in-memory sample with an appendID
 // greater than watermark.
-// When isolation is disabled (s.txs == nil), it always returns false;  in that mode,
-// CompactSelectedSeries and CompactStaleHead rely on their existing requirement that
-// no concurrent writes target the affected series.
+// When isolation is disabled (s.txs == nil), it always returns false; in that mode,
+// CompactSelectedSeries and CompactStaleHead rely on appendedSinceWatermark instead,
+// which does not depend on isolation.
 // Must be called with s.Lock held.
 func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 	if s.txs == nil {
@@ -1438,7 +1438,7 @@ func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 // not be evicted. Unlike hasAppendIDAbove, this works with isolation disabled.
 // Must be called with s.Lock held.
 func appendedSinceWatermark(s *memSeries, watermark uint64) bool {
-	return s.pendingCommit || s.lastAppendSeq > watermark
+	return s.pendingCommits > 0 || s.lastAppendSeq > watermark
 }
 
 // truncateSeries removes the provided series from the head, taking the chunk-snapshot lock,
@@ -2457,7 +2457,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 				minOOOTime = series.ooo.oooHeadChunk.minTime
 			}
 		}
-		if len(series.mmappedChunks) > 0 || series.headChunks != nil || series.pendingCommit ||
+		if len(series.mmappedChunks) > 0 || series.headChunks != nil || series.pendingCommits > 0 ||
 			(series.ooo != nil && (len(series.ooo.oooMmappedChunks) > 0 || series.ooo.oooHeadChunk != nil)) {
 			seriesMint := series.minTime()
 			if seriesMint < actualMint {
@@ -2891,9 +2891,15 @@ type memSeries struct {
 	// lastAppendSeq is Head.appendSeq of the last commit that applied samples to this
 	// series. Guarded by the series lock. Used by selected-series eviction, which skips
 	// series stamped above its captured watermark; works with isolation disabled.
-	lastAppendSeq                    uint64
+	lastAppendSeq uint64
+	// pendingCommits is the number of samples buffered for this series in open appenders,
+	// awaiting Commit or Rollback, plus one while the appender that created the series is
+	// open. A counter rather than a bool because multiple appenders can hold buffered
+	// samples for the same series concurrently, and one appender's commit must not clear
+	// the pending state of another appender's still-buffered samples. Guarded by the
+	// series lock.
+	pendingCommits                   uint32
 	histogramChunkHasComputedEndTime bool // True if nextAt has been predicted for the current histograms chunk; false otherwise.
-	pendingCommit                    bool // Whether there are samples waiting to be committed to this series.
 	// Whether garbage collection has removed this series from the head index. Such a
 	// series is unreachable, so appending to it would silently lose the samples;
 	// appenders that looked it up before it was collected have to get a fresh one
@@ -2902,8 +2908,8 @@ type memSeries struct {
 	// headChunkCount tracks the number of head chunks. All mutations of the
 	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
 	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.
-	// Explicitly uses sync/atomic.Uint32 (4 bytes) to fit in the existing padding
-	// between two bools and a float64.
+	// Explicitly uses sync/atomic.Uint32 (4 bytes) for compact packing among the
+	// surrounding small fields.
 	headChunkCount stdatomic.Uint32
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
@@ -2952,7 +2958,9 @@ func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64,
 		chunkEndTimeVariance: chunkEndTimeVariance,
 		shardHash:            shardHash,
 		secondaryHash:        secondaryHash,
-		pendingCommit:        pendingCommit,
+	}
+	if pendingCommit {
+		s.pendingCommits = 1
 	}
 	if !isolationDisabled {
 		s.txs = newTxRing(0)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -426,10 +426,14 @@ type headAppenderBase struct {
 	typesInBatch map[chunks.HeadSeriesRef]sampleType // Which (one) sample type each series holds in the most recent batch.
 
 	appendID, cleanupAppendIDsBelow uint64
-	closed                          bool
-	storeST                         bool // Whether start-timestamp storage is enabled for this append.
-	useXOR2                         bool // Whether XOR2 encoding is used for float chunks in this append.
-	useHistogramST                  bool // Whether ST-capable histogram chunk encoding is used in this append.
+	// appendSeq is Head.appendSeq assigned to this commit under Head.commitBarrier; each
+	// committed series is stamped with it so eviction can skip series appended to after
+	// its watermark capture. Maintained even when isolation is disabled.
+	appendSeq      uint64
+	closed         bool
+	storeST        bool // Whether start-timestamp storage is enabled for this append.
+	useXOR2        bool // Whether XOR2 encoding is used for float chunks in this append.
+	useHistogramST bool // Whether ST-capable histogram chunk encoding is used in this append.
 }
 type headAppender struct {
 	headAppenderBase
@@ -1529,6 +1533,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		series.pendingCommit = false
 		series.Unlock()
 	}
@@ -1631,6 +1636,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		series.pendingCommit = false
 		series.Unlock()
 	}
@@ -1733,6 +1739,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		series.pendingCommit = false
 		series.Unlock()
 	}
@@ -1822,6 +1829,11 @@ func (a *headAppenderBase) Commit() (err error) {
 		}
 	}()
 
+	// Apply samples under the commit barrier: the appendSeq assigned here is stamped on
+	// every committed series, and eviction captures its watermark under the write lock,
+	// so no commit spans a capture — its stamps are either all <= or all > the watermark.
+	h.commitBarrier.RLock()
+	a.appendSeq = h.appendSeq.Add(1)
 	for _, b := range a.batches {
 		// Do not change the order of these calls. We depend on it for
 		// correct commit order of samples and for the staleness marker
@@ -1833,6 +1845,7 @@ func (a *headAppenderBase) Commit() (err error) {
 	}
 	// Unmark all series as pending commit after all samples have been committed.
 	a.unmarkCreatedSeriesAsPendingCommit()
+	h.commitBarrier.RUnlock()
 
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatOOORejected))
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoOOORejected))

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -497,7 +497,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
 			return 0, storage.ErrOutOfOrderSample
 		}
-		s.pendingCommit = true
+		s.pendingCommits++
 	}
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
@@ -547,8 +547,8 @@ func (a *headAppender) AppendSTZeroSample(ref storage.SeriesRef, lset labels.Lab
 		return 0, err
 	}
 	isOOO, _, err := s.appendable(st, 0, a.headMaxt, a.minValidTime, a.oooTimeWindow)
-	if err == nil {
-		s.pendingCommit = true
+	if err == nil && !isOOO {
+		s.pendingCommits++
 	}
 	s.Unlock()
 	if err != nil {
@@ -902,7 +902,7 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err == nil {
-			s.pendingCommit = true
+			s.pendingCommits++
 		}
 		s.Unlock()
 		if delta > 0 {
@@ -937,7 +937,7 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err == nil {
-			s.pendingCommit = true
+			s.pendingCommits++
 		}
 		s.Unlock()
 		if delta > 0 {
@@ -1015,7 +1015,7 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			return 0, storage.ErrOutOfOrderST
 		}
 
-		s.pendingCommit = true
+		s.pendingCommits++
 		s.Unlock()
 		sTyp := stHistogram
 		if h.UsesCustomBuckets() {
@@ -1059,7 +1059,7 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			return 0, storage.ErrOutOfOrderST
 		}
 
-		s.pendingCommit = true
+		s.pendingCommits++
 		s.Unlock()
 		sTyp := stFloatHistogram
 		if fh.UsesCustomBuckets() {
@@ -1534,7 +1534,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
 		series.lastAppendSeq = a.appendSeq
-		series.pendingCommit = false
+		series.pendingCommits--
 		series.Unlock()
 	}
 }
@@ -1637,7 +1637,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
 		series.lastAppendSeq = a.appendSeq
-		series.pendingCommit = false
+		series.pendingCommits--
 		series.Unlock()
 	}
 }
@@ -1740,7 +1740,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
 		series.lastAppendSeq = a.appendSeq
-		series.pendingCommit = false
+		series.pendingCommits--
 		series.Unlock()
 	}
 }
@@ -1762,7 +1762,7 @@ func commitMetadata(b *appendBatch) {
 func (a *headAppenderBase) unmarkCreatedSeriesAsPendingCommit() {
 	for _, s := range a.series {
 		s.Lock()
-		s.pendingCommit = false
+		s.pendingCommits--
 		s.Unlock()
 	}
 }
@@ -2359,21 +2359,21 @@ func (a *headAppenderBase) Rollback() (err error) {
 			series = b.floatSeries[i]
 			series.Lock()
 			series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
-			series.pendingCommit = false
+			series.pendingCommits--
 			series.Unlock()
 		}
 		for i := range b.histograms {
 			series = b.histogramSeries[i]
 			series.Lock()
 			series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
-			series.pendingCommit = false
+			series.pendingCommits--
 			series.Unlock()
 		}
 		for i := range b.floatHistograms {
 			series = b.floatHistogramSeries[i]
 			series.Lock()
 			series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
-			series.pendingCommit = false
+			series.pendingCommits--
 			series.Unlock()
 		}
 		b.close(h)

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -241,7 +241,7 @@ func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastR
 		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
-		s.pendingCommit = true
+		s.pendingCommits++
 	}
 	s.Unlock()
 	if delta > 0 {
@@ -272,7 +272,7 @@ func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram
 		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
-		s.pendingCommit = true
+		s.pendingCommits++
 	}
 	s.Unlock()
 	if delta > 0 {
@@ -307,7 +307,7 @@ func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *his
 		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
-		s.pendingCommit = true
+		s.pendingCommits++
 	}
 	s.Unlock()
 	if delta > 0 {

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -1190,7 +1190,7 @@ func TestHeadAppenderV2_HistogramErrorDoesNotSetPendingCommit(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, ms)
 			ms.Lock()
-			pc := ms.pendingCommit
+			pc := ms.pendingCommits > 0
 			ms.Unlock()
 			require.False(t, pc, "pendingCommit should be cleared after a successful commit")
 
@@ -1201,7 +1201,7 @@ func TestHeadAppenderV2_HistogramErrorDoesNotSetPendingCommit(t *testing.T) {
 			require.NoError(t, app.Rollback())
 
 			ms.Lock()
-			pc = ms.pendingCommit
+			pc = ms.pendingCommits > 0
 			ms.Unlock()
 			require.False(t, pc, "pendingCommit should remain false after a failed AppenderV2.Append")
 		})

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6246,7 +6246,7 @@ func TestAppendHistogramErrorDoesNotSetPendingCommit(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, ms)
 			ms.Lock()
-			pc := ms.pendingCommit
+			pc := ms.pendingCommits > 0
 			ms.Unlock()
 			require.False(t, pc, "pendingCommit should be cleared after a successful commit")
 
@@ -6261,7 +6261,7 @@ func TestAppendHistogramErrorDoesNotSetPendingCommit(t *testing.T) {
 			require.NoError(t, app.Rollback())
 
 			ms.Lock()
-			pc = ms.pendingCommit
+			pc = ms.pendingCommits > 0
 			ms.Unlock()
 			require.False(t, pc, "pendingCommit should remain false after a failed AppendHistogram")
 		})

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1051,7 +1051,7 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
-	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
+	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64, math.MaxUint64))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -8659,7 +8659,7 @@ func TestHead_NumStaleSeries_MixedTypeRemoval(t *testing.T) {
 		{
 			name: "truncate_stale_series",
 			remove: func(t *testing.T, head *Head, refs []storage.SeriesRef) {
-				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64))
+				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64, math.MaxUint64))
 			},
 			wantSeries:        2, // Only the genuinely stale series is evicted.
 			crossTypeSurvives: true,
@@ -9106,7 +9106,7 @@ func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 
 						series := testHead.series.getByHash(lbls.Hash(), lbls)
 						require.NotNil(t, series)
-						require.NoError(t, testHead.truncateStaleSeries([]storage.SeriesRef{storage.SeriesRef(series.ref)}, 100, math.MaxUint64))
+						require.NoError(t, testHead.truncateStaleSeries([]storage.SeriesRef{storage.SeriesRef(series.ref)}, 100, math.MaxUint64, math.MaxUint64))
 						require.Zero(t, testHead.NumSeries())
 						require.Zero(t, testHead.NumStaleSeries())
 						require.Zero(t, testHead.NumNativeHistogramSeries())
@@ -10164,7 +10164,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64, math.MaxUint64))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -11003,7 +11003,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
 		require.NoError(t, h.truncateStaleSeries(
-			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts, math.MaxUint64,
+			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts, math.MaxUint64, math.MaxUint64,
 		))
 		requireCounterConsistent("after truncateStaleSeries")
 		require.Less(t, mmapReadyCounter(), readyBefore,


### PR DESCRIPTION
Selected/stale-series compaction writes blocks and then evicts the series from the head. A concurrent commit can land between those steps and be deleted before it reaches a block. The WAL eviction tombstone also prevents an ingester restart from restoring those samples. The existing append-ID guard does not protect Mimir, which disables isolation.

Addresses the data-loss mechanism described in the [mimir-ops-03 incident analysis](https://docs.google.com/document/d/1qDb0z-fi23bPyaO0LkCI2V4Mjqds2Y7c4LUiQFsJrqM/edit). The analysis reports that query results later recovered through block-builder’s independent Kafka-derived blocks. The ownership issue that triggered mass eviction remains separate follow-up work.

This change keeps a series in the head if it received a commit after compaction's watermark or still has samples buffered in an open appender:

- Track commits with a sequence number, using a brief barrier before block writing to finish in-flight sample application and capture the watermark.
- Replace the pending-commit boolean with a counter so one appender cannot clear another's pending samples. Apply both guards to selected- and stale-series eviction.

Also fixes `AppendSTZeroSample` leaving a pending marker when it rejects an out-of-order start timestamp.

Validation: selected/stale-series compaction tests and targeted race tests pass with isolation enabled and disabled, covering concurrent commits, overlapping open appenders, and restart recovery. CI is green.

```release-notes
[BUGFIX] TSDB: Prevent selected- and stale-series compaction from losing concurrent writes, including when isolation is disabled.
```
