### PR TITLE
[mimir-release-2.17] tsdb: wrap in-order and OOO chunk IDs (#19216, #19450)

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -77,7 +77,10 @@ func (p HeadChunkRef) Unpack() (HeadSeriesRef, HeadChunkID) {
 }
 
 // HeadChunkID refers to a specific chunk in a series (memSeries) in the Head.
-// Each memSeries has its own monotonically increasing number to refer to its chunks.
+// Each memSeries has its own number to refer to its chunks: both in-order and
+// out-of-order chunk IDs wrap around modulo 2^23 (see headChunkID and
+// oooHeadChunkID in tsdb/head_read.go), so they only increase between
+// wrap-arounds. All arithmetic on them is modulo 2^23.
 // If the HeadChunkID value is...
 //   - memSeries.firstChunkID+len(memSeries.mmappedChunks), it's the head chunk.
 //   - less than the above, but >= memSeries.firstID, then it's
@@ -87,7 +90,7 @@ func (p HeadChunkRef) Unpack() (HeadSeriesRef, HeadChunkID) {
 // "open" (accepting appends) instance. *memChunk is a linked list and memChunk.next pointer
 // might link to the older *memChunk instance.
 // If there are multiple *memChunk instances linked to each other from memSeries.headChunks
-// they will be m-mapped as soon as possible leaving only "open" *memChunk instance.
+// they will be m-mapped as soon as possible leaving only one "open" *memChunk instance.
 //
 // Example:
 // assume a memSeries.firstChunkID=7 and memSeries.mmappedChunks=[p5,p6,p7,p8,p9].

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -77,31 +77,22 @@ func (p HeadChunkRef) Unpack() (HeadSeriesRef, HeadChunkID) {
 }
 
 // HeadChunkID refers to a specific chunk in a series (memSeries) in the Head.
-// Each memSeries has its own number to refer to its chunks: both in-order and
-// out-of-order chunk IDs wrap around modulo 2^23 (see headChunkID and
-// oooHeadChunkID in tsdb/head_read.go), so they only increase between
-// wrap-arounds. All arithmetic on them is modulo 2^23.
-// If the HeadChunkID value is...
-//   - memSeries.firstChunkID+len(memSeries.mmappedChunks), it's the head chunk.
-//   - less than the above, but >= memSeries.firstID, then it's
-//     memSeries.mmappedChunks[i] where i = HeadChunkID - memSeries.firstID.
+// Each memSeries has its own IDs for in-order and out-of-order chunks.
+//
+// IDs occupy bits 0-22 of HeadChunkRef (bit 23 is the OOO flag) and wrap modulo
+// 2^23 (see wrapChunkID, headChunkID, and oooHeadChunkID in tsdb/head_read.go).
+// They are not a globally monotonic counter: never order them, compare them, or
+// bound-check them directly. Recover the live-chunk index with
+//
+//	i = wrapChunkID(HeadChunkID - firstChunkID)
+//
+// For in-order chunks, i indexes mmappedChunks, then the headChunks linked list.
 //
 // If memSeries.headChunks is non-nil it points to a *memChunk that holds the current
-// "open" (accepting appends) instance. *memChunk is a linked list and memChunk.next pointer
-// might link to the older *memChunk instance.
+// "open" (accepting appends) instance. *memChunk is a linked list and memChunk.prev
+// pointer might link to the older *memChunk instance.
 // If there are multiple *memChunk instances linked to each other from memSeries.headChunks
 // they will be m-mapped as soon as possible leaving only one "open" *memChunk instance.
-//
-// Example:
-// assume a memSeries.firstChunkID=7 and memSeries.mmappedChunks=[p5,p6,p7,p8,p9].
-//
-//	| HeadChunkID value | refers to ...                                                                          |
-//	|-------------------|----------------------------------------------------------------------------------------|
-//	|               0-6 | chunks that have been compacted to blocks, these won't return data for queries in Head |
-//	|              7-11 | memSeries.mmappedChunks[i] where i is 0 to 4.                                          |
-//	|                12 |                                                         *memChunk{next: nil}
-//	|                13 |                                         *memChunk{next: ^}
-//	|                14 | memSeries.headChunks -> *memChunk{next: ^}
 type HeadChunkID uint64
 
 // BlockChunkRef refers to a chunk within a persisted block.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9666,3 +9666,68 @@ func TestBiggerBlocksForOldOOOData(t *testing.T) {
 	seriesSet = query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: expOOOSamples}, seriesSet)
 }
+
+func TestOOOCompactionAcrossChunkIDWrap(t *testing.T) {
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			testOOOCompactionAcrossChunkIDWrap(t, scenario)
+		})
+	}
+}
+
+func testOOOCompactionAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenario) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 5
+	opts.OutOfOrderTimeWindow = 4 * time.Hour.Milliseconds()
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	l := labels.FromStrings("l", "v1")
+	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
+
+	app := db.Appender(context.Background())
+
+	// In-order sample.
+	ref, _, err := scenario.appendFunc(app, l, minutes(200), 200)
+	require.NoError(t, err)
+	var expSamples []chunks.Sample
+	expSamples = append(expSamples, scenario.sampleFunc(minutes(200), 200))
+
+	// 15 OOO samples to create 3 mmapped chunks (cap=5).
+	for i := int64(1); i <= 15; i++ {
+		_, _, err = scenario.appendFunc(app, l, minutes(i), i)
+		require.NoError(t, err)
+		expSamples = append(expSamples, scenario.sampleFunc(minutes(i), i))
+	}
+	require.NoError(t, app.Commit())
+
+	// Seed firstOOOChunkID near the wrap boundary.
+	ms := db.head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, ms)
+	ms.Lock()
+	require.NotNil(t, ms.ooo)
+	ms.ooo.firstOOOChunkID = chunks.HeadChunkID(oooChunkIDMask - 1)
+	ms.Unlock()
+
+	// More OOO data whose chunk IDs cross the boundary.
+	app = db.Appender(context.Background())
+	for i := int64(16); i <= 30; i++ {
+		_, _, err = scenario.appendFunc(app, l, minutes(i), i)
+		require.NoError(t, err)
+		expSamples = append(expSamples, scenario.sampleFunc(minutes(i), i))
+	}
+	require.NoError(t, app.Commit())
+
+	// Compact.
+	require.NoError(t, db.Compact(context.Background()))
+
+	// Query and verify all data is present.
+	querier, err := db.Querier(0, minutes(300))
+	require.NoError(t, err)
+
+	seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "l", "v1"))
+
+	sort.Slice(expSamples, func(i, j int) bool { return expSamples[i].T() < expSamples[j].T() })
+	requireEqualSeries(t, map[string][]chunks.Sample{l.String(): expSamples}, seriesSet, true)
+}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9731,3 +9731,80 @@ func testOOOCompactionAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenari
 	sort.Slice(expSamples, func(i, j int) bool { return expSamples[i].T() < expSamples[j].T() })
 	requireEqualSeries(t, map[string][]chunks.Sample{l.String(): expSamples}, seriesSet, true)
 }
+
+// TestInOrderCompactionAcrossChunkIDWrap verifies that queries and head
+// compaction work on a series whose in-order chunk IDs wrap past the 23-bit
+// boundary.
+func TestInOrderCompactionAcrossChunkIDWrap(t *testing.T) {
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			testInOrderCompactionAcrossChunkIDWrap(t, scenario)
+		})
+	}
+}
+
+func testInOrderCompactionAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenario) {
+	const chunkRange = 100
+	const maxT = 500
+
+	db := newTestDB(t, withRngs(chunkRange))
+	db.DisableCompactions()
+
+	l := labels.FromStrings("l", "v1")
+
+	// Create the series, then seed firstChunkID at the top of the 23-bit ID
+	// space to emulate a long-lived series that has already truncated ~8M
+	// chunks. Every chunk appended afterwards is created with an ID at or past
+	// the boundary, so their stored HeadChunkRef IDs must wrap.
+	app := db.Appender(context.Background())
+	ref, _, err := scenario.appendFunc(app, l, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	firstChunkIDSeed := chunks.HeadChunkID(oooChunkIDMask - 1)
+	ms := db.head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, ms)
+	ms.Lock()
+	ms.firstChunkID = firstChunkIDSeed
+	ms.Unlock()
+
+	newestChunkID := func() chunks.HeadChunkID {
+		ms.Lock()
+		defer ms.Unlock()
+		return ms.headChunkID(len(ms.mmappedChunks) + int(ms.headChunkCount.Load()) - 1)
+	}
+	newestBeforeAppends := newestChunkID()
+
+	expSamples := []chunks.Sample{scenario.sampleFunc(0, 0)}
+	app = db.Appender(context.Background())
+	for ts := int64(10); ts < maxT; ts += 10 {
+		_, _, err = scenario.appendFunc(app, l, ts, ts)
+		require.NoError(t, err)
+		expSamples = append(expSamples, scenario.sampleFunc(ts, ts))
+	}
+	require.NoError(t, app.Commit())
+	sort.Slice(expSamples, func(i, j int) bool { return expSamples[i].T() < expSamples[j].T() })
+
+	require.Less(t, newestChunkID(), newestBeforeAppends, "chunk IDs should have wrapped past the boundary")
+
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "l", "v1")
+
+	// Queries must resolve the wrapped chunk IDs while the data is in the head.
+	querier, err := db.Querier(0, maxT)
+	require.NoError(t, err)
+	requireEqualSeries(t, map[string][]chunks.Sample{l.String(): expSamples}, query(t, querier, matcher), true)
+
+	// Head compaction reads every chunk through the same wrapped IDs, then drops
+	// the compacted ones via truncateChunksBefore, wrapping firstChunkID too.
+	require.NoError(t, db.Compact(context.Background()))
+
+	ms.Lock()
+	firstChunkIDAfter := ms.firstChunkID
+	ms.Unlock()
+	require.Less(t, firstChunkIDAfter, firstChunkIDSeed, "firstChunkID should have wrapped past 0")
+
+	// The compacted block must contain every sample.
+	querier, err = db.Querier(0, maxT)
+	require.NoError(t, err)
+	requireEqualSeries(t, map[string][]chunks.Sample{l.String(): expSamples}, query(t, querier, matcher), true)
+}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9679,8 +9679,9 @@ func testOOOCompactionAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenari
 	opts := DefaultOptions()
 	opts.OutOfOrderCapMax = 5
 	opts.OutOfOrderTimeWindow = 4 * time.Hour.Milliseconds()
+	opts.EnableNativeHistograms = true
 
-	db := newTestDB(t, withOpts(opts))
+	db := newTestDBWithOpts(t, opts)
 	db.DisableCompactions()
 
 	l := labels.FromStrings("l", "v1")
@@ -9747,7 +9748,10 @@ func testInOrderCompactionAcrossChunkIDWrap(t *testing.T, scenario sampleTypeSce
 	const chunkRange = 100
 	const maxT = 500
 
-	db := newTestDB(t, withRngs(chunkRange))
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.EnableNativeHistograms = true
+	db := newTestDBWithOpts(t, opts)
 	db.DisableCompactions()
 
 	l := labels.FromStrings("l", "v1")

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2325,7 +2325,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
 				removedInOrder = chk.len() + len(s.mmappedChunks)
-				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
+				s.firstChunkID = (s.firstChunkID + chunks.HeadChunkID(removedInOrder)) % oooChunkIDMask
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
 					s.setHeadChunks(nil, 0)
@@ -2350,7 +2350,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedInOrder = i + 1
 		}
 		s.mmappedChunks = append(s.mmappedChunks[:0], s.mmappedChunks[removedInOrder:]...)
-		s.firstChunkID += chunks.HeadChunkID(removedInOrder)
+		s.firstChunkID = (s.firstChunkID + chunks.HeadChunkID(removedInOrder)) % oooChunkIDMask
 	}
 
 	var removedOOO int
@@ -2362,7 +2362,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedOOO = i + 1
 		}
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
-		s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO)) & (oooChunkIDMask - 1)
+		s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO)) % oooChunkIDMask
 
 		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
 			s.ooo = nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2362,7 +2362,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedOOO = i + 1
 		}
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
-		s.ooo.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
+		s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO)) & (oooChunkIDMask - 1)
 
 		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
 			s.ooo = nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2332,7 +2332,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
 				removedInOrder = chk.len() + len(s.mmappedChunks)
-				s.firstChunkID = (s.firstChunkID + chunks.HeadChunkID(removedInOrder)) % oooChunkIDMask
+				s.firstChunkID = wrapChunkID(s.firstChunkID + chunks.HeadChunkID(removedInOrder))
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
 					s.setHeadChunks(nil, 0)
@@ -2357,7 +2357,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedInOrder = i + 1
 		}
 		s.mmappedChunks = append(s.mmappedChunks[:0], s.mmappedChunks[removedInOrder:]...)
-		s.firstChunkID = (s.firstChunkID + chunks.HeadChunkID(removedInOrder)) % oooChunkIDMask
+		s.firstChunkID = wrapChunkID(s.firstChunkID + chunks.HeadChunkID(removedInOrder))
 	}
 
 	var removedOOO int
@@ -2369,7 +2369,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 			removedOOO = i + 1
 		}
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
-		s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO)) % oooChunkIDMask
+		s.ooo.firstOOOChunkID = wrapChunkID(s.ooo.firstOOOChunkID + chunks.HeadChunkID(removedOOO))
 
 		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
 			s.ooo = nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2298,6 +2298,13 @@ func (s *memSeries) maxTime() int64 {
 // (mmapChunks, truncateChunksBefore) must be immediately paired with a
 // setHeadChunks call.
 func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
+	// Chunk IDs can only be 23 bits, so a series cannot hold more than 2^23 chunks
+	// without two of them sharing an ID. This is not reachable in practice (head
+	// compaction keeps the live set tiny); panic rather than serve an ambiguous ID.
+	if len(s.mmappedChunks)+int(s.headChunkCount.Load()) >= oooChunkIDMask-1 {
+		panic(fmt.Sprintf("too many in-order head chunks for series %s (%d)", s.lset.String(), s.ref))
+	}
+
 	chk.prev = s.headChunks
 	s.headChunks = chk
 	s.headChunkCount.Add(1)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1888,13 +1888,6 @@ func addJitterToChunkEndTime(seriesHash uint64, chunkMinTime, nextAt, maxNextAt 
 }
 
 func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange int64) *memChunk {
-	// Chunk IDs can only be 23 bits, so we can't track any more than 2^23 without aliasing.
-	// This is not reachable in practice (head compaction keeps the live set tiny); panic rather
-	// than generate an ambiguous ID.
-	if len(s.mmappedChunks)+int(s.headChunkCount.Load()) >= oooChunkIDMask-1 {
-		panic(fmt.Sprintf("too many in-order head chunks for series %s (%d)", s.lset.String(), s.ref))
-	}
-
 	// When cutting a new head chunk we create a new memChunk instance with .prev
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1888,6 +1888,13 @@ func addJitterToChunkEndTime(seriesHash uint64, chunkMinTime, nextAt, maxNextAt 
 }
 
 func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange int64) *memChunk {
+	// Chunk IDs can only be 23 bits, so we can't track any more than 2^23 without aliasing.
+	// This is not reachable in practice (head compaction keeps the live set tiny); panic rather
+	// than generate an ambiguous ID.
+	if len(s.mmappedChunks)+int(s.headChunkCount.Load()) >= oooChunkIDMask-1 {
+		panic(fmt.Sprintf("too many in-order head chunks for series %s (%d)", s.lset.String(), s.ref))
+	}
+
 	// When cutting a new head chunk we create a new memChunk instance with .prev
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -285,8 +285,8 @@ const oooChunkIDMask = 1 << 23
 // so that IDs never overflow into the OOO flag at bit 23. Callers wrap in both
 // directions: pos + firstChunkID when a chunk ID is assigned, and id - firstChunkID
 // when its position is looked up.
-// This is effectively a modulo operation, but correctly wraps negative ids (such as
-// when firstChunkID > chunkID), which a signed % would not.
+// HeadChunkID is uint64, so id - firstChunkID wraps modulo 2^64 when firstChunkID > id;
+// masking with oooChunkIDMask-1 recovers the 23-bit position.
 func wrapChunkID(id chunks.HeadChunkID) chunks.HeadChunkID {
 	return id & (oooChunkIDMask - 1)
 }
@@ -297,8 +297,8 @@ func wrapChunkID(id chunks.HeadChunkID) chunks.HeadChunkID {
 //
 // The position is wrapped modulo oooChunkIDMask so that firstChunkID can grow
 // indefinitely without overflowing the 23-bit ID space. Correctness requires the
-// number of chunks a series holds to stay below oooChunkIDMask,
-// which cutNewHeadChunk enforces.
+// number of chunks a series holds to stay below 2^23,
+// which pushHeadChunk enforces.
 func (s *memSeries) headChunkID(pos int) chunks.HeadChunkID {
 	return wrapChunkID(chunks.HeadChunkID(pos) + s.firstChunkID)
 }
@@ -311,8 +311,8 @@ func (s *memSeries) headChunkID(pos int) chunks.HeadChunkID {
 //
 // The position is wrapped modulo oooChunkIDMask so that firstOOOChunkID can
 // grow indefinitely without overflowing the 23-bit ID space. Correctness
-// requires len(oooMmappedChunks) << oooChunkIDMask, which is enforced by the
-// guard in mmapCurrentOOOHeadChunk.
+// requires len(oooMmappedChunks) to stay below 2^23, which is
+// enforced by the guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
 	return wrapChunkID(chunks.HeadChunkID(pos)+s.ooo.firstOOOChunkID) | oooChunkIDMask
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -293,8 +293,13 @@ const oooChunkIDMask = 1 << 23
 // * 0 <= pos < len(s.oooMmappedChunks) refer to s.oooMmappedChunks[pos]
 // * pos == len(s.oooMmappedChunks) refers to s.oooHeadChunk
 // The caller must ensure that s.ooo is not nil.
+//
+// The position is wrapped modulo oooChunkIDMask so that firstOOOChunkID can
+// grow indefinitely without overflowing the 23-bit ID space. Correctness
+// requires len(oooMmappedChunks) << oooChunkIDMask, which is enforced by the
+// guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
-	return (chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) | oooChunkIDMask
+	return ((chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1)) | oooChunkIDMask
 }
 
 func unpackHeadChunkRef(ref chunks.ChunkRef) (seriesID chunks.HeadSeriesRef, chunkID chunks.HeadChunkID, isOOO bool) {
@@ -619,11 +624,13 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 // oooChunk returns the chunk for the HeadChunkID by m-mapping it from the disk.
 // It never returns the head OOO chunk.
 func (s *memSeries) oooChunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, _ *sync.Pool) (chunk chunkenc.Chunk, maxTime int64, err error) {
-	// ix represents the index of chunk in the s.ooo.oooMmappedChunks slice. The chunk id's are
-	// incremented by 1 when new chunk is created, hence (id - firstOOOChunkID) gives the slice index.
-	ix := int(id) - int(s.ooo.firstOOOChunkID)
+	// ix represents the index of chunk in the s.ooo.oooMmappedChunks slice.
+	// Both id and firstOOOChunkID live in a modular 23-bit space; unsigned
+	// subtraction followed by masking recovers the correct index even when
+	// firstOOOChunkID has wrapped past 0.
+	ix := int((id - s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1))
 
-	if ix < 0 || ix >= len(s.ooo.oooMmappedChunks) {
+	if ix >= len(s.ooo.oooMmappedChunks) {
 		return nil, 0, storage.ErrNotFound
 	}
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -279,14 +279,29 @@ func appendSeriesChunks(s *memSeries, mint, maxt int64, chks []chunks.Meta, head
 	return chks, headChunksBuf
 }
 
+const oooChunkIDMask = 1 << 23
+
+// wrapChunkID reduces id into the 23-bit chunk ID space (bits 0..22 of HeadChunkRef),
+// so that IDs never overflow into the OOO flag at bit 23. Callers wrap in both
+// directions: pos + firstChunkID when a chunk ID is assigned, and id - firstChunkID
+// when its position is looked up.
+// This is effectively a modulo operation, but correctly wraps negative ids (such as
+// when firstChunkID > chunkID), which a signed % would not.
+func wrapChunkID(id chunks.HeadChunkID) chunks.HeadChunkID {
+	return id & (oooChunkIDMask - 1)
+}
+
 // headChunkID returns the HeadChunkID referred to by the given position.
 // * 0 <= pos < len(s.mmappedChunks) refer to s.mmappedChunks[pos]
 // * pos >= len(s.mmappedChunks) refers to s.headChunks linked list.
+//
+// The position is wrapped modulo oooChunkIDMask so that firstChunkID can grow
+// indefinitely without overflowing the 23-bit ID space. Correctness requires the
+// number of chunks a series holds to stay below oooChunkIDMask,
+// which cutNewHeadChunk enforces.
 func (s *memSeries) headChunkID(pos int) chunks.HeadChunkID {
-	return chunks.HeadChunkID(pos) + s.firstChunkID
+	return wrapChunkID(chunks.HeadChunkID(pos) + s.firstChunkID)
 }
-
-const oooChunkIDMask = 1 << 23
 
 // oooHeadChunkID returns the HeadChunkID referred to by the given position.
 // Only the bottom 24 bits are used. Bit 23 is always 1 for an OOO chunk; for the rest:
@@ -299,7 +314,7 @@ const oooChunkIDMask = 1 << 23
 // requires len(oooMmappedChunks) << oooChunkIDMask, which is enforced by the
 // guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
-	return ((chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1)) | oooChunkIDMask
+	return wrapChunkID(chunks.HeadChunkID(pos)+s.ooo.firstOOOChunkID) | oooChunkIDMask
 }
 
 func unpackHeadChunkRef(ref chunks.ChunkRef) (seriesID chunks.HeadSeriesRef, chunkID chunks.HeadChunkID, isOOO bool) {
@@ -554,7 +569,8 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // if isOpen is true, it means that the returned *memChunk is used for appends.
 func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
 	// ix is the chunk's oldest-first position in the logical sequence. Chunk IDs
-	// increase by one when a chunk is created, so id-firstChunkID yields that position.
+	// increase by one per chunk, so wrapChunkID(id-firstChunkID) yields that
+	// position even after the IDs have wrapped past 0.
 	// s.mmappedChunks is stored oldest-first, while the s.headChunks linked list is
 	// stored newest-first:
 	//
@@ -566,10 +582,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	// Values below len(s.mmappedChunks) index the slice directly. Remaining values
 	// index head chunks oldest-first; the pre-collected headChunks slice already uses
 	// this order, while the linked-list fallback reverses the index.
-	ix := int(id) - int(s.firstChunkID)
-	if ix < 0 {
-		return nil, false, false, storage.ErrNotFound
-	}
+	ix := int(wrapChunkID(id - s.firstChunkID))
 
 	if ix < len(s.mmappedChunks) {
 		chk, err := chunkDiskMapper.Chunk(s.mmappedChunks[ix].ref)
@@ -624,11 +637,10 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 // oooChunk returns the chunk for the HeadChunkID by m-mapping it from the disk.
 // It never returns the head OOO chunk.
 func (s *memSeries) oooChunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, _ *sync.Pool) (chunk chunkenc.Chunk, maxTime int64, err error) {
-	// ix represents the index of chunk in the s.ooo.oooMmappedChunks slice.
-	// Both id and firstOOOChunkID live in a modular 23-bit space; unsigned
-	// subtraction followed by masking recovers the correct index even when
-	// firstOOOChunkID has wrapped past 0.
-	ix := int((id - s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1))
+	// ix is the index into s.ooo.oooMmappedChunks. Chunk IDs increase by one per
+	// chunk, so wrapChunkID(id-firstOOOChunkID) recovers the index even after the
+	// IDs have wrapped past 0.
+	ix := int(wrapChunkID(id - s.ooo.firstOOOChunkID))
 
 	if ix >= len(s.ooo.oooMmappedChunks) {
 		return nil, 0, storage.ErrNotFound
@@ -656,7 +668,7 @@ func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator 
 // iterator returns a chunk iterator for the requested chunk ID, or a NopIterator if it is out of range.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
 func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *isolationState, it chunkenc.Iterator) chunkenc.Iterator {
-	ix := int(id) - int(s.firstChunkID)
+	ix := int(wrapChunkID(id - s.firstChunkID))
 
 	numSamples := c.NumSamples()
 	stopAfter := numSamples

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -502,6 +502,75 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrNotFound)
 }
 
+// TestMemSeries_chunk_ResolveAfterWrap checks that chunk IDs keep resolving to
+// the same chunks as truncation advances firstChunkID and wraps it back past 0.
+// Truncated IDs must report ErrNotFound rather than aliasing onto a chunk that
+// is still live.
+func TestMemSeries_chunk_ResolveAfterWrap(t *testing.T) {
+	const chunkRange int64 = 100
+	const chunkStep int64 = 5
+	const numChunks = 20
+
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, chunkDiskMapper.Close()) })
+	memChunkPool := &sync.Pool{New: func() any { return &memChunk{} }}
+
+	series := newMemSeries(labels.EmptyLabels(), 1, 0, true, false)
+	series.firstChunkID = chunks.HeadChunkID(oooChunkIDMask - 10)
+
+	for ts := int64(0); ts < chunkRange*numChunks; ts += chunkStep {
+		ok, _ := series.append(0, ts, float64(ts), 0, chunkOpts{
+			chunkDiskMapper: chunkDiskMapper,
+			chunkRange:      chunkRange,
+			samplesPerChunk: DefaultSamplesPerChunk,
+		})
+		require.True(t, ok, "sample append failed")
+	}
+	series.mmapChunks(chunkDiskMapper)
+	require.Len(t, series.mmappedChunks, numChunks-1, "wrong number of mmapped chunks")
+	require.Equal(t, 1, series.headChunks.len(), "wrong number of head chunks")
+
+	// Chunk i covers [i*chunkRange, (i+1)*chunkRange). Positions 10+ take IDs
+	// past the 23-bit boundary, so they wrap back to 0, 1, 2, ...
+	ids := make([]chunks.HeadChunkID, numChunks)
+	for i := range ids {
+		ids[i] = series.headChunkID(i)
+		require.Zero(t, ids[i]&oooChunkIDMask, "pos %d: ID must not set the OOO flag", i)
+	}
+	require.Equal(t, chunks.HeadChunkID(oooChunkIDMask-1), ids[9], "pos 9 should hold the last ID before the boundary")
+	require.Equal(t, chunks.HeadChunkID(0), ids[10], "pos 10 should have wrapped to 0")
+
+	requireResolves := func(t *testing.T, firstLive int) {
+		t.Helper()
+		for pos := range numChunks {
+			chk, _, _, err := series.chunk(ids[pos], chunkDiskMapper, memChunkPool, nil)
+			if pos < firstLive {
+				require.ErrorIs(t, err, storage.ErrNotFound, "pos %d was truncated and must not resolve", pos)
+				continue
+			}
+			require.NoError(t, err, "pos %d should resolve", pos)
+			require.Equal(t, int64(pos)*chunkRange, chk.minTime, "pos %d resolved to the wrong chunk", pos)
+		}
+	}
+
+	requireResolves(t, 0)
+
+	// Truncate positions 0-3. firstChunkID stays near the top of the space, so
+	// the surviving wrapped IDs (positions 10+) are numerically below it.
+	removed := series.truncateChunksBefore(chunkRange*4, 0)
+	require.Equal(t, 4, removed)
+	require.Equal(t, chunks.HeadChunkID(oooChunkIDMask-6), series.firstChunkID)
+	requireResolves(t, 4)
+
+	// Truncate positions 4-11, which carries firstChunkID itself past 0.
+	removed = series.truncateChunksBefore(chunkRange*12, 0)
+	require.Equal(t, 8, removed)
+	require.Equal(t, chunks.HeadChunkID(2), series.firstChunkID)
+	requireResolves(t, 12)
+}
+
 func TestHeadIndexReader_PostingsForLabelMatching(t *testing.T) {
 	testPostingsForLabelMatching(t, 0, func(t *testing.T, series []labels.Labels) IndexReader {
 		opts := DefaultHeadOptions()

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -517,11 +517,11 @@ func TestMemSeries_chunk_ResolveAfterWrap(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, chunkDiskMapper.Close()) })
 	memChunkPool := &sync.Pool{New: func() any { return &memChunk{} }}
 
-	series := newMemSeries(labels.EmptyLabels(), 1, 0, true, false)
+	series := newMemSeries(labels.EmptyLabels(), 1, 0, 0, 0, true, false)
 	series.firstChunkID = chunks.HeadChunkID(oooChunkIDMask - 10)
 
 	for ts := int64(0); ts < chunkRange*numChunks; ts += chunkStep {
-		ok, _ := series.append(0, ts, float64(ts), 0, chunkOpts{
+		ok, _ := series.append(ts, float64(ts), 0, chunkOpts{
 			chunkDiskMapper: chunkDiskMapper,
 			chunkRange:      chunkRange,
 			samplesPerChunk: DefaultSamplesPerChunk,

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1574,6 +1574,15 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 	}
 }
 
+func TestCutNewHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
+	s := newMemSeries(labels.FromStrings("a", "b"), 1, 0, true, false)
+	s.headChunkCount.Store(oooChunkIDMask - 1)
+
+	require.Panics(t, func() {
+		s.cutNewHeadChunk(0, chunkenc.EncXOR, 1000)
+	})
+}
+
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 	for _, compress := range []compression.Type{compression.None, compression.Snappy, compression.Zstd} {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1574,12 +1574,16 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 	}
 }
 
-func TestCutNewHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
+func TestPushHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
 	s := newMemSeries(labels.FromStrings("a", "b"), 1, 0, true, false)
 	s.headChunkCount.Store(oooChunkIDMask - 1)
 
 	require.Panics(t, func() {
-		s.cutNewHeadChunk(0, chunkenc.EncXOR, 1000)
+		s.pushHeadChunk(&memChunk{
+			chunk:   chunkenc.NewXORChunk(),
+			minTime: 0,
+			maxTime: 0,
+		})
 	})
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1496,6 +1496,84 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 	})
 }
 
+func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
+	tests := []struct {
+		name               string
+		firstOOOChunkID    chunks.HeadChunkID
+		numOOOChunks       int
+		hasOOOHeadChunk    bool
+		truncateN          int
+		expFirstOOOChunkID chunks.HeadChunkID
+		expOOONil          bool
+		expOOOMmappedLen   int
+	}{
+		{
+			name:               "wrap past zero with remaining chunks",
+			firstOOOChunkID:    chunks.HeadChunkID(oooChunkIDMask - 3),
+			numOOOChunks:       5,
+			truncateN:          4,
+			expFirstOOOChunkID: 1,
+			expOOOMmappedLen:   1,
+		},
+		{
+			name:            "truncate all OOO chunks, no head chunk, ooo becomes nil",
+			firstOOOChunkID: chunks.HeadChunkID(oooChunkIDMask - 3),
+			numOOOChunks:    5,
+			truncateN:       5,
+			expOOONil:       true,
+		},
+		{
+			name:               "truncate all mmapped, head chunk keeps ooo alive",
+			firstOOOChunkID:    chunks.HeadChunkID(oooChunkIDMask - 1),
+			numOOOChunks:       3,
+			hasOOOHeadChunk:    true,
+			truncateN:          3,
+			expFirstOOOChunkID: 2,
+			expOOOMmappedLen:   0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, chunkDiskMapper.Close()) })
+
+			series := newMemSeries(labels.EmptyLabels(), 1, 0, true, false)
+			series.ooo = &memSeriesOOOFields{firstOOOChunkID: tc.firstOOOChunkID}
+
+			refs := make([]chunks.ChunkDiskMapperRef, tc.numOOOChunks)
+			for i := 0; i < tc.numOOOChunks; i++ {
+				ref := chunkDiskMapper.WriteChunk(series.ref, int64(i*100), int64(i*100+99), chunkenc.NewXORChunk(), true, handleChunkWriteError)
+				refs[i] = ref
+				series.ooo.oooMmappedChunks = append(series.ooo.oooMmappedChunks, &mmappedChunk{
+					ref: ref, minTime: int64(i * 100), maxTime: int64(i*100 + 99),
+				})
+			}
+
+			if tc.hasOOOHeadChunk {
+				series.ooo.oooHeadChunk = &oooHeadChunk{
+					chunk:   NewOOOChunk(),
+					minTime: int64(tc.numOOOChunks * 100),
+					maxTime: int64(tc.numOOOChunks*100 + 99),
+				}
+			}
+
+			minOOOMmapRef := refs[tc.truncateN-1]
+			series.truncateChunksBefore(0, minOOOMmapRef)
+
+			if tc.expOOONil {
+				require.Nil(t, series.ooo, "ooo should be nil after truncating all chunks")
+			} else {
+				require.NotNil(t, series.ooo, "ooo should not be nil")
+				require.Equal(t, tc.expFirstOOOChunkID, series.ooo.firstOOOChunkID, "firstOOOChunkID mismatch after wrap")
+				require.Len(t, series.ooo.oooMmappedChunks, tc.expOOOMmappedLen, "oooMmappedChunks length mismatch")
+			}
+		})
+	}
+}
+
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 	for _, compress := range []compression.Type{compression.None, compression.Snappy, compression.Zstd} {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
@@ -7448,4 +7526,157 @@ func testHeadAppendHistogramAndCommitConcurrency(t *testing.T, appendFn func(sto
 	}()
 
 	wg.Wait()
+}
+
+func TestQueryOOOHeadDuringTruncateAcrossWrap(t *testing.T) {
+	const maxT int64 = 6000
+
+	opts := DefaultOptions()
+	opts.OutOfOrderTimeWindow = maxT
+	opts.MinBlockDuration = maxT / 2
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	l := labels.FromStrings("a", "b")
+	app := db.Appender(context.Background())
+
+	// In-order samples.
+	ref, err := app.Append(0, l, 0, 0)
+	require.NoError(t, err)
+	for i := int64(100); i < maxT; i += 100 {
+		_, err = app.Append(ref, l, i, float64(i))
+		require.NoError(t, err)
+	}
+	// OOO samples interleaved between in-order ones.
+	for i := int64(50); i < maxT; i += 100 {
+		_, err = app.Append(ref, l, i, float64(i))
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	// Seed firstOOOChunkID near the wrap boundary.
+	ms := db.head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, ms)
+	ms.Lock()
+	require.NotNil(t, ms.ooo)
+	ms.ooo.firstOOOChunkID = chunks.HeadChunkID(oooChunkIDMask - 1)
+	ms.Unlock()
+
+	// Pre-truncation query.
+	q, err := db.Querier(0, maxT)
+	require.NoError(t, err)
+	ss := q.Select(context.Background(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	require.True(t, ss.Next())
+	it := ss.At().Iterator(nil)
+	var preCount int
+	for it.Next() != chunkenc.ValNone {
+		preCount++
+	}
+	require.NoError(t, it.Err())
+	require.Positive(t, preCount, "pre-truncation query should return data")
+	require.NoError(t, q.Close())
+
+	// Compact, which triggers truncation and wraps firstOOOChunkID.
+	require.NoError(t, db.Compact(context.Background()))
+
+	// Post-truncation query.
+	q, err = db.Querier(0, maxT)
+	require.NoError(t, err)
+	ss = q.Select(context.Background(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	require.True(t, ss.Next())
+	it = ss.At().Iterator(nil)
+	var postCount int
+	for it.Next() != chunkenc.ValNone {
+		postCount++
+	}
+	require.NoError(t, it.Err())
+	require.Positive(t, postCount, "post-truncation query should return data")
+	require.NoError(t, q.Close())
+}
+
+func TestOOORestartResetsFirstOOOChunkID(t *testing.T) {
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			testOOORestartResetsFirstOOOChunkID(t, scenario)
+		})
+	}
+}
+
+func testOOORestartResetsFirstOOOChunkID(t *testing.T, scenario sampleTypeScenario) {
+	dir := t.TempDir()
+	wal, err := wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compression.Snappy)
+	require.NoError(t, err)
+	oooWlog, err := wlog.NewSize(nil, nil, filepath.Join(dir, wlog.WblDirName), 32768, compression.Snappy)
+	require.NoError(t, err)
+
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChunkDirRoot = dir
+	opts.OutOfOrderCapMax.Store(30)
+	opts.OutOfOrderTimeWindow.Store(1000 * time.Minute.Milliseconds())
+
+	h, err := NewHead(nil, nil, wal, oooWlog, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, h.Init(0))
+
+	l := labels.FromStrings("foo", "bar")
+	appendSample := func(mins int64) {
+		app := h.Appender(context.Background())
+		_, _, err := scenario.appendFunc(app, l, mins*time.Minute.Milliseconds(), mins)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}
+
+	// In-order sample.
+	appendSample(200)
+
+	// OOO samples: 92 samples to create 3 mmapped chunks (cap=30).
+	for mins := int64(100); mins <= 191; mins++ {
+		appendSample(mins)
+	}
+
+	ms, ok, err := h.getOrCreate(l.Hash(), l, false)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.NotNil(t, ms)
+	require.NotNil(t, ms.ooo)
+	require.NotEmpty(t, ms.ooo.oooMmappedChunks)
+
+	expMmapCount := len(ms.ooo.oooMmappedChunks)
+
+	// Seed firstOOOChunkID to a large value.
+	ms.Lock()
+	ms.ooo.firstOOOChunkID = chunks.HeadChunkID(oooChunkIDMask - 100)
+	ms.Unlock()
+
+	require.NoError(t, h.Close())
+
+	// Reopen.
+	wal, err = wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compression.Snappy)
+	require.NoError(t, err)
+	oooWlog, err = wlog.NewSize(nil, nil, filepath.Join(dir, wlog.WblDirName), 32768, compression.Snappy)
+	require.NoError(t, err)
+	h, err = NewHead(nil, nil, wal, oooWlog, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, h.Init(0))
+
+	ms, ok, err = h.getOrCreate(l.Hash(), l, false)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.NotNil(t, ms)
+	require.NotNil(t, ms.ooo)
+
+	// firstOOOChunkID resets to 0 after replay.
+	require.Equal(t, chunks.HeadChunkID(0), ms.ooo.firstOOOChunkID)
+
+	// Verify mmapped chunks are still accessible.
+	require.Len(t, ms.ooo.oooMmappedChunks, expMmapCount)
+	for _, m := range ms.ooo.oooMmappedChunks {
+		chk, err := h.chunkDiskMapper.Chunk(m.ref)
+		require.NoError(t, err)
+		require.Equal(t, int(m.numSamples), chk.NumSamples())
+	}
+
+	require.NoError(t, h.Close())
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1540,7 +1540,7 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, chunkDiskMapper.Close()) })
 
-			series := newMemSeries(labels.EmptyLabels(), 1, 0, true, false)
+			series := newMemSeries(labels.EmptyLabels(), 1, 0, 0, 0, true, false)
 			series.ooo = &memSeriesOOOFields{firstOOOChunkID: tc.firstOOOChunkID}
 
 			refs := make([]chunks.ChunkDiskMapperRef, tc.numOOOChunks)
@@ -1575,7 +1575,7 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 }
 
 func TestPushHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
-	s := newMemSeries(labels.FromStrings("a", "b"), 1, 0, true, false)
+	s := newMemSeries(labels.FromStrings("a", "b"), 1, 0, 0, 0, true, false)
 	s.headChunkCount.Store(oooChunkIDMask - 1)
 
 	require.Panics(t, func() {
@@ -1588,7 +1588,10 @@ func TestPushHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
 }
 
 func TestAppendHistogramLayoutChange_PanicsAtIDSpaceBound(t *testing.T) {
-	head, _ := newTestHead(t, 1000, compression.None, false)
+	head, wal := newTestHead(t, 1000, compression.None, false)
+	// Close the WAL only: Head.Close() would mmapHeadChunks under the series
+	// lock, which is still held after the expected panic in pushHeadChunk.
+	t.Cleanup(func() { _ = wal.Close() })
 	l := labels.FromStrings("l", "v1")
 
 	app := head.Appender(context.Background())
@@ -7573,7 +7576,7 @@ func TestQueryOOOHeadDuringTruncateAcrossWrap(t *testing.T) {
 	opts.OutOfOrderTimeWindow = maxT
 	opts.MinBlockDuration = maxT / 2
 
-	db := newTestDB(t, withOpts(opts))
+	db := newTestDBWithOpts(t, opts)
 	db.DisableCompactions()
 
 	l := labels.FromStrings("a", "b")
@@ -7653,6 +7656,7 @@ func testOOORestartResetsFirstOOOChunkID(t *testing.T, scenario sampleTypeScenar
 	opts.ChunkDirRoot = dir
 	opts.OutOfOrderCapMax.Store(30)
 	opts.OutOfOrderTimeWindow.Store(1000 * time.Minute.Milliseconds())
+	opts.EnableNativeHistograms.Store(true)
 
 	h, err := NewHead(nil, nil, wal, oooWlog, opts, nil)
 	require.NoError(t, err)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1583,6 +1583,31 @@ func TestCutNewHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
 	})
 }
 
+func TestAppendHistogramLayoutChange_PanicsAtIDSpaceBound(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	l := labels.FromStrings("l", "v1")
+
+	app := head.Appender(context.Background())
+	h := tsdbutil.GenerateTestHistogram(0)
+	_, err := app.AppendHistogram(0, l, 0, h, nil)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	ms, _, err := head.getOrCreate(l.Hash(), l, false)
+	require.NoError(t, err)
+	ms.Lock()
+	ms.headChunkCount.Store(oooChunkIDMask - 1)
+	ms.Unlock()
+
+	h2 := h.Copy()
+	h2.Schema++
+	require.Panics(t, func() {
+		app := head.Appender(context.Background())
+		_, _ = app.AppendHistogram(0, l, 1, h2, nil)
+		_ = app.Commit()
+	})
+}
+
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 	for _, compress := range []compression.Type{compression.None, compression.Snappy, compression.Zstd} {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -1147,7 +1147,8 @@ func testOOOQueryAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenario) {
 	opts.OutOfOrderCapMax = 5
 	opts.OutOfOrderTimeWindow = 120 * time.Minute.Milliseconds()
 
-	db := newTestDB(t, withOpts(opts))
+	opts.EnableNativeHistograms = true
+	db := newTestDBWithOpts(t, opts)
 
 	s1 := labels.FromStrings("l", "v1")
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -1239,7 +1239,7 @@ func TestOOOChunk_ResolveAfterWrap(t *testing.T) {
 
 	// Simulate truncation of the first 8 chunks.
 	s.ooo.oooMmappedChunks = s.ooo.oooMmappedChunks[8:]
-	s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + 8) & (oooChunkIDMask - 1)
+	s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + 8) % oooChunkIDMask
 	require.Equal(t, chunks.HeadChunkID(3), s.ooo.firstOOOChunkID)
 
 	// Surviving chunks (original positions 8, 9) must resolve.

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -1133,3 +1133,151 @@ func newTestDBWithOpts(t *testing.T, opts *Options) *DB {
 
 	return db
 }
+
+func TestOOOQueryAcrossChunkIDWrap(t *testing.T) {
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			testOOOQueryAcrossChunkIDWrap(t, scenario)
+		})
+	}
+}
+
+func testOOOQueryAcrossChunkIDWrap(t *testing.T, scenario sampleTypeScenario) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 5
+	opts.OutOfOrderTimeWindow = 120 * time.Minute.Milliseconds()
+
+	db := newTestDB(t, withOpts(opts))
+
+	s1 := labels.FromStrings("l", "v1")
+	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
+
+	app := db.Appender(context.Background())
+
+	// In-order sample to establish the series.
+	ref, _, err := scenario.appendFunc(app, s1, minutes(120), 120)
+	require.NoError(t, err)
+	var expSamples []chunks.Sample
+	expSamples = append(expSamples, scenario.sampleFunc(minutes(120), 120))
+
+	// First batch of 10 OOO samples (creates 2 mmapped OOO chunks with cap=5).
+	for i := int64(1); i <= 10; i++ {
+		_, _, err = scenario.appendFunc(app, s1, minutes(i), i)
+		require.NoError(t, err)
+		expSamples = append(expSamples, scenario.sampleFunc(minutes(i), i))
+	}
+	require.NoError(t, app.Commit())
+
+	// Seed firstOOOChunkID near the wrap boundary.
+	ms := db.head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, ms)
+	ms.Lock()
+	require.NotNil(t, ms.ooo)
+	ms.ooo.firstOOOChunkID = chunks.HeadChunkID(oooChunkIDMask - 1)
+	ms.Unlock()
+
+	// Second batch of 10 OOO samples whose chunk IDs cross the boundary.
+	app = db.Appender(context.Background())
+	for i := int64(11); i <= 20; i++ {
+		_, _, err = scenario.appendFunc(app, s1, minutes(i), i)
+		require.NoError(t, err)
+		expSamples = append(expSamples, scenario.sampleFunc(minutes(i), i))
+	}
+	require.NoError(t, app.Commit())
+
+	// Query all data and verify every sample is returned.
+	querier, err := db.Querier(0, minutes(200))
+	require.NoError(t, err)
+
+	seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "l", "v1"))
+
+	sort.Slice(expSamples, func(i, j int) bool { return expSamples[i].T() < expSamples[j].T() })
+	requireEqualSeries(t, map[string][]chunks.Sample{s1.String(): expSamples}, seriesSet, true)
+}
+
+func TestOOOHeadChunkID_Wrap(t *testing.T) {
+	h, _ := newTestHead(t, 1000, compression.None, true)
+	require.NoError(t, h.Init(0))
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "b"), false)
+	s.ooo = &memSeriesOOOFields{firstOOOChunkID: chunks.HeadChunkID(oooChunkIDMask - 5)}
+
+	for pos := 0; pos <= 10; pos++ {
+		id := s.oooHeadChunkID(pos)
+		expected := chunks.HeadChunkID((pos + oooChunkIDMask - 5) % oooChunkIDMask)
+
+		require.NotZero(t, id&oooChunkIDMask, "pos %d: OOO flag (bit 23) must be set", pos)
+		require.Less(t, id, chunks.HeadChunkID(1<<24), "pos %d: chunk ID must fit in 24 bits", pos)
+		require.Equal(t, expected, id&(oooChunkIDMask-1), "pos %d: lower 23 bits mismatch", pos)
+
+		ref := chunks.NewHeadChunkRef(s.ref, id)
+		_, chunkID, isOOO := unpackHeadChunkRef(chunks.ChunkRef(ref))
+		require.True(t, isOOO, "pos %d: round-trip must identify as OOO", pos)
+		require.Equal(t, expected, chunkID, "pos %d: round-trip chunkID mismatch", pos)
+	}
+}
+
+func TestOOOChunk_ResolveAfterWrap(t *testing.T) {
+	h, _ := newTestHead(t, 1000, compression.None, true)
+	require.NoError(t, h.Init(0))
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "b"), false)
+	s.ooo = &memSeriesOOOFields{firstOOOChunkID: chunks.HeadChunkID(oooChunkIDMask - 5)}
+
+	ids := make([]chunks.HeadChunkID, 10)
+	rawIDs := make([]chunks.HeadChunkID, 10)
+	for i := range 10 {
+		ref := h.chunkDiskMapper.WriteChunk(s.ref, int64(i*100), int64(i*100+99), chunkenc.NewXORChunk(), true, handleChunkWriteError)
+		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, &mmappedChunk{
+			ref: ref, minTime: int64(i * 100), maxTime: int64(i*100 + 99),
+		})
+		ids[i] = s.oooHeadChunkID(i)
+		_, rawIDs[i], _ = unpackHeadChunkRef(chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, ids[i])))
+	}
+
+	// Simulate truncation of the first 8 chunks.
+	s.ooo.oooMmappedChunks = s.ooo.oooMmappedChunks[8:]
+	s.ooo.firstOOOChunkID = (s.ooo.firstOOOChunkID + 8) & (oooChunkIDMask - 1)
+	require.Equal(t, chunks.HeadChunkID(3), s.ooo.firstOOOChunkID)
+
+	// Surviving chunks (original positions 8, 9) must resolve.
+	for _, pos := range []int{8, 9} {
+		chk, _, err := s.oooChunk(rawIDs[pos], h.chunkDiskMapper, nil)
+		require.NoError(t, err, "pos %d should resolve after truncation", pos)
+		require.NotNil(t, chk, "pos %d chunk must not be nil", pos)
+	}
+
+	// Truncated chunks (original positions 0-7) must return ErrNotFound.
+	for pos := range 8 {
+		_, _, err := s.oooChunk(rawIDs[pos], h.chunkDiskMapper, nil)
+		require.Equal(t, storage.ErrNotFound, err, "pos %d should return ErrNotFound after truncation", pos)
+	}
+}
+
+func TestOOOMmapGuardPreventsAliasing(t *testing.T) {
+	// The guard in mmapCurrentOOOHeadChunk caps oooMmappedChunks at
+	// oooChunkIDMask - 1 entries. With modular wrapping, this ensures
+	// unique chunk IDs within a single getOOOSeriesChunks call.
+	require.Equal(t, (1<<23)-1, oooChunkIDMask-1,
+		"guard bound must equal oooChunkIDMask-1 to prevent intra-call aliasing")
+
+	h, _ := newTestHead(t, 1000, compression.None, true)
+	require.NoError(t, h.Init(0))
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "b"), false)
+	s.ooo = &memSeriesOOOFields{}
+
+	seen := make(map[chunks.HeadChunkID]int)
+	s.ooo.firstOOOChunkID = chunks.HeadChunkID(oooChunkIDMask - 100)
+	for pos := range 200 {
+		id := s.oooHeadChunkID(pos)
+		require.Less(t, id, chunks.HeadChunkID(1<<24), "chunk ID must fit in 24 bits")
+		if prev, ok := seen[id]; ok {
+			t.Fatalf("position %d produced same HeadChunkID as position %d", pos, prev)
+		}
+		seen[id] = pos
+	}
+}


### PR DESCRIPTION
Backport of [prometheus/prometheus#19216](https://github.com/prometheus/prometheus/pull/19216) and [prometheus/prometheus#19450](https://github.com/prometheus/prometheus/pull/19450) to `mimir-release-2.17`.

Chunk IDs packed into the 24-bit `HeadChunkRef` field overflow into the OOO flag at bit 23, causing head compaction failures. Wrap in-order and OOO IDs modulo 2^23 on assign and lookup, and panic in `pushHeadChunk` if the live set would exhaust the ID space.

Backport adaptations for this branch:

- Test helpers (`newTestDB`, `newMemSeries`, `append`) still use the release-branch signatures.
- Enable native histograms explicitly where wrap tests cover histogram sample types, because this branch disables them by default.
- Close the WAL after the expected `pushHeadChunk` panic so goleak stays clean; `Head.Close()` would deadlock on the series lock.

```release-notes
[BUGFIX] TSDB: Wrap in-order and OOO chunk IDs modulo 2^23 so they cannot overflow into the OOO flag bit
```

Made with [Cursor](https://cursor.com)