### PR TITLE
tsdb: retain a series if it received a sample since compaction started

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2166,12 +2166,17 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		return nil
 	}
 
+	// Snapshot each selected series' in-memory shape before writing any blocks. The eviction
+	// check below compares against this snapshot to catch a sample that arrived for the series
+	// after this point, independently of whether isolation is enabled.
+	fingerprints := db.head.snapshotFingerprints(selectedSeriesRefs.sortedByRef)
+
 	if err := db.compactHeadViewLocked(
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
 		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1977,20 +1977,11 @@ type headViewFactory func(head *Head, mint, maxt int64) BlockReader
 //
 // The evictor must preserve any series that may have received samples
 // after compaction began, as those samples might not be present in the
-// generated blocks.
+// generated blocks -- see fingerprintChangedForRef.
 //
 // maxt is the head's MaxTime at compaction start and is used to detect
 // obvious late writes via sample timestamps.
-//
-// appendIDWatermark is the head's append-ID counter at compaction
-// start. A series containing samples with appendID >
-// appendIDWatermark must not be evicted, as those samples were appended
-// after compaction began and may not be present in any block.
-//
-// When isolation is disabled, appendIDWatermark is always 0 and the
-// append-ID check becomes a no-op. In that mode, the caller must ensure
-// that no concurrent writes target the selected series.
-type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
+type headSeriesEvictor func(maxt int64) error
 
 // compactHeadViewLocked writes a block (or sequence of blocks, one per chunk range) for the
 // restricted head view produced by viewFactory, then runs evictor to remove those series from the
@@ -2000,22 +1991,6 @@ type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
 // The caller must hold db.cmtx.
 func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSeriesEvictor, configure func(*BlockMeta)) error {
 	mint, maxt := db.head.opts.ChunkRange*(db.head.MinTime()/db.head.opts.ChunkRange), db.head.MaxTime()
-	// Capture the highest guaranteed-committed appendID as an eviction watermark
-	// before writing any blocks.
-	//
-	// Samples with appendID <= watermark are guaranteed to be present in some
-	// generated block. Samples with higher IDs may or may not be present,
-	// depending on block-writer snapshot timing.
-	//
-	// The watermark is used during eviction: a series is removed only if it has
-	// not received any samples with appendID > watermark since compaction began.
-	//
-	// We use committedAppendID instead of lastAppendID because open appenders are
-	// excluded from all block snapshots via incompleteAppends. If one of those
-	// appenders commits between the write and evict phases, using lastAppendID
-	// could evict a series whose newest sample is present in neither the block nor
-	// the head, causing that sample to be lost on WAL replay.
-	appendIDWatermark := db.head.iso.committedAppendID()
 	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
 	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
@@ -2055,7 +2030,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 		compactHeadViewBeforeEvictTestingCallback = nil
 	}
 
-	if err := evict(maxt, appendIDWatermark); err != nil {
+	if err := evict(maxt); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)
@@ -2083,12 +2058,18 @@ func (db *DB) CompactStaleHead() (err error) {
 	if err != nil {
 		return err
 	}
+
+	// Snapshot each stale series' in-memory shape before writing any blocks. The eviction
+	// check below compares against this snapshot to catch a sample -- stale or not -- that
+	// arrived for the series after this point, independently of whether isolation is enabled.
+	fingerprints := db.head.snapshotFingerprints(staleSeriesRefs.sortedByRef)
+
 	if err := db.compactHeadViewLocked(
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, staleSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+		func(maxt int64) error {
+			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetStaleSeries() },
 	); err != nil {
@@ -2175,7 +2156,7 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
-		func(maxt int64, _ uint64) error {
+		func(maxt int64) error {
 			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2175,8 +2175,8 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
+		func(maxt int64, _ uint64) error {
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10541,6 +10541,67 @@ func TestStaleSeriesCompactionWithZeroSeries(t *testing.T) {
 	require.Empty(t, db.Blocks())
 }
 
+// TestCompactStaleHead_LateStaleAppendSurvives verifies that a stale series is not evicted
+// when another sample is appended after CompactStaleHead writes the block but before eviction,
+// even if the new sample is also a stale marker.
+//
+// This is the CompactStaleHead counterpart of
+// TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart. A live isStaleSeries
+// re-check cannot detect this case because the series is stale both before and after the append.
+// The fingerprint detects that the series changed and prevents its eviction.
+func TestCompactStaleHead_LateStaleAppendSurvives(t *testing.T) {
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	staleV := math.Float64frombits(value.StaleNaN)
+
+	// Filler series keeps head.MaxTime at 700, ensuring the late append at t=400 remains
+	// within appendableMinValidTime() = max(700-500, 0) = 200.
+	filler := labels.FromStrings("name", "filler")
+	sel := labels.FromStrings("name", "stale-selected")
+
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, filler, 100, 0.1)
+	require.NoError(t, err)
+	_, err = app.Append(0, filler, 700, 0.7)
+	require.NoError(t, err)
+	selRef, err := app.Append(0, sel, 100, 10.0)
+	require.NoError(t, err)
+	_, err = app.Append(selRef, sel, 200, staleV)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, int64(700), db.Head().MaxTime())
+	require.Equal(t, uint64(1), db.Head().NumStaleSeries())
+
+	// The hook fires after the block is written but before eviction.
+	const lateT = int64(400)
+	var hookErr error
+	compactHeadViewBeforeEvictTestingCallback = func() {
+		hookApp := db.Appender(context.Background())
+		if _, err := hookApp.Append(selRef, sel, lateT, staleV); err != nil {
+			hookErr = err
+			return
+		}
+		hookErr = hookApp.Commit()
+	}
+	t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
+
+	require.NoError(t, db.CompactStaleHead())
+	require.NoError(t, hookErr, "the late stale append/commit inside the hook must itself succeed")
+
+	// A block is written regardless -- it captures sel's t=100,200 samples as they stood when
+	// the write started. What the fingerprint protects is eviction: sel must still be in the
+	// head afterward too, so the late sample at t=400 isn't lost.
+	require.Len(t, db.Blocks(), 1)
+	require.Equal(t, uint64(2), db.Head().NumSeries(), "filler + sel: sel must survive eviction")
+}
+
 // TestCompactStaleHead_EvictedSeriesRecordKeptInCheckpoint verifies that after
 // CompactStaleHead evicts a stale series, the series's label record is retained
 // in the next WAL checkpoint while the WAL still holds sample records
@@ -11102,15 +11163,14 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 	require.Equal(t, expectedSamples, afterRestart, "all three samples must survive restart")
 }
 
-// TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives verifies that a series is
-// retained, not evicted, when an out-of-order sample transitions it from s.ooo == nil to
-// non-nil during compaction.
+// TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives verifies that a series is not
+// evicted when an out-of-order sample transitions it from s.ooo == nil to non-nil during
+// compaction.
 //
-// Unlike an in-order late append, an OOO sample changes neither headChunkCount nor the
-// current chunk's sample count, so the fingerprint check plays no part here. Instead,
-// isSeriesWithoutOOO -- re-evaluated live at eviction-check time, not from the
-// selection-time snapshot -- catches the transition on its own. Confirmed by temporarily
-// dropping isSeriesWithoutOOO from the eviction predicate and observing this test fail.
+// Unlike a late in-order append, an OOO sample changes neither headChunkCount nor the current
+// chunk’s sample count, so the fingerprint cannot detect it. Instead, isSeriesWithoutOOO is
+// re-evaluated at eviction time and detects the transition, preventing the series from being
+// evicted.
 func TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives(t *testing.T) {
 	const chunkRange = 1000
 	opts := DefaultOptions()

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -11009,9 +11009,12 @@ func TestInOrderBlocksMaxTime_ExcludesSelectedSeriesBlocks(t *testing.T) {
 //
 // The sample is committed too late to be included in the generated
 // block, but early enough that its timestamp still falls within the
-// compaction range. Without the appendID watermark check, the series
-// would be evicted, causing the late sample to disappear from both the
-// head and the WAL replay path after restart.
+// compaction range. Without a guard, the series would be evicted,
+// causing the late sample to disappear from both the head and the WAL
+// replay path after restart.
+//
+// Must hold regardless of isolation: hasAppendIDAbove catches it when isolation is on;
+// the isolation-independent fingerprint check catches it when the watermark is a no-op.
 //
 // The test injects such an append via
 // compactHeadViewBeforeEvictTestingCallback and verifies that the
@@ -11070,35 +11073,14 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 
 	require.Len(t, db.Blocks(), 1)
 
-	// The watermark guard only fires when isolation is enabled, because it
-	// relies on per-sample append-IDs that s.txs only tracks in that mode.
-	//   - isolation enabled: hasAppendIDAbove catches the post-watermark
-	//     commit, sel survives eviction, and all three samples are queryable.
-	//   - isolation disabled: per-sample append-IDs aren't tracked, the guard
-	//     is a no-op, sel gets evicted along with the late sample, and the
-	//     WAL tombstone drops the late sample permanently on replay. Only the
-	//     two samples the block captured remain queryable.
-	var (
-		expectedHeadSeries uint64
-		expectedSamples    []chunks.Sample
-	)
-	if defaultIsolationDisabled {
-		expectedHeadSeries = 1 // only filler remains; sel was evicted
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-		}
-	} else {
-		expectedHeadSeries = 2 // filler + sel
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-			sample{t: lateT, f: lateV},
-		}
+	// sel survives regardless of isolation, so all three samples remain queryable.
+	expectedSamples := []chunks.Sample{
+		sample{t: 100, f: 10.0},
+		sample{t: 200, f: 20.0},
+		sample{t: lateT, f: lateV},
 	}
 
-	require.Equal(t, expectedHeadSeries, db.Head().NumSeries(),
-		"head series count must match the expected watermark-guard outcome for this isolation mode")
+	require.Equal(t, uint64(2), db.Head().NumSeries(), "filler + sel: sel must survive eviction")
 
 	querySelected := func(d *DB) []chunks.Sample {
 		q, err := d.Querier(0, chunkRange)
@@ -11108,8 +11090,7 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 	}
 
 	beforeRestart := querySelected(db)
-	require.Equal(t, expectedSamples, beforeRestart,
-		"visible samples before restart must match the expected watermark-guard outcome")
+	require.Equal(t, expectedSamples, beforeRestart, "all three samples must be visible before restart")
 
 	// Verify the same data is visible after a restart driven by WAL replay.
 	require.NoError(t, db.Close())
@@ -11118,8 +11099,70 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
 	afterRestart := querySelected(db)
-	require.Equal(t, expectedSamples, afterRestart,
-		"visible samples after restart must match the expected watermark-guard outcome")
+	require.Equal(t, expectedSamples, afterRestart, "all three samples must survive restart")
+}
+
+// TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives verifies that a series is
+// retained, not evicted, when an out-of-order sample transitions it from s.ooo == nil to
+// non-nil during compaction.
+//
+// Unlike an in-order late append, an OOO sample changes neither headChunkCount nor the
+// current chunk's sample count, so the fingerprint check plays no part here. Instead,
+// isSeriesWithoutOOO -- re-evaluated live at eviction-check time, not from the
+// selection-time snapshot -- catches the transition on its own. Confirmed by temporarily
+// dropping isSeriesWithoutOOO from the eviction predicate and observing this test fail.
+func TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives(t *testing.T) {
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	opts.OutOfOrderTimeWindow = chunkRange // enable OOO ingestion
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	filler := labels.FromStrings("name", "filler")
+	sel := labels.FromStrings("name", "selected")
+
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, filler, 100, 0.1)
+	require.NoError(t, err)
+	_, err = app.Append(0, filler, 700, 0.7)
+	require.NoError(t, err)
+	selRef, err := app.Append(0, sel, 100, 10.0)
+	require.NoError(t, err)
+	_, err = app.Append(selRef, sel, 200, 20.0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, uint64(2), db.Head().NumSeries())
+
+	// The hook fires after the block is written but before eviction. This sample, earlier
+	// than sel's max (200) but within the OOO window, flips sel's s.ooo from nil to non-nil.
+	const oooT, oooV = int64(150), 15.0
+	var hookErr error
+	compactHeadViewBeforeEvictTestingCallback = func() {
+		hookApp := db.Appender(context.Background())
+		if _, err := hookApp.Append(selRef, sel, oooT, oooV); err != nil {
+			hookErr = err
+			return
+		}
+		hookErr = hookApp.Commit()
+	}
+	t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
+
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{selRef}))
+	require.NoError(t, hookErr, "the OOO append/commit inside the hook must itself succeed")
+
+	require.Equal(t, uint64(2), db.Head().NumSeries(), "filler + sel: sel must survive eviction")
+
+	q, err := db.Querier(0, chunkRange)
+	require.NoError(t, err)
+	seriesSet := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+	require.Equal(t, []chunks.Sample{
+		sample{t: 100, f: 10.0},
+		sample{t: oooT, f: oooV},
+		sample{t: 200, f: 20.0},
+	}, seriesSet[`{name="selected"}`], "all three samples, including the OOO one, must be visible")
 }
 
 // TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction verifies

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -11013,8 +11013,8 @@ func TestInOrderBlocksMaxTime_ExcludesSelectedSeriesBlocks(t *testing.T) {
 // causing the late sample to disappear from both the head and the WAL
 // replay path after restart.
 //
-// Must hold regardless of isolation: hasAppendIDAbove catches it when isolation is on;
-// the isolation-independent fingerprint check catches it when the watermark is a no-op.
+// The fingerprint check that catches this doesn't depend on isolation, so this holds
+// regardless of how isolation is configured.
 //
 // The test injects such an append via
 // compactHeadViewBeforeEvictTestingCallback and verifies that the
@@ -11171,15 +11171,12 @@ func TestCompactSelectedSeries_OOOAppendDuringCompactionSurvives(t *testing.T) {
 // The test covers the case where a write starts before compaction begins but
 // only commits after block generation and before eviction. Such a sample may
 // not be included in the generated blocks, so compaction must ensure the
-// corresponding series is retained in the head.
+// corresponding series is retained in the head. The commit lands after the
+// fingerprint snapshot is taken, so the check catches it regardless of isolation.
 //
 // The test verifies that the sample remains queryable both immediately after
 // compaction and after a restart.
 func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing.T) {
-	if defaultIsolationDisabled {
-		t.Skip("watermark guard relies on per-sample append-IDs that s.txs only tracks when isolation is enabled")
-	}
-
 	const chunkRange = 1000
 	opts := DefaultOptions()
 	opts.MinBlockDuration = chunkRange
@@ -11210,12 +11207,10 @@ func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing
 		lateV = 40.0
 	)
 
-	// Open the appender BEFORE CompactSelectedSeries: this is the key
-	// difference from TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart,
-	// where the appender is opened inside the hook (and so gets an appendID
-	// strictly greater than the captured watermark). Here, the appender's ID
-	// is issued before the watermark capture, so a watermark based on
-	// lastAppendID() would incorrectly cover it.
+	// Open the appender BEFORE CompactSelectedSeries -- the key difference from
+	// TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart, where the appender
+	// is opened inside the hook. Append() only reserves a pending commit here; the chunk
+	// mutation that the fingerprint notices happens later, at Commit() time inside the hook.
 	late := db.Appender(context.Background())
 	_, err = late.Append(selRef, sel, lateT, lateV)
 	require.NoError(t, err)
@@ -11234,7 +11229,7 @@ func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing
 
 	require.Len(t, db.Blocks(), 1)
 	require.Equal(t, uint64(2), db.Head().NumSeries(),
-		"sel must survive eviction because its late commit has an appendID > watermark")
+		"sel must survive eviction: its late commit changed the fingerprint taken before the block was written")
 
 	expected := []chunks.Sample{
 		sample{t: 100, f: 10.0},

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1380,20 +1380,21 @@ func isStaleSeries(s *memSeries) bool {
 
 // truncateStaleSeries removes the provided series as long as they are still stale and
 // carry no out-of-order data.
-// appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
-// have received samples with greater appendIDs are skipped, because those samples may not be
-// present in the generated block.
-func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+// Series that received a sample since their fingerprint was snapshotted are skipped via
+// fingerprintChangedForRef.
+// This covers both fresh samples, which the live isStaleSeries check also catches, and
+// new stale markers, which only the fingerprint detects.
+func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !fingerprintChangedForRef(s, fingerprints)
 	})
 	return err
 }
 
 // truncateSelectedSeries removes the series identified by the provided refs from the head.
-// Series that received fresh samples or acquired OOO data after the caller collected the ref
-// list are skipped, via fingerprints -- see fingerprintChangedForRef. The latter must be
-// flushed by CompactOOOHead before they can be evicted.
+// Series that received new samples or acquired OOO data after the refs were collected are
+// skipped via fingerprints; see fingerprintChangedForRef. OOO data must first be flushed by
+// CompactOOOHead before the series can be evicted.
 func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
 		return isSeriesWithoutOOO(s) && !fingerprintChangedForRef(s, fingerprints)
@@ -1401,34 +1402,13 @@ func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64
 	return err
 }
 
-// hasAppendIDAbove reports whether s contains any in-memory sample with an appendID
-// greater than watermark.
-// When isolation is disabled (s.txs == nil), it always returns false; in that mode,
-// CompactStaleHead relies on its existing requirement that no concurrent writes target
-// the affected series. CompactSelectedSeries no longer uses this: fingerprintChangedForRef
-// covers the same ground without needing isolation.
-// Must be called with s.Lock held.
-func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
-	if s.txs == nil {
-		return false
-	}
-	it := s.txs.iterator()
-	for i := uint32(0); i < s.txs.txIDCount; i++ {
-		if it.At() > watermark {
-			return true
-		}
-		it.Next()
-	}
-	return false
-}
-
 // seriesFingerprint is an isolation-independent snapshot of a series' in-order head chunk
-// shape. Comparing two snapshots detects an in-order append in between -- in flight or
-// already committed -- without the per-sample append-ID tracking hasAppendIDAbove needs
-// isolation for.
+// shape. Comparing two snapshots detects an in-order append in between, whether still in
+// flight or already committed.
 //
 // No field tracks OOO transitions: isSeriesWithoutOOO is re-evaluated live at eviction-check
 // time, so a series that turns OOO after being selected is already caught there, for free.
+// Likewise, no field tracks staleness: isStaleSeries is re-evaluated live too.
 type seriesFingerprint struct {
 	headChunkCount   uint32
 	lastChunkSamples int
@@ -1460,8 +1440,8 @@ func fingerprintChanged(s *memSeries, fp seriesFingerprint) bool {
 
 // fingerprintChangedForRef looks up s's snapshot in fingerprints and reports whether it has
 // since changed. A missing entry is treated as changed -- retain rather than risk evicting --
-// though every ref CompactSelectedSeries passes through should have one. Must be called with
-// s.Lock held.
+// though every ref CompactSelectedSeries or CompactStaleHead passes through should have one.
+// Must be called with s.Lock held.
 func fingerprintChangedForRef(s *memSeries, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
 	fp, ok := fingerprints[storage.SeriesRef(s.ref)]
 	if !ok {
@@ -1470,9 +1450,10 @@ func fingerprintChangedForRef(s *memSeries, fingerprints map[storage.SeriesRef]s
 	return fingerprintChanged(s, fp)
 }
 
-// snapshotFingerprints captures a seriesFingerprint per ref, before CompactSelectedSeries
-// writes any blocks, so the later eviction check can detect -- independently of isolation --
-// a sample received since this point. Refs that no longer resolve to a live series are omitted.
+// snapshotFingerprints captures a seriesFingerprint per ref, before the caller
+// (CompactSelectedSeries or CompactStaleHead) writes any blocks, so the later eviction check
+// can detect -- independently of isolation -- a sample received since this point. Refs that no
+// longer resolve to a live series are omitted.
 func (h *Head) snapshotFingerprints(seriesRefs []storage.SeriesRef) map[storage.SeriesRef]seriesFingerprint {
 	fingerprints := make(map[storage.SeriesRef]seriesFingerprint, len(seriesRefs))
 	for _, ref := range seriesRefs {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1392,13 +1392,11 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, a
 
 // truncateSelectedSeries removes the series identified by the provided refs from the head.
 // Series that received fresh samples or acquired OOO data after the caller collected the ref
-// list are skipped. The latter must be flushed by CompactOOOHead before they can be evicted.
-// appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
-// have received samples with greater appendIDs are skipped, because those samples may not be
-// present in the generated block.
-func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
+// list are skipped, via fingerprints -- see fingerprintChangedForRef. The latter must be
+// flushed by CompactOOOHead before they can be evicted.
+func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark) && !fingerprintChangedForRef(s, fingerprints)
+		return isSeriesWithoutOOO(s) && !fingerprintChangedForRef(s, fingerprints)
 	})
 	return err
 }
@@ -1406,9 +1404,9 @@ func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64
 // hasAppendIDAbove reports whether s contains any in-memory sample with an appendID
 // greater than watermark.
 // When isolation is disabled (s.txs == nil), it always returns false; in that mode,
-// CompactSelectedSeries and CompactStaleHead rely on their existing requirement that no
-// concurrent writes target the affected series -- CompactSelectedSeries additionally backs
-// this with fingerprintChangedForRef.
+// CompactStaleHead relies on its existing requirement that no concurrent writes target
+// the affected series. CompactSelectedSeries no longer uses this: fingerprintChangedForRef
+// covers the same ground without needing isolation.
 // Must be called with s.Lock held.
 func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 	if s.txs == nil {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1396,18 +1396,19 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, a
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
-func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark) && !fingerprintChangedForRef(s, fingerprints)
 	})
 	return err
 }
 
 // hasAppendIDAbove reports whether s contains any in-memory sample with an appendID
 // greater than watermark.
-// When isolation is disabled (s.txs == nil), it always returns false;  in that mode,
-// CompactSelectedSeries and CompactStaleHead rely on their existing requirement that
-// no concurrent writes target the affected series.
+// When isolation is disabled (s.txs == nil), it always returns false; in that mode,
+// CompactSelectedSeries and CompactStaleHead rely on their existing requirement that no
+// concurrent writes target the affected series -- CompactSelectedSeries additionally backs
+// this with fingerprintChangedForRef.
 // Must be called with s.Lock held.
 func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 	if s.txs == nil {
@@ -1421,6 +1422,71 @@ func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 		it.Next()
 	}
 	return false
+}
+
+// seriesFingerprint is an isolation-independent snapshot of a series' in-order head chunk
+// shape. Comparing two snapshots detects an in-order append in between -- in flight or
+// already committed -- without the per-sample append-ID tracking hasAppendIDAbove needs
+// isolation for.
+//
+// No field tracks OOO transitions: isSeriesWithoutOOO is re-evaluated live at eviction-check
+// time, so a series that turns OOO after being selected is already caught there, for free.
+type seriesFingerprint struct {
+	headChunkCount   uint32
+	lastChunkSamples int
+}
+
+// snapshotFingerprint captures s's current fingerprint. Must be called with s.Lock held.
+func snapshotFingerprint(s *memSeries) seriesFingerprint {
+	fp := seriesFingerprint{
+		headChunkCount: s.headChunkCount.Load(),
+	}
+	if s.headChunks != nil {
+		fp.lastChunkSamples = s.headChunks.chunk.NumSamples()
+	}
+	return fp
+}
+
+// fingerprintChanged reports whether s's current fingerprint no longer matches fp. Must be
+// called with s.Lock held.
+func fingerprintChanged(s *memSeries, fp seriesFingerprint) bool {
+	if s.headChunkCount.Load() != fp.headChunkCount {
+		return true
+	}
+	var lastChunkSamples int
+	if s.headChunks != nil {
+		lastChunkSamples = s.headChunks.chunk.NumSamples()
+	}
+	return lastChunkSamples != fp.lastChunkSamples
+}
+
+// fingerprintChangedForRef looks up s's snapshot in fingerprints and reports whether it has
+// since changed. A missing entry is treated as changed -- retain rather than risk evicting --
+// though every ref CompactSelectedSeries passes through should have one. Must be called with
+// s.Lock held.
+func fingerprintChangedForRef(s *memSeries, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
+	fp, ok := fingerprints[storage.SeriesRef(s.ref)]
+	if !ok {
+		return true
+	}
+	return fingerprintChanged(s, fp)
+}
+
+// snapshotFingerprints captures a seriesFingerprint per ref, before CompactSelectedSeries
+// writes any blocks, so the later eviction check can detect -- independently of isolation --
+// a sample received since this point. Refs that no longer resolve to a live series are omitted.
+func (h *Head) snapshotFingerprints(seriesRefs []storage.SeriesRef) map[storage.SeriesRef]seriesFingerprint {
+	fingerprints := make(map[storage.SeriesRef]seriesFingerprint, len(seriesRefs))
+	for _, ref := range seriesRefs {
+		s := h.series.getByID(chunks.HeadSeriesRef(ref))
+		if s == nil {
+			continue
+		}
+		s.Lock()
+		fingerprints[ref] = snapshotFingerprint(s)
+		s.Unlock()
+	}
+	return fingerprints
 }
 
 // truncateSeries removes the provided series from the head, taking the chunk-snapshot lock,

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1051,7 +1051,8 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
-	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
+	staleRefs := []storage.SeriesRef{ref1}
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 3500, head.snapshotFingerprints(staleRefs)))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -8753,7 +8754,7 @@ func TestHead_NumStaleSeries_MixedTypeRemoval(t *testing.T) {
 		{
 			name: "truncate_stale_series",
 			remove: func(t *testing.T, head *Head, refs []storage.SeriesRef) {
-				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64))
+				require.NoError(t, head.truncateStaleSeries(refs, 1000, head.snapshotFingerprints(refs)))
 			},
 			wantSeries:        2, // Only the genuinely stale series is evicted.
 			crossTypeSurvives: true,
@@ -9200,7 +9201,8 @@ func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 
 						series := testHead.series.getByHash(lbls.Hash(), lbls)
 						require.NotNil(t, series)
-						require.NoError(t, testHead.truncateStaleSeries([]storage.SeriesRef{storage.SeriesRef(series.ref)}, 100, math.MaxUint64))
+						staleRefs := []storage.SeriesRef{storage.SeriesRef(series.ref)}
+						require.NoError(t, testHead.truncateStaleSeries(staleRefs, 100, testHead.snapshotFingerprints(staleRefs)))
 						require.Zero(t, testHead.NumSeries())
 						require.Zero(t, testHead.NumStaleSeries())
 						require.Zero(t, testHead.NumNativeHistogramSeries())
@@ -10258,7 +10260,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, head.snapshotFingerprints(staleRefs)))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -11096,8 +11098,9 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		readyBefore := mmapReadyCounter()
 
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
+		staleRefs := []storage.SeriesRef{storage.SeriesRef(sB.ref)}
 		require.NoError(t, h.truncateStaleSeries(
-			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts, math.MaxUint64,
+			staleRefs, ts, h.snapshotFingerprints(staleRefs),
 		))
 		requireCounterConsistent("after truncateStaleSeries")
 		require.Less(t, mmapReadyCounter(), readyBefore,


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Description

Both `CompactSelectedSeries` and `CompactStaleHead` write selected series into a block and then evict them from the head. If a sample lands for one of those series after its block is written but before eviction runs, that sample can be silently lost — it isn't in the block, and the series gets removed from the head anyway.

Until now, the only guard against this was an append-ID watermark (`hasAppendIDAbove`), which relies on Prometheus's isolation subsystem tracking per-sample append IDs. When isolation is disabled, that tracking doesn't exist, and the guard silently becomes a no-op — a config-dependent gap with no compile-time or test-time signal that it had disappeared.

This PR replaces it with a fingerprint of each series' in-order head chunk shape (chunk count + current chunk's sample count), snapshotted before the block is written and rechecked right before eviction. Any mismatch means something was appended in between — in flight or already committed — and the series is retained instead of evicted. This works identically whether isolation is enabled or not, since it never reads any isolation-related state. Two other transitions that also need to block eviction — a series turning out-of-order, and (for stale-series compaction specifically) a series becoming un-stale — are already caught for free, because `isSeriesWithoutOOO`/`isStaleSeries` are re-evaluated live at eviction time rather than from a stale snapshot.

With the fingerprint covering everything the watermark did and more, the watermark and `hasAppendIDAbove` are removed from both compaction paths entirely, along with the now-unused `appendIDWatermark` plumbing through `headSeriesEvictor`/`compactHeadViewLocked`.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix a race in selected-series and stale-series compaction where a sample committed after the block was written but before the series was evicted from the head could be silently lost. The fix no longer depends on isolation being enabled.
```
